### PR TITLE
Add focused org access tests for /exports/ listing

### DIFF
--- a/backend/tests/test_exports.py
+++ b/backend/tests/test_exports.py
@@ -1,11 +1,6 @@
-"""Basic test cases for the export API endpoints.
+"""Focused test coverage for the exports list endpoint."""
 
-This module contains simple unit tests to exercise the new export
-listing functionality. These tests are not exhaustive but
-demonstrate how pytest can be used to drive the FastAPI app and
-assert responses. To execute the tests, run ``pytest`` from the
-repository root.
-"""
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -15,9 +10,9 @@ from sqlalchemy.pool import StaticPool
 
 try:
     from app.main import app
-    from app.db.models import Base, User, Org, UserOrg
+    from app.db.models import Base, Export, Incident, Org, User, UserOrg
     from app.db.session import get_db
-    from app.core.security import hash_password, create_access_token
+    from app.core.security import create_access_token, hash_password
 except ModuleNotFoundError:
     pytest.skip("FastAPI app not available for testing", allow_module_level=True)
 
@@ -41,6 +36,15 @@ def db_session():
 @pytest.fixture()
 def test_org(db_session):
     org = Org(name="Test Org")
+    db_session.add(org)
+    db_session.commit()
+    db_session.refresh(org)
+    return org
+
+
+@pytest.fixture()
+def other_org(db_session):
+    org = Org(name="Other Org")
     db_session.add(org)
     db_session.commit()
     db_session.refresh(org)
@@ -85,7 +89,90 @@ def client(db_session) -> TestClient:
 
 
 def test_list_exports_empty(client: TestClient, auth_headers) -> None:
-    """Ensure the list exports endpoint returns an empty list when no exports exist."""
-    response = client.get("/exports", headers=auth_headers)
+    response = client.get("/exports/", headers=auth_headers)
     assert response.status_code == 200
     assert response.json() == []
+
+
+def test_list_exports_filters_by_org_including_legacy_null_org_exports(
+    client: TestClient,
+    db_session,
+    test_org,
+    other_org,
+    auth_headers,
+) -> None:
+    now = datetime.now(timezone.utc)
+
+    caller_incident = Incident(org_id=test_org.id, status="open")
+    other_incident = Incident(org_id=other_org.id, status="open")
+    db_session.add_all([caller_incident, other_incident])
+    db_session.commit()
+    db_session.refresh(caller_incident)
+    db_session.refresh(other_incident)
+
+    caller_export = Export(
+        incident_id=caller_incident.incident_id,
+        org_id=test_org.id,
+        status="ready",
+        created_at_utc=now - timedelta(minutes=2),
+    )
+    legacy_caller_export = Export(
+        incident_id=caller_incident.incident_id,
+        org_id=None,
+        status="processing",
+        created_at_utc=now - timedelta(minutes=1),
+    )
+    other_org_export = Export(
+        incident_id=other_incident.incident_id,
+        org_id=other_org.id,
+        status="failed",
+        created_at_utc=now,
+    )
+
+    db_session.add_all([caller_export, legacy_caller_export, other_org_export])
+    db_session.commit()
+
+    response = client.get("/exports/", headers=auth_headers)
+    assert response.status_code == 200
+
+    rows = response.json()
+    assert len(rows) == 2
+
+    by_id = {row["export_id"]: row for row in rows}
+    assert str(caller_export.export_id) in by_id
+    assert str(legacy_caller_export.export_id) in by_id
+    assert str(other_org_export.export_id) not in by_id
+
+    for export in [caller_export, legacy_caller_export]:
+        row = by_id[str(export.export_id)]
+        assert set(["export_id", "incident_id", "status", "created_at_utc"]).issubset(
+            row.keys()
+        )
+        assert row["incident_id"] == str(export.incident_id)
+        assert row["status"] == export.status
+        assert row["created_at_utc"] is not None
+
+
+def test_list_exports_regression_excludes_exports_from_unauthorized_org(
+    client: TestClient,
+    db_session,
+    other_org,
+    auth_headers,
+) -> None:
+    other_incident = Incident(org_id=other_org.id, status="open")
+    db_session.add(other_incident)
+    db_session.commit()
+    db_session.refresh(other_incident)
+
+    unauthorized_export = Export(
+        incident_id=other_incident.incident_id,
+        org_id=other_org.id,
+        status="requested",
+    )
+    db_session.add(unauthorized_export)
+    db_session.commit()
+
+    response = client.get("/exports/", headers=auth_headers)
+    assert response.status_code == 200
+    rows = response.json()
+    assert rows == []


### PR DESCRIPTION
### Motivation
- Ensure the `/exports/` listing endpoint returns only exports the caller is allowed to see, including legacy rows where `Export.org_id` is `NULL` but the linked `Incident.org_id` belongs to the caller. 
- Verify the API returns the specific fields consumed by the frontend (`export_id`, `incident_id`, `status`, `created_at_utc`).
- Add a regression test to prevent accidental exposure of exports from unauthorized orgs.

### Description
- Rewrote `backend/tests/test_exports.py` with focused coverage and additional imports for `Export` and `Incident`, and added a second org fixture (`other_org`).
- Added `test_list_exports_filters_by_org_including_legacy_null_org_exports` which seeds exports in the caller org, a legacy null-org export linked to the caller incident, and an export in another org, and asserts only the two allowed rows are returned.
- Added assertions that each returned row contains `export_id`, `incident_id`, `status`, and `created_at_utc` and that values match the seeded rows.
- Added `test_list_exports_regression_excludes_exports_from_unauthorized_org` to confirm exports owned by another org are not returned to the caller.

### Testing
- Ran linting with `make lint` and the linter checks passed.
- Ran the focused test module with `cd backend && pytest tests/test_exports.py -v` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb395785708321a7c7740af0424636)