### PR TITLE
Marketing-first root route with session-aware CTAs and layout updates

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,9 +7,10 @@ This package contains the Next.js frontend for the Accident Documentation & Comp
 ### Core app routes
 
 - `/login` – email/password sign-in page.
-- `/` – auth-aware redirect page:
-  - redirects to `/login` when no valid token is present,
-  - redirects to `/dashboard` when authenticated.
+- `/` – public marketing homepage (canonical landing route).
+  - always renders the marketing content for unauthenticated visitors,
+  - runs a lightweight client-side session check for header CTA behavior,
+  - shows `Sign in` when signed out and `Go to dashboard` when authenticated.
 - `/dashboard` – primary landing page with summary cards and links into workflow areas.
 - `/incidents` – incidents listing page.
 - `/incidents/[id]` – incident detail page (evidence inventory, timeline, exports status/actions).
@@ -82,5 +83,4 @@ These behaviors are intentional in the current MVP and differ from what develope
 - **Token storage is in `localStorage`**: not HTTP-only cookie auth.
 - **Timeline page is a placeholder**: it does not yet use SSE/WebSockets for true live event streaming.
 - **Some dashboard cards are placeholders**: counts for non-incident metrics currently render as `—`.
-- **Root route is redirect-only**: `/` is not a content page; it is a session check/redirect shim.
-
+- **Root route is marketing-first**: `/` is always the public marketing page. Session-aware CTA links help returning users jump to `/dashboard`.

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -19,6 +19,7 @@ export const metadata: Metadata = buildPageMetadata(
 export default function Home() {
   return (
     <>
+      {/* Canonical root route: public marketing home (session-aware CTA in Hero). */}
       {/* 1. Hero — headline, subhead, 2 CTAs, trust badge */}
       <Hero />
 

--- a/frontend/components/MainLayout.tsx
+++ b/frontend/components/MainLayout.tsx
@@ -29,8 +29,16 @@ export default function MainLayout({ title, children }: MainLayoutProps) {
 
   if (!user) {
     return (
-      <div className="p-6 text-sm text-gray-500">
-        You must be logged in to view this page.
+      <div className="space-y-2 p-6 text-sm text-gray-500">
+        <p>You must be logged in to view this page.</p>
+        <div className="flex items-center gap-4">
+          <Link href="/login" className="font-medium text-blue-600 hover:underline dark:text-blue-400">
+            Sign in
+          </Link>
+          <Link href="/" className="font-medium text-gray-600 hover:underline dark:text-gray-300">
+            Back to homepage
+          </Link>
+        </div>
       </div>
     );
   }
@@ -49,11 +57,15 @@ export default function MainLayout({ title, children }: MainLayoutProps) {
         <div>
           {title ? (
             <h1 className="text-lg font-bold text-gray-900 dark:text-white">
-              {title}
+              <Link href="/dashboard" className="hover:underline">
+                {title}
+              </Link>
             </h1>
           ) : (
             <h1 className="text-lg font-bold text-gray-900 dark:text-white">
-              ADC Dashboard
+              <Link href="/dashboard" className="hover:underline">
+                ADC Dashboard
+              </Link>
             </h1>
           )}
         </div>

--- a/frontend/components/marketing/Hero.tsx
+++ b/frontend/components/marketing/Hero.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { MarketingContainer } from "@/components/marketing/LayoutPrimitives";
 import { marketingTokens } from "@/components/marketing/tokens";
@@ -24,6 +24,31 @@ const bulletFeatures = [
 
 export function Hero() {
   const [selectedFleet, setSelectedFleet] = useState<string | null>(null);
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (!token) {
+      return;
+    }
+
+    const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
+    fetch(`${apiBase}/auth/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+      credentials: "include",
+    })
+      .then((res) => {
+        if (!res.ok) {
+          localStorage.removeItem("token");
+          setIsAuthenticated(false);
+          return;
+        }
+        setIsAuthenticated(true);
+      })
+      .catch(() => {
+        setIsAuthenticated(false);
+      });
+  }, []);
 
   return (
     <header className="bg-[#EBF2FA]">
@@ -40,9 +65,15 @@ export function Hero() {
           </ul>
 
           <div className="flex items-center gap-3">
-            <Link href="/login" className={marketingTokens.buttonVariants.ghost}>
-              Login
-            </Link>
+            {isAuthenticated ? (
+              <Link href="/dashboard" className={marketingTokens.buttonVariants.ghost}>
+                Go to dashboard
+              </Link>
+            ) : (
+              <Link href="/login" className={marketingTokens.buttonVariants.ghost}>
+                Sign in
+              </Link>
+            )}
             <div className="h-5 w-px bg-slate-300" aria-hidden="true" />
             <Link href="/pricing" className={marketingTokens.buttonVariants.secondary}>
               Check Our Prices


### PR DESCRIPTION
### Motivation
- Make `/` the canonical public marketing landing while still surfacing an obvious path for returning authenticated users. 
- Ensure CTA links and dashboard navigation present a consistent, session-aware experience across marketing and app layouts. 
- Update docs to match actual runtime behavior so developers have an accurate mental model of routing.

### Description
- Keep the marketing home as the canonical root and add a clarifying comment in `frontend/app/page.tsx` to document the decision. 
- Add a client-side session-aware CTA in `frontend/components/marketing/Hero.tsx` that checks `localStorage.token` and validates the session via `GET /auth/me`, showing `Sign in` when signed out and `Go to dashboard` when authenticated. 
- Adjust `frontend/components/MainLayout.tsx` to include explicit unauthenticated fallback links (`Sign in` and `Back to homepage`) and make the dashboard header title link to `/dashboard` for clearer navigation. 
- Update `frontend/README.md` routing documentation to reflect the marketing-first root and the session-aware CTA behavior.

### Testing
- Ran `npm run lint` in `frontend`, which completed successfully with one pre-existing warning in `app/dashboard/page.tsx`. 
- Ran `npm run build` (Next.js production build), which completed successfully and prerendered the routes without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd3c0131dc83218bdf5ab161c85c54)