### PR TITLE
docs: refresh README task inventory for backend Celery tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ adc-mvp/
 │   │   │   ├── pdf_render.py          # PDF rendering service
 │   │   │   └── s3_key_builder.py      # S3 key construction helper
 │   │   ├── tasks/
-│   │   │   ├── celery_app.py          # Celery configuration
-│   │   │   ├── evidence_tasks.py      # Evidence collection tasks
-│   │   │   └── export_tasks.py        # Export generation tasks
+│   │   │   ├── __init__.py            # Tasks package marker
+│   │   │   ├── celery_app.py          # Celery app config + task routing/queues
+│   │   │   ├── evidence_tasks.py      # Dashcam + telematics evidence ingestion
+│   │   │   ├── export_tasks.py        # Export build + persistence/upload tasks
+│   │   │   ├── notification_tasks.py  # Safety manager SMS/voice alerts via Twilio
+│   │   │   └── notify_tasks.py        # Legacy shim alias for deprecated notify task
 │   │   └── domain/
 │   │       ├── event_types.py         # Event type definitions
 │   │       ├── evidence_types.py      # Evidence type definitions


### PR DESCRIPTION
### Motivation
- Keep the `backend/app/tasks/` README inventory accurate and clarify the safety-manager notification responsibilities to avoid onboarding confusion.

### Description
- Updated the `backend/app` tree in `README.md` to explicitly list `__init__.py`, `celery_app.py`, `evidence_tasks.py`, `export_tasks.py`, `notification_tasks.py` (documented as Twilio-backed safety manager SMS/voice alerts), and `notify_tasks.py` (documented as a legacy/deprecated shim alias).

### Testing
- Ran `make lint` which completed successfully.
- Ran `make test` which failed in this environment due to network/proxy restrictions when pip attempted to resolve `boto3>=1.34.0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb373f7d9883218a9ce522c0f231e5)