### PR TITLE
Extend incident detail with defensibility summary and lifecycle evidence details

### DIFF
--- a/frontend/app/incidents/[id]/IncidentDetailClient.tsx
+++ b/frontend/app/incidents/[id]/IncidentDetailClient.tsx
@@ -59,6 +59,38 @@ export default function IncidentDetailClient() {
   const total = artifactStatuses.length || EVIDENCE_TYPES.length;
   const isCapturing = pending > 0;
   const refreshIntervalSeconds = REFRESH_INTERVAL_MS / 1000;
+  const timelineTypes = useMemo(
+    () => new Set((incident?.timeline ?? []).map((event) => event.event_type)),
+    [incident]
+  );
+  const lifecycleCoverage = useMemo(() => {
+    const hasCollected = [...timelineTypes].some(
+      (type) =>
+        type.includes("capture") ||
+        type.includes("collected") ||
+        type.includes("incident_started")
+    );
+    const hasValidated = [...timelineTypes].some(
+      (type) => type.includes("hash") || type.includes("validat")
+    );
+    const hasExported = [...timelineTypes].some((type) => type.includes("export"));
+    const hasDownloaded = [...timelineTypes].some((type) =>
+      type.includes("download")
+    );
+    return { hasCollected, hasValidated, hasExported, hasDownloaded };
+  }, [timelineTypes]);
+  const completenessPercent = Math.round((captured / total) * 100);
+  const continuityChecks = [
+    lifecycleCoverage.hasCollected,
+    lifecycleCoverage.hasValidated,
+    lifecycleCoverage.hasExported,
+  ].filter(Boolean).length;
+  const custodyContinuityLabel =
+    continuityChecks === 3
+      ? "Strong"
+      : continuityChecks === 2
+        ? "Partial"
+        : "Limited";
 
   useEffect(() => {
     if (!user) return;
@@ -164,6 +196,41 @@ export default function IncidentDetailClient() {
       </header>
 
       <main className="mx-auto max-w-6xl space-y-6 p-6">
+        <div className="rounded-lg border bg-white p-4 shadow dark:bg-gray-800">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+            Defensibility Summary
+          </h2>
+          <div className="mt-3 grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-4">
+            <div className="rounded border bg-gray-50 p-3 dark:bg-gray-700">
+              <p className="text-xs text-gray-500">Artifact Completeness</p>
+              <p className="font-semibold text-gray-900 dark:text-white">
+                {captured}/{total} ({completenessPercent}%)
+              </p>
+            </div>
+            <div className="rounded border bg-gray-50 p-3 dark:bg-gray-700">
+              <p className="text-xs text-gray-500">Custody Continuity</p>
+              <p className="font-semibold text-gray-900 dark:text-white">
+                {custodyContinuityLabel}
+              </p>
+            </div>
+            <div className="rounded border bg-gray-50 p-3 dark:bg-gray-700">
+              <p className="text-xs text-gray-500">Unavailable Artifacts</p>
+              <p className="font-semibold text-gray-900 dark:text-white">
+                {unavailable}
+              </p>
+            </div>
+            <div className="rounded border bg-gray-50 p-3 dark:bg-gray-700">
+              <p className="text-xs text-gray-500">Lifecycle Coverage</p>
+              <p className="font-semibold text-gray-900 dark:text-white">
+                {lifecycleCoverage.hasCollected ? "✓C " : "•C "}
+                {lifecycleCoverage.hasValidated ? "✓V " : "•V "}
+                {lifecycleCoverage.hasExported ? "✓E " : "•E "}
+                {lifecycleCoverage.hasDownloaded ? "✓D" : "•D"}
+              </p>
+            </div>
+          </div>
+        </div>
+
         {/* ── Panel A: Evidence Inventory ────────────────────────── */}
         <div className="rounded-lg border bg-white p-6 shadow dark:bg-gray-800">
           <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-500">

--- a/frontend/components/EvidenceTable.tsx
+++ b/frontend/components/EvidenceTable.tsx
@@ -57,10 +57,28 @@ interface EvidenceTableProps {
   artifacts: ArtifactSummary[];
 }
 
+interface ArtifactDetail extends ArtifactSummary {
+  artifact_hash?: string | null;
+  source_provider?: string | null;
+  capture_method?: string | null;
+  remediation_state?: string | null;
+  collected_at_utc?: string | null;
+  validated_at_utc?: string | null;
+  exported_at_utc?: string | null;
+  downloaded_at_utc?: string | null;
+}
+
+function toTitleCase(value?: string | null): string {
+  if (!value) return "—";
+  return value
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 export default function EvidenceTable({ artifacts }: EvidenceTableProps) {
-  const artifactMap = new Map<string, ArtifactSummary>();
+  const artifactMap = new Map<string, ArtifactDetail>();
   for (const a of artifacts) {
-    artifactMap.set(a.artifact_type, a);
+    artifactMap.set(a.artifact_type, a as ArtifactDetail);
   }
 
   return (
@@ -78,7 +96,19 @@ export default function EvidenceTable({ artifacts }: EvidenceTableProps) {
               Captured Time
             </th>
             <th className="px-4 py-2 font-medium text-gray-600 dark:text-gray-300">
-              Reason
+              Artifact Hash
+            </th>
+            <th className="px-4 py-2 font-medium text-gray-600 dark:text-gray-300">
+              Source Provider
+            </th>
+            <th className="px-4 py-2 font-medium text-gray-600 dark:text-gray-300">
+              Capture Method
+            </th>
+            <th className="px-4 py-2 font-medium text-gray-600 dark:text-gray-300">
+              Custody Timestamps
+            </th>
+            <th className="px-4 py-2 font-medium text-gray-600 dark:text-gray-300">
+              Availability Notes
             </th>
           </tr>
         </thead>
@@ -87,7 +117,10 @@ export default function EvidenceTable({ artifacts }: EvidenceTableProps) {
             const art = artifactMap.get(type);
             const status = art?.status ?? "pending";
             return (
-              <tr key={type}>
+              <tr
+                key={type}
+                className={status === "unavailable" ? "bg-red-50/60" : undefined}
+              >
                 <td className="px-4 py-2 font-medium text-gray-800 dark:text-gray-200">
                   {label}
                 </td>
@@ -104,7 +137,45 @@ export default function EvidenceTable({ artifacts }: EvidenceTableProps) {
                   {formatTime(art?.captured_at_utc)}
                 </td>
                 <td className="px-4 py-2 text-gray-500 dark:text-gray-400">
-                  {art?.unavailable_reason ?? "—"}
+                  {art?.artifact_hash ? (
+                    <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-700">
+                      {art.artifact_hash}
+                    </code>
+                  ) : (
+                    "—"
+                  )}
+                </td>
+                <td className="px-4 py-2 text-gray-500 dark:text-gray-400">
+                  {toTitleCase(art?.source_provider)}
+                </td>
+                <td className="px-4 py-2 text-gray-500 dark:text-gray-400">
+                  {toTitleCase(art?.capture_method)}
+                </td>
+                <td className="px-4 py-2 text-xs text-gray-500 dark:text-gray-400">
+                  <div className="space-y-1">
+                    <p>Collected: {formatTime(art?.collected_at_utc ?? art?.captured_at_utc)}</p>
+                    <p>Validated: {formatTime(art?.validated_at_utc)}</p>
+                    <p>Exported: {formatTime(art?.exported_at_utc)}</p>
+                    <p>Downloaded: {formatTime(art?.downloaded_at_utc)}</p>
+                  </div>
+                </td>
+                <td className="px-4 py-2 text-gray-500 dark:text-gray-400">
+                  {status === "unavailable" ? (
+                    <div className="space-y-1 text-xs">
+                      <p>
+                        <span className="font-medium text-red-700">Reason:</span>{" "}
+                        {art?.unavailable_reason ?? "Unknown"}
+                      </p>
+                      <p>
+                        <span className="font-medium text-red-700">
+                          Remediation:
+                        </span>{" "}
+                        {toTitleCase(art?.remediation_state)}
+                      </p>
+                    </div>
+                  ) : (
+                    "—"
+                  )}
                 </td>
               </tr>
             );

--- a/frontend/components/Timeline.tsx
+++ b/frontend/components/Timeline.tsx
@@ -34,26 +34,76 @@ interface TimelineProps {
   events: EventSummary[];
 }
 
+const MILESTONE_GROUPS = [
+  { key: "collected", label: "Collected" },
+  { key: "validated", label: "Validated" },
+  { key: "exported", label: "Exported" },
+  { key: "downloaded", label: "Downloaded" },
+] as const;
+
+function milestoneForEvent(eventType: string): (typeof MILESTONE_GROUPS)[number]["key"] {
+  if (
+    eventType.includes("hash") ||
+    eventType.includes("validat") ||
+    eventType.includes("integrity")
+  ) {
+    return "validated";
+  }
+  if (eventType.includes("export")) {
+    return "exported";
+  }
+  if (eventType.includes("download")) {
+    return "downloaded";
+  }
+  return "collected";
+}
+
 export default function Timeline({ events }: TimelineProps) {
   if (!events || events.length === 0) {
     return <p className="text-sm text-gray-400">No events yet.</p>;
   }
 
   const displayed = events.slice(-MAX_EVENTS);
+  const grouped = new Map<
+    (typeof MILESTONE_GROUPS)[number]["key"],
+    EventSummary[]
+  >();
+  for (const event of displayed) {
+    const key = milestoneForEvent(event.event_type);
+    const bucket = grouped.get(key) ?? [];
+    bucket.push(event);
+    grouped.set(key, bucket);
+  }
 
   return (
-    <ol className="relative border-l border-gray-200 dark:border-gray-600">
-      {displayed.map((ev, i) => (
-        <li key={i} className="mb-4 ml-4">
-          <div className="absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full border border-white bg-blue-500 dark:border-gray-800" />
-          <time className="mb-1 text-xs text-gray-400">
-            {formatTime(ev.occurred_at_utc)}
-          </time>
-          <p className="text-sm font-medium text-gray-800 dark:text-gray-200">
-            {friendlyEventType(ev.event_type)}
-          </p>
-        </li>
-      ))}
-    </ol>
+    <div className="space-y-5">
+      {MILESTONE_GROUPS.map((group) => {
+        const groupEvents = grouped.get(group.key) ?? [];
+        return (
+          <section key={group.key}>
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+              {group.label} ({groupEvents.length})
+            </h3>
+            {groupEvents.length === 0 ? (
+              <p className="text-xs text-gray-400">No events.</p>
+            ) : (
+              <ol className="relative border-l border-gray-200 dark:border-gray-600">
+                {groupEvents.map((ev, i) => (
+                  <li key={`${group.key}-${i}`} className="mb-4 ml-4">
+                    <div className="absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full border border-white bg-blue-500 dark:border-gray-800" />
+                    <time className="mb-1 text-xs text-gray-400">
+                      {formatTime(ev.occurred_at_utc)}
+                    </time>
+                    <p className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                      {friendlyEventType(ev.event_type)}
+                    </p>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </section>
+        );
+      })}
+    </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Improve visibility for chain-of-custody and defensibility on the incident detail page by surfacing integrity metadata, custody timestamps, and lifecycle coverage.  
- Make unavailable artifacts easier to triage by showing reason and remediation state in the inventory view.  
- Provide a higher-level, compact summary so users can quickly assess completeness and custody continuity.  

### Description
- Updated `frontend/components/EvidenceTable.tsx` to render additional artifact metadata columns (`artifact_hash`, `source_provider`, `capture_method`) and custody timestamps (`collected_at_utc`, `validated_at_utc`, `exported_at_utc`, `downloaded_at_utc`) and to accept them as optional fields on each artifact.  
- Highlight unavailable artifact rows and show explicit `unavailable_reason` and `remediation_state` in the Availability Notes cell.  
- Reworked `frontend/components/Timeline.tsx` to group events by lifecycle milestones (`Collected`, `Validated`, `Exported`, `Downloaded`) using a small heuristic (`milestoneForEvent`) that maps event type substrings to milestone buckets.  
- Added a compact “Defensibility Summary” card to `frontend/app/incidents/[id]/IncidentDetailClient.tsx` that reports artifact completeness, custody continuity label (Strong/Partial/Limited), unavailable count, and lifecycle coverage indicators computed from the incident timeline and artifact counts.  

### Testing
- Ran `npm run lint` in `frontend` which completed successfully and reported a single pre-existing warning in `frontend/app/dashboard/page.tsx` (unused variable) that was not introduced by this change.  
- Ran `npm run build` (Next.js production build) which completed successfully and compiled the modified routes including `/incidents/[id]`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd3d99bca48321928d5c42a05c836f)