### PR TITLE
docs: standardize startup instructions and docker command in README/Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,20 @@
 .PHONY: dev test fmt lint
 
-## Start all services (infra + backend + worker + frontend)
+## Start all services (infra + backend + worker + frontend) from repo root
+## Uses docker compose (plugin-style command)
 dev:
-	docker-compose -f infra/docker-compose.yml up --build
+	docker compose -f infra/docker-compose.yml up --build
 
-## Run backend tests and contract validation
+## Run backend tests and contract validation from repo root
 test:
 	cd backend && pip install -q -r requirements.txt && pytest tests/ -v
 	python scripts/validate_schemas.py
 
-## Format & lint backend code
+## Format & lint backend code (from repo root)
 fmt:
 	cd backend && pip install -q ruff && ruff check --fix --unsafe-fixes app/ tests/
 	cd backend && ruff format app/ tests/
 
-## Lint only (no auto-fix)
+## Lint only (no auto-fix) from repo root
 lint:
 	cd backend && pip install -q ruff && ruff check app/ tests/

--- a/README.md
+++ b/README.md
@@ -92,20 +92,27 @@ adc-mvp/
 - Redis 7+
 - Node.js 18+ (for frontend)
 
-### Quick Start
+### Directory Context (important)
+
+- **From repo root (`adc-mvp/`)**: use commands with `backend.app...` import paths.
+- **From `backend/`**: use commands with `app...` import paths.
+
+All commands below call out which directory they assume.
+
+### Quick Start (from repo root)
 
 ```bash
 # Start everything (backend + worker + frontend + infra)
 make dev
 
-# Run tests
+# Run backend tests + schema validation
 make test
 
-# Format / lint
+# Lint and format backend code
 make fmt
 ```
 
-### Run Everything
+### Manual Development (from repo root)
 
 Open four terminals and run each command:
 
@@ -123,6 +130,21 @@ celery -A backend.app.tasks.celery_app worker -l info
 cd frontend && npm run dev
 ```
 
+### Backend-only Manual Development (from backend/)
+
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+### Run Tests Manually (from repo root)
+
+```bash
+cd backend && pytest tests/ -v
+python scripts/validate_schemas.py
+```
+
 ### Driver App (Expo)
 
 ```bash
@@ -134,15 +156,7 @@ EXPO_PUBLIC_API_BASE_URL=http://localhost:8000 npm run start
 - API: `http://localhost:8000`
 - Frontend: `http://localhost:3000`
 
-### Local Development (manual)
-
-```bash
-cd backend
-pip install -r requirements.txt
-uvicorn app.main:app --reload
-```
-
-### Docker
+### Docker (from repo root)
 
 ```bash
 docker compose -f infra/docker-compose.yml up --build


### PR DESCRIPTION
### Motivation

- Reduce confusion by making startup and dev instructions consistent across the repository.
- Ensure the documented import paths match the actual run context and package layout.
- Prefer the modern Docker Compose plugin-style command and make directory assumptions explicit to avoid ambiguous commands.

### Description

- Updated `README.md` to add a clear "Directory Context" note and to unify examples so they use `backend.app...` when run from the repo root and `app...` when run from the `backend/` directory. 
- Standardized Docker usage in `README.md` and examples to use `docker compose -f infra/docker-compose.yml ...` and aligned Quick Start, Manual Development, Tests, and Docker sections to reference the same directory assumptions. 
- Updated `Makefile` to use `docker compose` (plugin-style) instead of `docker-compose` and clarified target comments to state they run from the repo root.

### Testing

- Ran `make test`, which executed `pytest` and the schema validator; all tests passed (`226 passed, 1 warning`) and `python scripts/validate_schemas.py` reported all schemas valid. 
- Ran `make lint`, which runs `ruff` checks, and it completed with `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9d08284288321b98035e0e7362a8a)