### PR TITLE
Fix Alembic revision IDs and add migration-integrity test

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,7 +1,7 @@
 # A minimal Alembic configuration file for database migrations.
 
 [alembic]
-script_location = migrations
+script_location = app/db/migrations
 sqlalchemy.url = sqlite:///./test.db
 
 [loggers]

--- a/backend/app/db/migrations/versions/0007_add_otp_code_hash.py
+++ b/backend/app/db/migrations/versions/0007_add_otp_code_hash.py
@@ -1,7 +1,7 @@
 """add otp code hash to otp challenges
 
-Revision ID: 0006
-Revises: 0005
+Revision ID: 0007
+Revises: 0006
 Create Date: 2026-02-10
 
 """
@@ -12,8 +12,8 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision: str = "0006"
-down_revision: Union[str, None] = "0005"
+revision: str = "0007"
+down_revision: Union[str, None] = "0006"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/tests/test_migration_integrity.py
+++ b/backend/tests/test_migration_integrity.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+VERSIONS_DIR = Path(__file__).resolve().parents[1] / "app" / "db" / "migrations" / "versions"
+REVISION_PATTERN = re.compile(r'^revision:\s*str\s*=\s*"([^"]+)"', re.MULTILINE)
+DOWN_REVISION_PATTERN = re.compile(
+    r'^down_revision:\s*Union\[str,\s*None\]\s*=\s*(?:"([^"]+)"|None)', re.MULTILINE
+)
+
+
+def _migration_pairs() -> list[tuple[str, str | None]]:
+    pairs: list[tuple[str, str | None]] = []
+    for path in sorted(VERSIONS_DIR.glob("*.py")):
+        content = path.read_text()
+        revision_match = REVISION_PATTERN.search(content)
+        down_revision_match = DOWN_REVISION_PATTERN.search(content)
+
+        assert revision_match, f"missing revision in {path.name}"
+        assert down_revision_match, f"missing down_revision in {path.name}"
+
+        pairs.append((revision_match.group(1), down_revision_match.group(1)))
+
+    assert pairs, "no migrations found"
+    return pairs
+
+
+def test_migrations_have_single_linear_head() -> None:
+    pairs = _migration_pairs()
+
+    revisions = [revision for revision, _ in pairs]
+    assert len(set(revisions)) == len(revisions), "duplicate Alembic revision IDs detected"
+
+    parent_by_revision = dict(pairs)
+    children: dict[str, list[str]] = {}
+    roots: list[str] = []
+
+    for revision, parent in pairs:
+        if parent is None:
+            roots.append(revision)
+            continue
+        children.setdefault(parent, []).append(revision)
+
+    assert len(roots) == 1, f"expected exactly one root migration, got: {roots}"
+
+    branch_points = {parent: kids for parent, kids in children.items() if len(kids) > 1}
+    assert not branch_points, f"found migration branches: {branch_points}"
+
+    heads = [revision for revision in revisions if revision not in children]
+    assert len(heads) == 1, f"expected exactly one migration head, got: {heads}"
+
+    # Walk from root and ensure we can visit every revision once in order.
+    visited: list[str] = []
+    current = roots[0]
+    while True:
+        visited.append(current)
+        next_revisions = children.get(current, [])
+        if not next_revisions:
+            break
+        current = next_revisions[0]
+
+    assert len(visited) == len(revisions), (
+        "migration graph is disconnected or cyclic; "
+        f"visited={visited}, all={sorted(revisions)}"
+    )
+
+    # Sanity-check no self-references.
+    for revision, parent in pairs:
+        assert revision != parent, f"migration {revision} cannot depend on itself"
+        assert parent is None or parent in parent_by_revision, (
+            f"migration {revision} points to unknown down_revision {parent}"
+        )


### PR DESCRIPTION
### Motivation
- Ensure Alembic migrations have unique revision IDs and form a single linear chain instead of producing an ambiguous/branched head. 
- Make Alembic resolve migrations from the active `app/db/migrations` tree so `head` and ordering checks align with the repository layout.

### Description
- Renamed the duplicate migration file from `backend/app/db/migrations/versions/0006_add_otp_code_hash.py` to `.../0007_add_otp_code_hash.py` and updated its Alembic metadata so the chain becomes `0005 -> 0006 -> 0007` by changing `revision` to `0007` and `down_revision` to `0006`.
- Updated `backend/alembic.ini` to set `script_location = app/db/migrations` so Alembic inspects the correct migrations directory.
- Added `backend/tests/test_migration_integrity.py`, a test that asserts unique revision IDs, a single root, no branch points, exactly one head, and that the migration graph is connected and acyclic.

### Testing
- Ran formatting/lint check with `ruff check app tests` which completed without errors.
- Ran the new integrity test with `pytest -q tests/test_migration_integrity.py` which passed (`1 passed`).
- Verified Alembic sees a single head with `alembic heads`, which returned the single head `0007`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c93bed1d788321b08f14f303143f68)