### PR TITLE
Add assertions for incident initiation task dispatch

### DIFF
--- a/backend/tests/test_driver_admin_endpoints.py
+++ b/backend/tests/test_driver_admin_endpoints.py
@@ -369,6 +369,13 @@ class TestDriverInitiate:
         incident = db_session.query(Incident).first()
         assert incident is not None
         assert incident.adc_vehicle_id == "veh-100"
+        mock_dash.delay.assert_called_once_with(
+            str(incident.incident_id), None, None
+        )
+        mock_tele.delay.assert_called_once_with(
+            str(incident.incident_id), None, None
+        )
+        mock_notify_manager.delay.assert_called_once_with(str(incident.incident_id))
 
         events = (
             db_session.query(Event)
@@ -405,6 +412,13 @@ class TestDriverInitiate:
         assert resp.status_code == 200
         incident = db_session.query(Incident).first()
         assert incident.adc_vehicle_id == "veh-200"
+        mock_dash.delay.assert_called_once_with(
+            str(incident.incident_id), None, None
+        )
+        mock_tele.delay.assert_called_once_with(
+            str(incident.incident_id), None, None
+        )
+        mock_notify_manager.delay.assert_called_once_with(str(incident.incident_id))
 
 
 # ── GET /driver/instructions/active ─────────────────────────────────


### PR DESCRIPTION
### Motivation
- Ensure the driver incident initiation flow dispatches the expected async tasks and that the notification task is invoked with the created incident ID. 
- Preserve regression coverage for parallel evidence capture (dashcam/telematics) while updating tests to reference the unified notification task path. 

### Description
- Updated `TestDriverInitiate` in `backend/tests/test_driver_admin_endpoints.py` to assert that `capture_dashcam.delay` and `capture_telematics_bundle.delay` are called with `str(incident.incident_id), None, None`. 
- Added assertions that `notify_safety_manager.delay` is called with `str(incident.incident_id)` in both the `last_assigned` and `qr` initiation paths. 
- Kept existing test structure and mocks patched at `app.api.routes_driver` so the tests validate dispatch parameters without changing application code. 

### Testing
- Ran linting with `make lint` and all checks passed. 
- Ran the updated test file with `pytest tests/test_driver_admin_endpoints.py -q` and it succeeded (`28 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb399d92c48321872e2c6d731fb3fd)