### PR TITLE
Implement org-scoped exports listing with legacy-incident fallback

### DIFF
--- a/backend/app/api/routes_exports.py
+++ b/backend/app/api/routes_exports.py
@@ -10,7 +10,7 @@ from app.api.schemas import DownloadExportResponse
 from app.core.deps import get_current_user
 from app.db.models import User
 from app.db.session import get_db
-from app.db.repo.exports import get_export
+from app.db.repo.exports import get_export, list_exports_for_org_ids
 from app.db.repo.events import create_event
 from app.db.repo.incidents import get_incident
 from app.db.repo.users import get_user_org_ids
@@ -38,8 +38,17 @@ def list_exports_endpoint(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    _ = get_user_org_ids(db, current_user.id)
-    return []
+    org_ids = get_user_org_ids(db, current_user.id)
+    exports = list_exports_for_org_ids(db, org_ids)
+    return [
+        {
+            "export_id": str(export.export_id),
+            "incident_id": str(export.incident_id),
+            "status": export.status,
+            "created_at_utc": export.created_at_utc,
+        }
+        for export in exports
+    ]
 
 
 @router.get("/{export_id}")

--- a/backend/app/db/repo/exports.py
+++ b/backend/app/db/repo/exports.py
@@ -3,9 +3,10 @@
 import uuid as _uuid
 from typing import Optional
 
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
 
-from app.db.models import Export
+from app.db.models import Export, Incident
 
 
 def _get_export_query(db: Session, export_id: _uuid.UUID):
@@ -16,6 +17,25 @@ def _get_export_query(db: Session, export_id: _uuid.UUID):
 def get_exports_by_incident(db: Session, incident_id: _uuid.UUID) -> list[Export]:
     """Retrieve all exports for a specific incident."""
     return db.query(Export).filter(Export.incident_id == incident_id).all()
+
+
+def list_exports_for_org_ids(db: Session, org_ids: list[_uuid.UUID]) -> list[Export]:
+    """List exports visible to the caller's organizations, newest first."""
+    if not org_ids:
+        return []
+
+    return (
+        db.query(Export)
+        .outerjoin(Incident, Incident.incident_id == Export.incident_id)
+        .filter(
+            or_(
+                Export.org_id.in_(org_ids),
+                and_(Export.org_id.is_(None), Incident.org_id.in_(org_ids)),
+            )
+        )
+        .order_by(Export.created_at_utc.desc())
+        .all()
+    )
 
 
 def get_export(db: Session, export_id: _uuid.UUID) -> Optional[Export]:

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -1,6 +1,7 @@
 """Tests for API endpoints."""
 
 import uuid
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -720,6 +721,53 @@ class TestListExports:
 
         resp = client.get(f"/exports/{exp.export_id}", headers=no_org_auth_headers)
         assert resp.status_code == 403
+
+    def test_list_exports_includes_direct_and_legacy_org_scoped_rows(
+        self, client, db_session, test_org, auth_headers
+    ):
+        visible_incident = Incident(status="open", org_id=test_org.id)
+        other_incident = Incident(status="open", org_id=uuid.uuid4())
+        db_session.add_all([visible_incident, other_incident])
+        db_session.commit()
+        db_session.refresh(visible_incident)
+        db_session.refresh(other_incident)
+
+        now = datetime.now(timezone.utc)
+        direct_export = Export(
+            incident_id=visible_incident.incident_id,
+            org_id=test_org.id,
+            status="ready",
+            created_at_utc=now - timedelta(minutes=10),
+        )
+        legacy_visible_export = Export(
+            incident_id=visible_incident.incident_id,
+            org_id=None,
+            status="processing",
+            created_at_utc=now - timedelta(minutes=5),
+        )
+        legacy_hidden_export = Export(
+            incident_id=other_incident.incident_id,
+            org_id=None,
+            status="failed",
+            created_at_utc=now,
+        )
+        db_session.add_all([direct_export, legacy_visible_export, legacy_hidden_export])
+        db_session.commit()
+        db_session.refresh(direct_export)
+        db_session.refresh(legacy_visible_export)
+
+        resp = client.get("/exports/", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert len(data) == 2
+        assert [row["export_id"] for row in data] == [
+            str(legacy_visible_export.export_id),
+            str(direct_export.export_id),
+        ]
+        assert data[0]["incident_id"] == str(visible_incident.incident_id)
+        assert data[0]["status"] == "processing"
+        assert "created_at_utc" in data[0]
 
 
 # ── Health check ────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Provide a real implementation for `GET /exports/` that returns exports visible to the caller's organizations instead of the placeholder `return []`.
- Reuse repository-layer logic to avoid duplicating SQL in the route and to support legacy rows where `exports.org_id` is NULL but the linked incident belongs to the caller's org.

### Description
- Added `list_exports_for_org_ids` to `backend/app/db/repo/exports.py` which outer-joins `Incident` and returns exports where `Export.org_id` is in the caller's org IDs or where `Export.org_id IS NULL` and `Incident.org_id` is in the caller's org IDs, ordered by `created_at_utc DESC`.
- Updated `backend/app/api/routes_exports.py` to call `get_user_org_ids(db, current_user.id)` and use `list_exports_for_org_ids` to build the response list shaped for the frontend with `export_id`, `incident_id`, `status`, and `created_at_utc`.
- Added an API test in `backend/tests/test_api_endpoints.py` to verify inclusion of directly owned exports and legacy visible exports, exclusion of legacy exports tied to other orgs, and newest-first ordering by `created_at_utc`.

### Testing
- Ran linter with `make lint` which completed successfully (`All checks passed!`).
- Ran targeted tests with `cd backend && pytest tests/test_api_endpoints.py tests/test_exports.py -q` and all tests passed (`33 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb2d952c288321bc8ecae7a80854e7)