### PR TITLE
Handle verify-otp by latest challenge status

### DIFF
--- a/backend/app/api/routes_driver_auth.py
+++ b/backend/app/api/routes_driver_auth.py
@@ -18,10 +18,10 @@ from app.api.schemas import (
 )
 from app.core.config import settings
 from app.core.security import create_access_token
-from app.db.models import OtpChallenge
 from app.db.repo.drivers import (
     create_otp_challenge,
     get_driver_by_phone,
+    get_latest_otp_challenge_by_phone,
     increment_otp_attempts,
     mark_otp_verified,
 )
@@ -124,16 +124,8 @@ def verify_otp(body: DriverOtpVerifyRequest, db: Session = Depends(get_db)):
         )
     _enforce_rate_limit(_verify_timestamps, _phone_hash(phone_e164), _VERIFY_LIMIT)
 
-    # Find the latest pending challenge for this phone
-    challenge = (
-        db.query(OtpChallenge)
-        .filter(
-            OtpChallenge.phone_e164 == phone_e164,
-            OtpChallenge.status == "pending",
-        )
-        .order_by(OtpChallenge.created_at_utc.desc())
-        .first()
-    )
+    # Find the latest challenge for this phone, then branch by challenge status.
+    challenge = get_latest_otp_challenge_by_phone(db, phone_e164)
     if challenge is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/db/repo/drivers.py
+++ b/backend/app/db/repo/drivers.py
@@ -71,6 +71,18 @@ def get_otp_challenge(db: Session, challenge_id: _uuid.UUID) -> OtpChallenge | N
     )
 
 
+def get_latest_otp_challenge_by_phone(
+    db: Session, phone_e164: str
+) -> OtpChallenge | None:
+    """Return the most recent OTP challenge for a phone, regardless of status."""
+    return (
+        db.query(OtpChallenge)
+        .filter(OtpChallenge.phone_e164 == phone_e164)
+        .order_by(OtpChallenge.created_at_utc.desc())
+        .first()
+    )
+
+
 def increment_otp_attempts(db: Session, challenge: OtpChallenge) -> OtpChallenge:
     """Increment attempt count and lock or expire the challenge when appropriate."""
     now_utc = datetime.now(timezone.utc)

--- a/backend/tests/test_driver_auth_endpoints.py
+++ b/backend/tests/test_driver_auth_endpoints.py
@@ -1,5 +1,6 @@
 """Tests for driver auth OTP endpoints."""
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -143,3 +144,127 @@ def test_driver_request_otp_rate_limited(client, driver):
         )
         assert blocked.status_code == 429
         assert "Retry-After" in blocked.headers
+
+
+def _create_challenge(
+    db_session,
+    phone_e164: str,
+    *,
+    status: str = "pending",
+    attempt_count: int = 0,
+    created_at_utc: datetime | None = None,
+    expires_at_utc: datetime | None = None,
+):
+    challenge = OtpChallenge(
+        phone_e164=phone_e164,
+        otp_code_hash="",
+        status=status,
+        attempt_count=attempt_count,
+        created_at_utc=created_at_utc or datetime.now(timezone.utc),
+        expires_at_utc=expires_at_utc
+        or (datetime.now(timezone.utc) + timedelta(minutes=5)),
+    )
+    db_session.add(challenge)
+    db_session.commit()
+    db_session.refresh(challenge)
+    return challenge
+
+
+def test_verify_otp_latest_locked_challenge_returns_423(client, db_session, driver):
+    now = datetime.now(timezone.utc)
+    _create_challenge(
+        db_session,
+        driver.phone_e164,
+        status="pending",
+        created_at_utc=now - timedelta(minutes=1),
+        expires_at_utc=now + timedelta(minutes=5),
+    )
+    _create_challenge(
+        db_session,
+        driver.phone_e164,
+        status="locked",
+        created_at_utc=now,
+        expires_at_utc=now + timedelta(minutes=5),
+    )
+
+    verify_resp = client.post(
+        "/driver/auth/verify-otp",
+        json={"phone_e164": driver.phone_e164, "otp_code": "123456"},
+    )
+
+    assert verify_resp.status_code == 423
+    assert verify_resp.json()["detail"] == "Challenge locked due to too many attempts"
+
+
+def test_verify_otp_latest_verified_challenge_returns_400(client, db_session, driver):
+    now = datetime.now(timezone.utc)
+    _create_challenge(
+        db_session,
+        driver.phone_e164,
+        status="pending",
+        created_at_utc=now - timedelta(minutes=1),
+        expires_at_utc=now + timedelta(minutes=5),
+    )
+    _create_challenge(
+        db_session,
+        driver.phone_e164,
+        status="verified",
+        created_at_utc=now,
+        expires_at_utc=now + timedelta(minutes=5),
+    )
+
+    verify_resp = client.post(
+        "/driver/auth/verify-otp",
+        json={"phone_e164": driver.phone_e164, "otp_code": "123456"},
+    )
+
+    assert verify_resp.status_code == 400
+    assert verify_resp.json()["detail"] == "Challenge already verified"
+
+
+def test_verify_otp_latest_expired_challenge_returns_410(client, db_session, driver):
+    now = datetime.now(timezone.utc)
+    _create_challenge(
+        db_session,
+        driver.phone_e164,
+        status="pending",
+        created_at_utc=now - timedelta(minutes=1),
+        expires_at_utc=now + timedelta(minutes=5),
+    )
+    _create_challenge(
+        db_session,
+        driver.phone_e164,
+        status="expired",
+        created_at_utc=now,
+        expires_at_utc=now - timedelta(minutes=1),
+    )
+
+    verify_resp = client.post(
+        "/driver/auth/verify-otp",
+        json={"phone_e164": driver.phone_e164, "otp_code": "123456"},
+    )
+
+    assert verify_resp.status_code == 410
+    assert verify_resp.json()["detail"] == "Challenge expired"
+
+
+def test_verify_otp_invalid_code_increments_attempts_and_locks(client, db_session, driver):
+    challenge = _create_challenge(
+        db_session,
+        driver.phone_e164,
+        status="pending",
+        attempt_count=4,
+        expires_at_utc=datetime.now(timezone.utc) + timedelta(minutes=5),
+    )
+
+    with patch("app.services.twilio_verify.check_verification", return_value=False):
+        verify_resp = client.post(
+            "/driver/auth/verify-otp",
+            json={"phone_e164": driver.phone_e164, "otp_code": "000000"},
+        )
+
+    db_session.refresh(challenge)
+    assert verify_resp.status_code == 423
+    assert verify_resp.json()["detail"] == "Challenge locked due to too many attempts"
+    assert challenge.attempt_count == 5
+    assert challenge.status == "locked"


### PR DESCRIPTION
### Motivation

- Make OTP verification evaluate the most recent challenge for a phone (not just those filtered to `pending`) so status-specific outcomes (locked/verified/expired) are enforced based on the latest challenge.
- Keep security semantics explicit for each challenge state: locked -> `423`, verified -> `400`, expired -> `410`, and invalid OTPs increment attempts and may lock.

### Description

- Added repository helper `get_latest_otp_challenge_by_phone` in `backend/app/db/repo/drivers.py` to return the most recent `OtpChallenge` for a phone regardless of status.
- Updated `verify_otp` in `backend/app/api/routes_driver_auth.py` to call `get_latest_otp_challenge_by_phone` and branch on `locked`, `verified`, `expired`, and `pending`/invalid OTP paths with the explicit status codes described above.
- Kept invalid-OTP handling to call `increment_otp_attempts`, which increments attempts and sets `locked` when the threshold is reached.
- Added tests in `backend/tests/test_driver_auth_endpoints.py` that create timestamped challenges and assert the `locked`, `verified`, `expired`, and invalid-OTP branches are reachable and behave correctly.

### Testing

- Ran linter with `cd backend && ruff check app/ tests/` and it passed.
- Ran full backend test suite with `cd backend && pytest tests/ -v` which initially surfaced 3 failing endpoint tests related to branch setup; those failures were addressed by adjusting test challenge timestamps and creation.
- Re-ran the endpoint tests with `cd backend && pytest tests/test_driver_auth_endpoints.py -v` and all tests in that file passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9488afac8832195dfa472456e381a)