### PR TITLE
Fix root Alembic import path after backend package consolidation

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -14,14 +14,21 @@ migrations: https://alembic.sqlalchemy.org/.
 from __future__ import annotations
 
 import os
+import sys
 from logging.config import fileConfig
+from pathlib import Path
 
 from sqlalchemy import engine_from_config, pool
 from sqlalchemy import create_engine
 
 from alembic import context
 
-from app.db.models import Base  # Import your models here
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_ROOT = REPO_ROOT / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.db.models import Base  # Import canonical backend models via backend/ path
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.


### PR DESCRIPTION
### Motivation

- The repository-root Alembic environment (`migrations/env.py`) stopped resolving `app.db.models` after consolidating runtime code to `backend/app`, causing `ModuleNotFoundError` when running root migrations.
- Preserve existing root `alembic.ini` workflows without reintroducing duplicate runtime modules under top-level `app/`.

### Description

- Prepend `backend/` to `sys.path` in `migrations/env.py` and continue using `from app.db.models import Base` so the root import resolves to `backend/app/db/models.py`.
- Leave `target_metadata = Base.metadata` unchanged so Alembic autogeneration and metadata resolution continue to work.
- Apply a small newline/formatting fix to the end of `migrations/env.py`.

### Testing

- Ran `python scripts/check_no_duplicate_modules.py` which succeeded and reported no duplicate critical module paths.
- Ran `alembic -c alembic.ini current` which completed without import errors and printed Alembic SQLite runtime info.
- Ran `cd backend && pytest tests/test_migration_integrity.py -q` which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca780a57788321bf9cef134156bcd8)