### PR TITLE
Wire driver incident initiation to canonical notification task

### DIFF
--- a/backend/app/api/routes_driver.py
+++ b/backend/app/api/routes_driver.py
@@ -46,7 +46,7 @@ from app.db.repo.incidents import create_incident, get_incident
 from app.db.session import get_db
 from app.domain.system_event_types import SystemEventType
 from app.tasks.evidence_tasks import capture_dashcam, capture_telematics_bundle
-from app.tasks.notify_tasks import notify_safety
+from app.tasks.notification_tasks import notify_safety_manager
 
 logger = logging.getLogger(__name__)
 
@@ -502,7 +502,7 @@ def initiate_incident(
     str_id = str(incident.incident_id)
     capture_dashcam.delay(str_id, body.window_start, body.window_end)
     capture_telematics_bundle.delay(str_id, body.window_start, body.window_end)
-    notify_safety.delay(str_id)
+    notify_safety_manager.delay(str_id)
 
     return DriverIncidentInitiateResponse(
         incident_id=incident.incident_id,

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -22,6 +22,9 @@ celery_app.conf.update(
         "app.tasks.evidence_tasks.capture_dashcam": {"queue": "evidence"},
         "app.tasks.evidence_tasks.capture_telematics_bundle": {"queue": "evidence"},
         "app.tasks.export_tasks.build_export": {"queue": "exports"},
+        "app.tasks.notification_tasks.notify_safety_manager": {
+            "queue": "notifications"
+        },
         "app.tasks.notify_tasks.notify_safety": {"queue": "notifications"},
     },
 )

--- a/backend/app/tasks/notify_tasks.py
+++ b/backend/app/tasks/notify_tasks.py
@@ -1,14 +1,18 @@
-"""Notification tasks for safety alerts."""
+"""Backward-compatible notification task aliases."""
 
 import logging
 
 from app.tasks.celery_app import celery_app
+from app.tasks.notification_tasks import notify_safety_manager
 
 logger = logging.getLogger(__name__)
 
 
 @celery_app.task
 def notify_safety(incident_id: str):
-    """Notify safety team that an incident was initiated."""
-    logger.info("Safety notification queued for incident %s", incident_id)
-    return {"incident_id": incident_id, "status": "notified"}
+    """Backward-compatible alias for legacy task name."""
+    logger.warning(
+        "notify_safety is deprecated; forwarding incident %s to notify_safety_manager",
+        incident_id,
+    )
+    return notify_safety_manager(incident_id)

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -121,6 +121,7 @@ class TestCeleryAppConfig:
         assert "app.tasks.evidence_tasks.capture_dashcam" in routes
         assert "app.tasks.evidence_tasks.capture_telematics_bundle" in routes
         assert "app.tasks.export_tasks.build_export" in routes
+        assert "app.tasks.notification_tasks.notify_safety_manager" in routes
 
 
 # ── capture_dashcam ─────────────────────────────────────────────────

--- a/backend/tests/test_driver_admin_endpoints.py
+++ b/backend/tests/test_driver_admin_endpoints.py
@@ -338,14 +338,14 @@ class TestRotateQr:
 
 
 class TestDriverInitiate:
-    @patch("app.api.routes_driver.notify_safety")
+    @patch("app.api.routes_driver.notify_safety_manager")
     @patch("app.api.routes_driver.capture_telematics_bundle")
     @patch("app.api.routes_driver.capture_dashcam")
     def test_driver_initiate_creates_incident_and_events(
         self,
         mock_dash,
         mock_tele,
-        mock_notify,
+        mock_notify_manager,
         client,
         db_session,
         test_driver,
@@ -354,7 +354,7 @@ class TestDriverInitiate:
     ):
         mock_dash.delay = MagicMock()
         mock_tele.delay = MagicMock()
-        mock_notify.delay = MagicMock()
+        mock_notify_manager.delay = MagicMock()
 
         resp = client.post(
             "/driver/incidents/initiate",
@@ -379,14 +379,14 @@ class TestDriverInitiate:
         assert "incident_protocol_initiated" in event_types
         assert "evidence_lockdown_started" in event_types
 
-    @patch("app.api.routes_driver.notify_safety")
+    @patch("app.api.routes_driver.notify_safety_manager")
     @patch("app.api.routes_driver.capture_telematics_bundle")
     @patch("app.api.routes_driver.capture_dashcam")
     def test_driver_initiate_resolves_vehicle_by_qr(
         self,
         mock_dash,
         mock_tele,
-        mock_notify,
+        mock_notify_manager,
         client,
         db_session,
         test_driver,
@@ -395,7 +395,7 @@ class TestDriverInitiate:
     ):
         mock_dash.delay = MagicMock()
         mock_tele.delay = MagicMock()
-        mock_notify.delay = MagicMock()
+        mock_notify_manager.delay = MagicMock()
 
         resp = client.post(
             "/driver/incidents/initiate",


### PR DESCRIPTION
### Motivation
- Ensure driver-initiated incidents enqueue the canonical notification implementation that actually notifies the safety manager rather than a logging-only stub. 
- Make sure the canonical task is routed to the `notifications` Celery queue so workers pick it up correctly. 
- Preserve backward compatibility for any callers referencing the legacy task name while gradually migrating to the canonical API.

### Description
- Replaced the legacy import and call in `backend/app/api/routes_driver.py` to use `app.tasks.notification_tasks.notify_safety_manager` and call `notify_safety_manager.delay(str_id)` when initiating an incident. 
- Added an explicit route for `app.tasks.notification_tasks.notify_safety_manager` to the `notifications` queue in `backend/app/tasks/celery_app.py` while retaining the legacy `app.tasks.notify_tasks.notify_safety` route for compatibility. 
- Converted `backend/app/tasks/notify_tasks.py` into a backward-compatible shim that logs a deprecation warning and forwards execution to `notify_safety_manager`. 
- Updated tests to patch and assert the canonical task (`notify_safety_manager`) and to verify the new route is present in Celery config (`backend/tests/test_driver_admin_endpoints.py` and `backend/tests/test_celery_tasks.py`). 
- Did not change event emission logic; system events created during incident initiation remain unchanged and are consistent with `SystemEventType` values.

### Testing
- Ran linter via `make lint` which completed successfully (`ruff` checks passed). 
- Ran unit tests via `cd backend && pytest tests/test_driver_admin_endpoints.py tests/test_celery_tasks.py -q` and all tests passed (`55 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb2f8f210c8321ad375f39bf8d265e)