### PR TITLE
Follow-up: block legacy null-org export access and inherit incident org checks

### DIFF
--- a/backend/app/api/routes_exports.py
+++ b/backend/app/api/routes_exports.py
@@ -12,6 +12,7 @@ from app.db.models import User
 from app.db.session import get_db
 from app.db.repo.exports import get_export
 from app.db.repo.events import create_event
+from app.db.repo.incidents import get_incident
 from app.db.repo.users import get_user_org_ids
 from app.domain.system_event_types import SystemEventType
 from app.core.config import settings
@@ -19,6 +20,17 @@ from app.core.config import settings
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _get_export_owner_org_id(db: Session, export):
+    """Resolve org ownership for an export, including legacy null-org rows."""
+    if export.org_id is not None:
+        return export.org_id
+
+    incident = get_incident(db, export.incident_id)
+    if incident is None:
+        return None
+    return incident.org_id
 
 
 @router.get("/")
@@ -40,8 +52,11 @@ def get_export_endpoint(
     export = get_export(db, export_id)
     if not export:
         raise HTTPException(status_code=404, detail="Export not found")
-    if export.org_id is not None and export.org_id not in org_ids:
+
+    export_org_id = _get_export_owner_org_id(db, export)
+    if export_org_id is None or export_org_id not in org_ids:
         raise HTTPException(status_code=403, detail="Forbidden")
+
     return {
         "export_id": str(export.export_id),
         "incident_id": str(export.incident_id),
@@ -59,7 +74,9 @@ def download_export_endpoint(
     export = get_export(db, export_id)
     if not export:
         raise HTTPException(status_code=404, detail="Export not found")
-    if export.org_id is not None and export.org_id not in org_ids:
+
+    export_org_id = _get_export_owner_org_id(db, export)
+    if export_org_id is None or export_org_id not in org_ids:
         raise HTTPException(status_code=403, detail="Forbidden")
 
     if export.status != "ready":

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -556,6 +556,50 @@ class TestDownloadExport:
         resp = client.get(f"/exports/{exp.export_id}/download", headers=auth_headers)
         assert resp.status_code == 403
 
+    def test_download_export_uses_incident_org_for_legacy_null_org_export(
+        self, client, db_session, auth_headers, test_org
+    ):
+        inc = Incident(status="open", org_id=test_org.id)
+        db_session.add(inc)
+        db_session.commit()
+        db_session.refresh(inc)
+
+        exp = Export(
+            incident_id=inc.incident_id,
+            org_id=None,
+            status="ready",
+            s3_bucket="legacy-bucket",
+            s3_key="exports/legacy.zip",
+        )
+        db_session.add(exp)
+        db_session.commit()
+        db_session.refresh(exp)
+
+        resp = client.get(f"/exports/{exp.export_id}/download", headers=auth_headers)
+        assert resp.status_code == 200
+
+    def test_download_export_forbidden_when_legacy_null_org_export_has_no_org_incident(
+        self, client, db_session, auth_headers
+    ):
+        inc = Incident(status="open", org_id=None)
+        db_session.add(inc)
+        db_session.commit()
+        db_session.refresh(inc)
+
+        exp = Export(
+            incident_id=inc.incident_id,
+            org_id=None,
+            status="ready",
+            s3_bucket="legacy-bucket",
+            s3_key="exports/legacy.zip",
+        )
+        db_session.add(exp)
+        db_session.commit()
+        db_session.refresh(exp)
+
+        resp = client.get(f"/exports/{exp.export_id}/download", headers=auth_headers)
+        assert resp.status_code == 403
+
 
 # ── GET /exports/{export_id} ───────────────────────────────────────
 
@@ -603,6 +647,46 @@ class TestGetExport:
         db_session.refresh(inc)
 
         exp = Export(incident_id=inc.incident_id, org_id=other_org.id, status="ready")
+        db_session.add(exp)
+        db_session.commit()
+        db_session.refresh(exp)
+
+        resp = client.get(f"/exports/{exp.export_id}", headers=auth_headers)
+        assert resp.status_code == 403
+
+    def test_get_export_uses_incident_org_for_legacy_null_org_export(
+        self, client, db_session, test_org, auth_headers
+    ):
+        inc = Incident(status="open", org_id=test_org.id)
+        db_session.add(inc)
+        db_session.commit()
+        db_session.refresh(inc)
+
+        exp = Export(
+            incident_id=inc.incident_id,
+            org_id=None,
+            status="requested",
+        )
+        db_session.add(exp)
+        db_session.commit()
+        db_session.refresh(exp)
+
+        resp = client.get(f"/exports/{exp.export_id}", headers=auth_headers)
+        assert resp.status_code == 200
+
+    def test_get_export_forbidden_when_legacy_null_org_export_has_no_org_incident(
+        self, client, db_session, auth_headers
+    ):
+        inc = Incident(status="open", org_id=None)
+        db_session.add(inc)
+        db_session.commit()
+        db_session.refresh(inc)
+
+        exp = Export(
+            incident_id=inc.incident_id,
+            org_id=None,
+            status="requested",
+        )
         db_session.add(exp)
         db_session.commit()
         db_session.refresh(exp)


### PR DESCRIPTION
### Motivation
- Prevent a high-priority cross-tenant information leak where `exports` rows with `org_id = NULL` were readable by any authenticated user. 
- Legacy export rows should either inherit ownership from their related `Incident` or be treated as inaccessible when ownership cannot be resolved.

### Description
- Added a helper `_get_export_owner_org_id(db, export)` that returns `export.org_id` or falls back to the related incident's `org_id` using `get_incident` in `backend/app/api/routes_exports.py`.
- Enforced org-based authorization in both `GET /exports/{export_id}` and `GET /exports/{export_id}/download` by checking the resolved owner org and returning `403` when ownership is unresolved or not in the caller's org links in `backend/app/api/routes_exports.py`.
- Imported `get_incident` into `routes_exports.py` and replaced the previous `export.org_id`-only check with the new resolved-owner check in both endpoints (`_get_export_owner_org_id` usage).
- Added targeted regression tests in `backend/tests/test_api_endpoints.py` that verify legacy-null `Export` rows are accessible when the related `Incident.org_id` matches the caller and are forbidden when both export and incident have `org_id = NULL`.

### Testing
- Ran the targeted tests with `pytest tests/test_api_endpoints.py -k 'legacy_null_org_export or download_export_forbidden_when_legacy_null_org_export_has_no_org_incident or get_export_forbidden_when_legacy_null_org_export_has_no_org_incident' -v` and observed `4 passed` (27 tests deselected).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca7ae272148321989988035c70d350)