### PR TITLE
Add reusable marketing UI system, brand tokens, and docs

### DIFF
--- a/docs/website/components.md
+++ b/docs/website/components.md
@@ -1,0 +1,52 @@
+# Website marketing components
+
+The marketing UI lives in:
+
+- `frontend/app/(marketing)/marketing/page.tsx`
+- `frontend/components/marketing/*`
+
+## Brand tokens
+
+Shared tokens are defined in `frontend/components/marketing/tokens.ts`.
+
+- **Spacing:** `container`, `sectionSpacing`
+- **Typography:** `headingScale.display`, `h2`, `h3`, `body`, `muted`
+- **Buttons:** `buttonVariants.primary`, `buttonVariants.secondary`
+- **Surfaces:** `surfaces.page`, `card`, `subtle`, `accent`
+
+Use these tokens in new marketing sections to preserve visual consistency and responsive behavior.
+
+## Layout primitives
+
+- `MarketingContainer`: enforces the canonical max-width and horizontal padding.
+- `MarketingSection`: wraps section spacing and container behavior.
+
+Prefer these instead of manual `max-w-*` wrappers.
+
+## Reusable sections
+
+- `Hero`
+  - Includes top navigation with keyboard focus styles.
+  - Includes accessible form labels and submit action.
+- `ProofBar`
+  - Lightweight proof-point row with responsive grid behavior.
+- `FeatureGrid`
+  - Feature cards, section heading, and descriptive lead text.
+- `UseCaseCards`
+  - Role-based use case cards for claims/safety/compliance.
+- `TestimonialQuote`
+  - Featured customer quote surface.
+- `PricingTable`
+  - Tier cards with ARIA labels and strong CTA affordance.
+- `CTASection`
+  - End-of-page conversion call-to-action.
+
+## Accessibility standards
+
+For all marketing components:
+
+1. Include `focus-visible` ring styles on links/buttons/inputs.
+2. Provide `aria-label` text where action context is ambiguous.
+3. Keep form controls associated with `<label>` elements.
+4. Maintain contrast by using slate/sky palette combinations already in tokens.
+5. Use semantic landmarks (`header`, `nav`, `section`, `main`) and heading hierarchy.

--- a/frontend/app/(marketing)/marketing/page.tsx
+++ b/frontend/app/(marketing)/marketing/page.tsx
@@ -1,0 +1,22 @@
+import { CTASection } from "@/components/marketing/CTASection";
+import { FeatureGrid } from "@/components/marketing/FeatureGrid";
+import { Hero } from "@/components/marketing/Hero";
+import { PricingTable } from "@/components/marketing/PricingTable";
+import { ProofBar } from "@/components/marketing/ProofBar";
+import { TestimonialQuote } from "@/components/marketing/TestimonialQuote";
+import { UseCaseCards } from "@/components/marketing/UseCaseCards";
+import { marketingTokens } from "@/components/marketing/tokens";
+
+export default function MarketingPage() {
+  return (
+    <main className={`${marketingTokens.surfaces.page} min-h-screen`}>
+      <Hero />
+      <ProofBar />
+      <FeatureGrid />
+      <UseCaseCards />
+      <TestimonialQuote />
+      <PricingTable />
+      <CTASection />
+    </main>
+  );
+}

--- a/frontend/components/marketing/CTASection.tsx
+++ b/frontend/components/marketing/CTASection.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+import { MarketingSection } from "@/components/marketing/LayoutPrimitives";
+import { marketingTokens } from "@/components/marketing/tokens";
+
+export function CTASection() {
+  return (
+    <MarketingSection id="contact" className="pt-0">
+      <div className={`${marketingTokens.surfaces.card} flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between`}>
+        <div>
+          <h2 className={marketingTokens.headingScale.h3}>Ready to modernize incident response?</h2>
+          <p className="mt-2 text-slate-700">Launch in days with migration support and guided onboarding.</p>
+        </div>
+        <Link href="/login" className={marketingTokens.buttonVariants.primary} aria-label="Book a product demo">
+          Book demo
+        </Link>
+      </div>
+    </MarketingSection>
+  );
+}

--- a/frontend/components/marketing/FeatureGrid.tsx
+++ b/frontend/components/marketing/FeatureGrid.tsx
@@ -1,0 +1,28 @@
+import { MarketingSection } from "@/components/marketing/LayoutPrimitives";
+import { marketingTokens } from "@/components/marketing/tokens";
+
+const features = [
+  ["Unified timeline", "Merge video, ELD, GPS, and safety events by incident."],
+  ["Evidence integrity", "Track each file access with immutable chain-of-custody logs."],
+  ["Automated exports", "Generate insurer-ready incident packages in minutes."],
+  ["Operational alerts", "Escalate high-risk events to the right people automatically."],
+];
+
+export function FeatureGrid() {
+  return (
+    <MarketingSection id="features">
+      <div className="space-y-4 text-center">
+        <h2 className={marketingTokens.headingScale.h2}>Everything your safety desk needs to move fast.</h2>
+        <p className="mx-auto max-w-3xl text-slate-700">Purpose-built workflows for response teams, adjusters, and compliance leaders.</p>
+      </div>
+      <div className="mt-10 grid gap-5 md:grid-cols-2">
+        {features.map(([title, body]) => (
+          <article key={title} className={marketingTokens.surfaces.card}>
+            <h3 className={marketingTokens.headingScale.h3}>{title}</h3>
+            <p className="mt-3 text-slate-700">{body}</p>
+          </article>
+        ))}
+      </div>
+    </MarketingSection>
+  );
+}

--- a/frontend/components/marketing/Hero.tsx
+++ b/frontend/components/marketing/Hero.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+import { MarketingContainer } from "@/components/marketing/LayoutPrimitives";
+import { marketingTokens } from "@/components/marketing/tokens";
+
+export function Hero() {
+  return (
+    <header className="border-b border-slate-200/80">
+      <MarketingContainer>
+        <nav className="flex items-center justify-between py-6" aria-label="Primary">
+          <span className="text-sm font-semibold uppercase tracking-[0.2em] text-sky-700">ADC</span>
+          <ul className="hidden items-center gap-6 text-sm text-slate-700 md:flex" role="list">
+            <li><a className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2" href="#features">Features</a></li>
+            <li><a className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2" href="#pricing">Pricing</a></li>
+            <li><a className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2" href="#contact">Contact</a></li>
+          </ul>
+          <Link className={marketingTokens.buttonVariants.secondary} href="/login" aria-label="Sign in to your account">
+            Sign in
+          </Link>
+        </nav>
+
+        <div className="grid gap-10 py-14 lg:grid-cols-[1.15fr_1fr] lg:items-center lg:py-20">
+          <div className="space-y-6">
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-sky-700">Safety + operations intelligence</p>
+            <h1 className={marketingTokens.headingScale.display}>Faster fleet investigations with audit-ready evidence.</h1>
+            <p className={marketingTokens.headingScale.body}>
+              Centralize incidents, telematics, and chain-of-custody exports in one place your safety team can trust.
+            </p>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <Link className={marketingTokens.buttonVariants.primary} href="/login" aria-label="Start a free fleet trial">
+                Start free trial
+              </Link>
+              <a className={marketingTokens.buttonVariants.secondary} href="#pricing" aria-label="Jump to pricing plans">
+                View pricing
+              </a>
+            </div>
+          </div>
+
+          <form className={`${marketingTokens.surfaces.card} space-y-4`} aria-label="Request demo form">
+            <h2 className={marketingTokens.headingScale.h3}>Request a walkthrough</h2>
+            <label className="block text-sm font-medium text-slate-800" htmlFor="work-email">Work email</label>
+            <input
+              id="work-email"
+              name="email"
+              type="email"
+              required
+              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+              placeholder="you@fleetco.com"
+            />
+            <button type="submit" className={`${marketingTokens.buttonVariants.primary} w-full`} aria-label="Submit demo request">
+              Request demo
+            </button>
+          </form>
+        </div>
+      </MarketingContainer>
+    </header>
+  );
+}

--- a/frontend/components/marketing/LayoutPrimitives.tsx
+++ b/frontend/components/marketing/LayoutPrimitives.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from "react";
+import { marketingTokens } from "@/components/marketing/tokens";
+
+type MarketingContainerProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function MarketingContainer({ children, className = "" }: MarketingContainerProps) {
+  return <div className={`${marketingTokens.container} ${className}`.trim()}>{children}</div>;
+}
+
+type MarketingSectionProps = {
+  children: ReactNode;
+  className?: string;
+  id?: string;
+};
+
+export function MarketingSection({ children, className = "", id }: MarketingSectionProps) {
+  return (
+    <section id={id} className={`${marketingTokens.sectionSpacing} ${className}`.trim()}>
+      <MarketingContainer>{children}</MarketingContainer>
+    </section>
+  );
+}

--- a/frontend/components/marketing/PricingTable.tsx
+++ b/frontend/components/marketing/PricingTable.tsx
@@ -1,0 +1,33 @@
+import { MarketingSection } from "@/components/marketing/LayoutPrimitives";
+import { marketingTokens } from "@/components/marketing/tokens";
+
+const tiers = [
+  { name: "Starter", price: "$299", features: ["Up to 25 vehicles", "Incident timeline", "CSV exports"] },
+  { name: "Growth", price: "$799", features: ["Up to 150 vehicles", "Automated alerts", "PDF evidence bundles"] },
+  { name: "Enterprise", price: "Contact", features: ["Unlimited vehicles", "Dedicated support", "Advanced retention controls"] },
+];
+
+export function PricingTable() {
+  return (
+    <MarketingSection id="pricing">
+      <div className="space-y-4 text-center">
+        <h2 className={marketingTokens.headingScale.h2}>Simple pricing for fleet scale.</h2>
+        <p className="text-slate-700">All plans include secure evidence storage and role-based access controls.</p>
+      </div>
+      <div className="mt-10 grid gap-5 lg:grid-cols-3" role="list" aria-label="Pricing plans">
+        {tiers.map((tier) => (
+          <article key={tier.name} className={marketingTokens.surfaces.card} role="listitem">
+            <h3 className={marketingTokens.headingScale.h3}>{tier.name}</h3>
+            <p className="mt-3 text-3xl font-semibold text-slate-900">{tier.price}<span className="text-sm font-normal text-slate-600">/month</span></p>
+            <ul className="mt-4 space-y-2 text-sm text-slate-700" role="list">
+              {tier.features.map((feature) => <li key={feature}>• {feature}</li>)}
+            </ul>
+            <button className={`${marketingTokens.buttonVariants.primary} mt-6 w-full`} aria-label={`Choose ${tier.name} plan`}>
+              Choose {tier.name}
+            </button>
+          </article>
+        ))}
+      </div>
+    </MarketingSection>
+  );
+}

--- a/frontend/components/marketing/ProofBar.tsx
+++ b/frontend/components/marketing/ProofBar.tsx
@@ -1,0 +1,15 @@
+import { MarketingSection } from "@/components/marketing/LayoutPrimitives";
+
+const proofPoints = ["Trusted by 120+ fleets", "SOC 2 workflows", "99.9% uptime", "24/7 evidence support"];
+
+export function ProofBar() {
+  return (
+    <MarketingSection className="py-8">
+      <ul className="grid gap-4 text-center text-sm font-medium text-slate-700 sm:grid-cols-2 lg:grid-cols-4" aria-label="Company proof points">
+        {proofPoints.map((item) => (
+          <li key={item} className="rounded-full border border-slate-200 bg-white px-4 py-2">{item}</li>
+        ))}
+      </ul>
+    </MarketingSection>
+  );
+}

--- a/frontend/components/marketing/TestimonialQuote.tsx
+++ b/frontend/components/marketing/TestimonialQuote.tsx
@@ -1,0 +1,15 @@
+import { MarketingSection } from "@/components/marketing/LayoutPrimitives";
+import { marketingTokens } from "@/components/marketing/tokens";
+
+export function TestimonialQuote() {
+  return (
+    <MarketingSection>
+      <figure className={`${marketingTokens.surfaces.accent} p-8 sm:p-12`}>
+        <blockquote className="text-xl leading-8 sm:text-2xl">
+          “ADC cut our investigation prep from hours to minutes. We finally have one defensible source of truth.”
+        </blockquote>
+        <figcaption className="mt-6 text-sm text-sky-100">Jordan Lee, Director of Safety Operations, NorthLine Freight</figcaption>
+      </figure>
+    </MarketingSection>
+  );
+}

--- a/frontend/components/marketing/UseCaseCards.tsx
+++ b/frontend/components/marketing/UseCaseCards.tsx
@@ -1,0 +1,24 @@
+import { MarketingSection } from "@/components/marketing/LayoutPrimitives";
+import { marketingTokens } from "@/components/marketing/tokens";
+
+const useCases = [
+  { title: "Claims", copy: "Deliver complete packets before adjusters ask.", cta: "Reduce cycle time" },
+  { title: "Safety", copy: "Spot recurring behavior trends and coach faster.", cta: "Lower preventables" },
+  { title: "Compliance", copy: "Export evidence trails aligned with policy standards.", cta: "Pass audits" },
+];
+
+export function UseCaseCards() {
+  return (
+    <MarketingSection>
+      <div className="grid gap-5 lg:grid-cols-3">
+        {useCases.map((useCase) => (
+          <article key={useCase.title} className={marketingTokens.surfaces.subtle}>
+            <h3 className={marketingTokens.headingScale.h3}>{useCase.title}</h3>
+            <p className="mt-2 text-slate-700">{useCase.copy}</p>
+            <p className="mt-4 text-sm font-semibold text-sky-800">{useCase.cta}</p>
+          </article>
+        ))}
+      </div>
+    </MarketingSection>
+  );
+}

--- a/frontend/components/marketing/tokens.ts
+++ b/frontend/components/marketing/tokens.ts
@@ -1,0 +1,23 @@
+export const marketingTokens = {
+  container: "mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8",
+  sectionSpacing: "py-14 sm:py-18 lg:py-24",
+  headingScale: {
+    display: "text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl",
+    h2: "text-3xl font-semibold tracking-tight sm:text-4xl",
+    h3: "text-xl font-semibold tracking-tight sm:text-2xl",
+    body: "text-base leading-7 text-slate-700",
+    muted: "text-sm leading-6 text-slate-600",
+  },
+  buttonVariants: {
+    primary:
+      "inline-flex items-center justify-center rounded-md bg-sky-600 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2",
+    secondary:
+      "inline-flex items-center justify-center rounded-md border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-slate-900 transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2",
+  },
+  surfaces: {
+    page: "bg-gradient-to-b from-white via-sky-50/40 to-white text-slate-900",
+    card: "rounded-2xl border border-slate-200 bg-white p-6 shadow-sm",
+    subtle: "rounded-2xl border border-slate-200/80 bg-slate-50/70 p-6",
+    accent: "rounded-3xl bg-sky-900 text-white",
+  },
+};


### PR DESCRIPTION
### Motivation

- Provide a cohesive, reusable marketing area with shared brand tokens and layout primitives to ensure consistent spacing, typography, button styles, and container behavior across the site.  
- Ship accessible, responsive marketing sections (Hero, features, proof, pricing, CTA, testimonials, use-case cards) so the marketing page can be composed and maintained easily.

### Description

- Add shared brand tokens in `frontend/components/marketing/tokens.ts` covering container spacing, `headingScale`, `buttonVariants`, and `surfaces`.  
- Add responsive layout primitives `MarketingContainer` and `MarketingSection` in `frontend/components/marketing/LayoutPrimitives.tsx` to standardize max-width and section spacing.  
- Implement reusable marketing components: `Hero`, `ProofBar`, `FeatureGrid`, `UseCaseCards`, `TestimonialQuote`, `PricingTable`, and `CTASection` under `frontend/components/marketing/`.  
- Compose a new marketing route at `frontend/app/(marketing)/marketing/page.tsx` and document usage/accessibility guidance in `docs/website/components.md`.

### Testing

- Ran `npm run lint` in `frontend` and it completed (one pre-existing warning in `frontend/app/dashboard/page.tsx` was reported).  
- Ran `npm run build` in `frontend` and the Next.js production build succeeded.  
- Ran `npm run test --if-present` in `frontend` and the command completed (no frontend test script is defined).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb3d3480bc8321bfebafc4cd44e400)