### PR TITLE
Use boto3 to generate presigned S3 URLs for export downloads

### DIFF
--- a/backend/app/api/routes_exports.py
+++ b/backend/app/api/routes_exports.py
@@ -16,6 +16,11 @@ from app.db.repo.incidents import get_incident
 from app.db.repo.users import get_user_org_ids
 from app.domain.system_event_types import SystemEventType
 from app.core.config import settings
+from app.services.vault_s3 import (
+    S3PresignConfigurationError,
+    S3PresignGenerationError,
+    generate_presigned_download_url,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -91,13 +96,24 @@ def download_export_endpoint(
     if export.status != "ready":
         raise HTTPException(status_code=409, detail="Export is not ready")
 
-    # Build a presigned-style URL (placeholder — real impl uses boto3)
     bucket = export.s3_bucket or settings.S3_BUCKET
     key = export.s3_key or f"exports/{export.export_id}.zip"
-    presigned_url = (
-        f"https://{bucket}.s3.{settings.AWS_REGION}.amazonaws.com/{key}"
-        f"?X-Amz-Expires=3600"
-    )
+    expires_in_seconds = 3600
+
+    try:
+        presigned_url = generate_presigned_download_url(
+            bucket=bucket,
+            key=key,
+            region=settings.AWS_REGION,
+            expires_in=expires_in_seconds,
+        )
+    except S3PresignConfigurationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except S3PresignGenerationError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail="Unable to generate export download URL",
+        ) from exc
 
     create_event(
         db,

--- a/backend/app/services/vault_s3.py
+++ b/backend/app/services/vault_s3.py
@@ -5,6 +5,14 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+class S3PresignConfigurationError(ValueError):
+    """Raised when required S3 presign configuration is missing."""
+
+
+class S3PresignGenerationError(RuntimeError):
+    """Raised when generating an S3 presigned URL fails."""
+
+
 class VaultS3:
     """Handles storing and retrieving artifacts from S3."""
 
@@ -27,9 +35,11 @@ class VaultS3:
 
     def presign_download(self, key: str, expires_in: int = 3600) -> str:
         """Return a presigned URL for downloading the object."""
-        return (
-            f"https://{self.bucket}.s3.{self.region}.amazonaws.com/{key}"
-            f"?X-Amz-Expires={expires_in}"
+        return generate_presigned_download_url(
+            bucket=self.bucket,
+            key=key,
+            region=self.region,
+            expires_in=expires_in,
         )
 
     def upload(self, key: str, data: bytes) -> str:
@@ -39,3 +49,34 @@ class VaultS3:
     def download(self, key: str) -> bytes:
         """Backward-compatible alias for get_bytes."""
         return self.get_bytes(key)
+
+
+def generate_presigned_download_url(
+    *,
+    bucket: str,
+    key: str,
+    region: str,
+    expires_in: int = 3600,
+) -> str:
+    """Generate a presigned S3 download URL using boto3."""
+    if not bucket:
+        raise S3PresignConfigurationError("Export download bucket is not configured")
+    if not key:
+        raise S3PresignConfigurationError("Export download object key is not configured")
+
+    try:
+        import boto3
+        from botocore.exceptions import BotoCoreError, ClientError
+
+        client = boto3.client("s3", region_name=region)
+        return client.generate_presigned_url(
+            ClientMethod="get_object",
+            Params={"Bucket": bucket, "Key": key},
+            ExpiresIn=expires_in,
+        )
+    except ImportError as exc:
+        logger.exception("boto3 is required to generate S3 presigned URLs")
+        raise S3PresignGenerationError("Failed to generate download URL") from exc
+    except (ClientError, BotoCoreError) as exc:
+        logger.exception("Failed to generate presigned S3 URL")
+        raise S3PresignGenerationError("Failed to generate download URL") from exc

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ pydantic-settings>=2.0.0
 jsonschema>=4.0.0
 bcrypt>=4.2.0
 python-jose[cryptography]>=3.5.0
+boto3>=1.34.0

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -472,7 +472,10 @@ class TestDownloadExport:
         resp = client.get(f"/exports/{exp.export_id}/download", headers=auth_headers)
         assert resp.status_code == 409
 
-    def test_download_export_ready(self, client, db_session, test_org, auth_headers):
+    @patch("app.api.routes_exports.generate_presigned_download_url")
+    def test_download_export_ready(
+        self, mock_generate_presigned_download_url, client, db_session, test_org, auth_headers
+    ):
         inc = Incident(status="open", org_id=test_org.id)
         db_session.add(inc)
         db_session.commit()
@@ -489,15 +492,21 @@ class TestDownloadExport:
         db_session.commit()
         db_session.refresh(exp)
 
+        mock_generate_presigned_download_url.return_value = (
+            "https://signed.example.com/exports/test.zip"
+        )
+
+
         resp = client.get(f"/exports/{exp.export_id}/download", headers=auth_headers)
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"] == "ready"
         assert "url" in data
-        assert "my-bucket" in data["url"]
+        assert "signed.example.com" in data["url"]
 
+    @patch("app.api.routes_exports.generate_presigned_download_url")
     def test_download_export_logs_event(
-        self, client, db_session, test_org, auth_headers
+        self, mock_generate_presigned_download_url, client, db_session, test_org, auth_headers
     ):
         inc = Incident(status="open", org_id=test_org.id)
         db_session.add(inc)
@@ -514,6 +523,8 @@ class TestDownloadExport:
         db_session.add(exp)
         db_session.commit()
         db_session.refresh(exp)
+
+        mock_generate_presigned_download_url.return_value = "https://signed.example.com/k"
 
         client.get(f"/exports/{exp.export_id}/download", headers=auth_headers)
 
@@ -557,8 +568,9 @@ class TestDownloadExport:
         resp = client.get(f"/exports/{exp.export_id}/download", headers=auth_headers)
         assert resp.status_code == 403
 
+    @patch("app.api.routes_exports.generate_presigned_download_url")
     def test_download_export_uses_incident_org_for_legacy_null_org_export(
-        self, client, db_session, auth_headers, test_org
+        self, mock_generate_presigned_download_url, client, db_session, auth_headers, test_org
     ):
         inc = Incident(status="open", org_id=test_org.id)
         db_session.add(inc)
@@ -576,8 +588,72 @@ class TestDownloadExport:
         db_session.commit()
         db_session.refresh(exp)
 
+        mock_generate_presigned_download_url.return_value = (
+            "https://signed.example.com/exports/legacy.zip"
+        )
+
         resp = client.get(f"/exports/{exp.export_id}/download", headers=auth_headers)
         assert resp.status_code == 200
+
+    @patch("app.api.routes_exports.generate_presigned_download_url")
+    def test_download_export_missing_bucket_or_key_returns_422(
+        self, mock_generate_presigned_download_url, client, db_session, test_org, auth_headers
+    ):
+        inc = Incident(status="open", org_id=test_org.id)
+        db_session.add(inc)
+        db_session.commit()
+        db_session.refresh(inc)
+
+        exp = Export(
+            org_id=test_org.id,
+            incident_id=inc.incident_id,
+            status="ready",
+            s3_bucket=None,
+            s3_key=None,
+        )
+        db_session.add(exp)
+        db_session.commit()
+        db_session.refresh(exp)
+
+        from app.services.vault_s3 import S3PresignConfigurationError
+
+        mock_generate_presigned_download_url.side_effect = S3PresignConfigurationError(
+            "Export download bucket is not configured"
+        )
+
+        resp = client.get(f"/exports/{exp.export_id}/download", headers=auth_headers)
+        assert resp.status_code == 422
+        assert resp.json()["detail"] == "Export download bucket is not configured"
+
+    @patch("app.api.routes_exports.generate_presigned_download_url")
+    def test_download_export_presign_failure_returns_502(
+        self, mock_generate_presigned_download_url, client, db_session, test_org, auth_headers
+    ):
+        inc = Incident(status="open", org_id=test_org.id)
+        db_session.add(inc)
+        db_session.commit()
+        db_session.refresh(inc)
+
+        exp = Export(
+            org_id=test_org.id,
+            incident_id=inc.incident_id,
+            status="ready",
+            s3_bucket="my-bucket",
+            s3_key="exports/failure.zip",
+        )
+        db_session.add(exp)
+        db_session.commit()
+        db_session.refresh(exp)
+
+        from app.services.vault_s3 import S3PresignGenerationError
+
+        mock_generate_presigned_download_url.side_effect = S3PresignGenerationError(
+            "Failed to generate download URL"
+        )
+
+        resp = client.get(f"/exports/{exp.export_id}/download", headers=auth_headers)
+        assert resp.status_code == 502
+        assert resp.json()["detail"] == "Unable to generate export download URL"
 
     def test_download_export_forbidden_when_legacy_null_org_export_has_no_org_incident(
         self, client, db_session, auth_headers

--- a/backend/tests/test_vault_s3.py
+++ b/backend/tests/test_vault_s3.py
@@ -1,0 +1,76 @@
+"""Tests for S3 presigned URL generation helpers."""
+
+import sys
+from types import SimpleNamespace
+
+from app.services.vault_s3 import (
+    S3PresignConfigurationError,
+    S3PresignGenerationError,
+    generate_presigned_download_url,
+)
+
+
+class _FakeS3Client:
+    def generate_presigned_url(self, ClientMethod, Params, ExpiresIn):  # noqa: N803
+        assert ClientMethod == "get_object"
+        assert Params["Bucket"] == "bucket"
+        assert Params["Key"] == "exports/test.zip"
+        assert ExpiresIn == 900
+        return "https://signed.example.com/exports/test.zip"
+
+
+def test_generate_presigned_download_url_missing_bucket_raises():
+    try:
+        generate_presigned_download_url(
+            bucket="",
+            key="exports/test.zip",
+            region="us-east-1",
+        )
+    except S3PresignConfigurationError as exc:
+        assert str(exc) == "Export download bucket is not configured"
+    else:
+        raise AssertionError("Expected S3PresignConfigurationError")
+
+
+def test_generate_presigned_download_url_uses_boto3(monkeypatch):
+    fake_boto3 = SimpleNamespace(client=lambda *_args, **_kwargs: _FakeS3Client())
+    fake_botocore_exceptions = SimpleNamespace(
+        BotoCoreError=Exception,
+        ClientError=Exception,
+    )
+
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+    monkeypatch.setitem(sys.modules, "botocore.exceptions", fake_botocore_exceptions)
+
+    url = generate_presigned_download_url(
+        bucket="bucket",
+        key="exports/test.zip",
+        region="us-east-1",
+        expires_in=900,
+    )
+
+    assert url == "https://signed.example.com/exports/test.zip"
+
+
+def test_generate_presigned_download_url_missing_boto3_raises(monkeypatch):
+    monkeypatch.delitem(sys.modules, "boto3", raising=False)
+
+    original_import = __import__
+
+    def _raising_import(name, *args, **kwargs):
+        if name == "boto3":
+            raise ImportError("No module named boto3")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _raising_import)
+
+    try:
+        generate_presigned_download_url(
+            bucket="bucket",
+            key="exports/test.zip",
+            region="us-east-1",
+        )
+    except S3PresignGenerationError as exc:
+        assert str(exc) == "Failed to generate download URL"
+    else:
+        raise AssertionError("Expected S3PresignGenerationError")


### PR DESCRIPTION
### Motivation
- Replace the fragile string-concatenated URL used for export downloads with real S3 presigning so downloads are secure, time-limited, and compatible with AWS signing semantics.  
- Provide a reusable, testable helper to centralize presign logic and surface clear errors for missing configuration or AWS/client failures.  

### Description
- Replace the placeholder URL construction in `download_export_endpoint` with calls to `generate_presigned_download_url(...)`, resolving `bucket`/`key` from `export.s3_bucket`/`export.s3_key` with safe fallbacks and an explicit expiry of `3600` seconds.  
- Add `generate_presigned_download_url`, `S3PresignConfigurationError`, and `S3PresignGenerationError` in `app/services/vault_s3.py`, and wire `VaultS3.presign_download()` to use it.  
- Map helper exceptions to HTTP responses in the endpoint: return `422` for missing bucket/key configuration and `502` for presign generation failures, while preserving existing authorization checks and emitting the `EXPORT_DOWNLOADED` event.  
- Add `boto3` to `backend/requirements.txt` for runtime support, and update tests to mock the presign helper and add dedicated unit tests for the helper.  

### Testing
- Ran linter checks with `ruff check app tests` and `ruff check app/api/routes_exports.py app/services/vault_s3.py tests/test_api_endpoints.py`, and all checks passed.  
- Ran targeted pytest runs for the modified behavior with `pytest -q tests/test_api_endpoints.py -k download_export` which passed and then `pytest -q tests/test_api_endpoints.py::TestDownloadExport tests/test_vault_s3.py`, which completed successfully (`13 passed`, 1 warning about pydantic settings).  
- Added `backend/tests/test_vault_s3.py` to exercise missing-config, boto3 path (via monkeypatch), and missing-boto3 error handling, and those tests passed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb30b7086c8321a49562364450a976)