### PR TITLE
docs(frontend): replace template README with project-specific documentation

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,36 +1,86 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# ADC Frontend
 
-## Getting Started
+This package contains the Next.js frontend for the Accident Documentation & Compliance (ADC) MVP. It is an App Router application that talks to the backend API for auth, incidents, exports, vehicle admin tools, and driver protocol administration.
 
-First, run the development server:
+## Implemented routes
+
+### Core app routes
+
+- `/login` – email/password sign-in page.
+- `/` – auth-aware redirect page:
+  - redirects to `/login` when no valid token is present,
+  - redirects to `/dashboard` when authenticated.
+- `/dashboard` – primary landing page with summary cards and links into workflow areas.
+- `/incidents` – incidents listing page.
+- `/incidents/[id]` – incident detail page (evidence inventory, timeline, exports status/actions).
+- `/exports` – export package listing and download actions.
+- `/vehicles` – fleet vehicle management page for admins (non-admin users are blocked from actions).
+- `/timeline` – currently a placeholder “live timeline” screen (not real-time yet).
+
+### Admin routes
+
+- `/admin/driver-protocol` – driver protocol settings editor.
+- `/admin/driver-protocol/instructions` – instruction step editor (add/edit/reorder/enable/disable/reset).
+- `/admin/vehicles` – admin vehicle list with QR generate/rotate workflow.
+
+## Environment variables
+
+The frontend API client resolves backend base URLs differently on client vs server:
+
+- `NEXT_PUBLIC_API_BASE_URL` (**required**)
+  - Public API base URL used by browser requests.
+  - Example: `http://localhost:8000`
+- `API_INTERNAL_BASE_URL` (**optional, server-side only**)
+  - Used by server-side code when available (falls back to `NEXT_PUBLIC_API_BASE_URL`).
+  - Useful when the frontend container/network should call a private backend hostname.
+
+If neither variable is set, code falls back to `http://localhost:8000`.
+
+## Local development
+
+From `frontend/`:
 
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Then open `http://localhost:3000`.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Quality and build commands
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+From `frontend/`:
 
-## Learn More
+```bash
+npm run lint
+npm run build
+```
 
-To learn more about Next.js, take a look at the following resources:
+Available package scripts:
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+- `npm run dev` – start development server.
+- `npm run lint` – run ESLint.
+- `npm run build` – create production build.
+- `npm run start` – run production server from built output.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## Authentication model
 
-## Deploy on Vercel
+Authentication is token-based with client-side session checks:
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+- Login/register API calls store `access_token` in `localStorage` under `token`.
+- API requests attach `Authorization: Bearer <token>` when running in the browser.
+- On `401 Unauthorized`, the token is removed and users are redirected to `/login`.
+- Route protection is implemented in client code (`useAuth` + layout guards), which calls `/auth/me` to validate sessions.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Protected experiences include dashboard/incidents/exports/vehicles/admin UIs. Admin pages also enforce `user.role === "admin"` checks in the admin layout.
+
+## Known limitations / placeholders
+
+These behaviors are intentional in the current MVP and differ from what developers might assume from a stock Next.js template:
+
+- **No Next.js middleware auth gate**: protection is primarily client-side; redirects happen after hydration/session checks.
+- **Token storage is in `localStorage`**: not HTTP-only cookie auth.
+- **Timeline page is a placeholder**: it does not yet use SSE/WebSockets for true live event streaming.
+- **Some dashboard cards are placeholders**: counts for non-incident metrics currently render as `—`.
+- **Root route is redirect-only**: `/` is not a content page; it is a session check/redirect shim.
+


### PR DESCRIPTION
### Motivation

- Replace the generic Next.js template README with a focused guide for the ADC frontend to make onboarding and development expectations explicit.

### Description

- Rewrote `frontend/README.md` with project-specific documentation covering implemented routes (core and admin), environment variable resolution, local dev and build commands, the token-based auth model, and known MVP limitations.
- Documented the key routes such as `/dashboard`, `/incidents`, `/incidents/[id]`, `/exports`, `/vehicles`, `/timeline`, and admin pages under `/admin/*` and explained role-based access enforced by `useAuth` and the admin layout.
- Clarified environment variables `NEXT_PUBLIC_API_BASE_URL` (browser) and optional `API_INTERNAL_BASE_URL` (server-side fallback), and noted the fallback to `http://localhost:8000` when unset.
- Added the package scripts and commands (`npm run dev`, `npm run lint`, `npm run build`, `npm run start`) and an overview of the authentication flow (tokens stored in `localStorage`, API calls attach `Authorization`, `useAuth` + `/auth/me` validation, and client-side redirection on `401`).

### Testing

- Ran `npm run lint` in `frontend/`; linter passed but reported one existing warning in `app/dashboard/page.tsx` about an unused `error` variable.
- Ran `npm run build` in `frontend/`; production build completed successfully and static/SSG pages were generated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb3594a2e483218dc4d18dfc0f4a50)