### PR TITLE
Add driver workflow visibility to incident detail and list views

### DIFF
--- a/frontend/app/incidents/[id]/IncidentDetailClient.tsx
+++ b/frontend/app/incidents/[id]/IncidentDetailClient.tsx
@@ -5,9 +5,12 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import {
   getIncident,
+  getDriverProtocolSettings,
   requestExport,
   downloadExport,
   type IncidentDetail,
+  type DriverProtocolSummary,
+  type DriverResponseSummary,
 } from "@/lib/api";
 import { useAuth } from "@/lib/useAuth";
 import EvidenceTable, { EVIDENCE_TYPES } from "@/components/EvidenceTable";
@@ -35,6 +38,8 @@ export default function IncidentDetailClient() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [exporting, setExporting] = useState(false);
+  const [driverProtocolSettings, setDriverProtocolSettings] =
+    useState<DriverProtocolSummary | null>(null);
 
   const artifactStatuses = useMemo(() => {
     if (!incident) return [];
@@ -67,6 +72,15 @@ export default function IncidentDetailClient() {
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
   }, [id, user]);
+
+  useEffect(() => {
+    if (!user) return;
+    getDriverProtocolSettings()
+      .then((data) => setDriverProtocolSettings(data))
+      .catch(() => {
+        // Non-admin users may not have access to admin settings.
+      });
+  }, [user]);
 
   const refreshIncident = useCallback(() => {
     return getIncident(id)
@@ -127,6 +141,17 @@ export default function IncidentDetailClient() {
           unavailable === 1 ? "" : "s"
         }.`
       : "Capture complete.";
+
+  const driverResponse: DriverResponseSummary = incident.driver_response ?? {};
+  const protocolSummary =
+    incident.driver_protocol_summary ?? driverProtocolSettings;
+  const notificationSent = Boolean(driverResponse.notification_sent_at_utc);
+  const acknowledged = Boolean(driverResponse.acknowledged_at_utc);
+  const uploadsComplete = Boolean(driverResponse.uploads_complete);
+  const waitingOnDriver = Boolean(
+    driverResponse.awaiting_driver_action ??
+      (notificationSent && (!acknowledged || !uploadsComplete))
+  );
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
@@ -192,6 +217,84 @@ export default function IncidentDetailClient() {
             onDownload={handleDownload}
             exporting={exporting}
           />
+        </div>
+
+        {/* ── Panel D: Driver Response ───────────────────────────── */}
+        <div className="rounded-lg border bg-white p-6 shadow dark:bg-gray-800">
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-500">
+            D) Driver response
+          </h2>
+          <div className="mb-4 flex flex-wrap gap-2">
+            <span
+              className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                waitingOnDriver
+                  ? "bg-yellow-100 text-yellow-800"
+                  : "bg-green-100 text-green-800"
+              }`}
+            >
+              {waitingOnDriver
+                ? "Waiting on driver action"
+                : "Driver response complete"}
+            </span>
+          </div>
+          <ul className="space-y-3 text-sm text-gray-700 dark:text-gray-200">
+            <li className="flex items-center justify-between gap-2 rounded-md border px-3 py-2">
+              <span>Notification sent</span>
+              <span className={notificationSent ? "text-green-700" : "text-gray-500"}>
+                {notificationSent
+                  ? formatTime(driverResponse.notification_sent_at_utc)
+                  : "Pending"}
+              </span>
+            </li>
+            <li className="flex items-center justify-between gap-2 rounded-md border px-3 py-2">
+              <span>Acknowledged</span>
+              <span className={acknowledged ? "text-green-700" : "text-gray-500"}>
+                {acknowledged ? formatTime(driverResponse.acknowledged_at_utc) : "Pending"}
+              </span>
+            </li>
+            <li className="flex items-center justify-between gap-2 rounded-md border px-3 py-2">
+              <span>Uploads complete</span>
+              <span className={uploadsComplete ? "text-green-700" : "text-gray-500"}>
+                {uploadsComplete
+                  ? formatTime(driverResponse.uploads_completed_at_utc)
+                  : "Pending"}
+              </span>
+            </li>
+          </ul>
+
+          {protocolSummary && (
+            <div className="mt-6 rounded-md border bg-gray-50 p-4 dark:bg-gray-900/40">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Driver protocol configuration
+              </h3>
+              <dl className="mt-3 grid gap-2 text-sm sm:grid-cols-2">
+                <div>
+                  <dt className="text-gray-500">Instruction source</dt>
+                  <dd className="font-medium capitalize text-gray-800 dark:text-gray-200">
+                    {protocolSummary.instruction_source ?? "Default"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500">Acknowledgment required</dt>
+                  <dd className="font-medium text-gray-800 dark:text-gray-200">
+                    {protocolSummary.require_ack ? "Yes" : "No"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500">SMS notifications</dt>
+                  <dd className="font-medium text-gray-800 dark:text-gray-200">
+                    {protocolSummary.sms_enabled ? "Enabled" : "Disabled"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500">Voice notifications</dt>
+                  <dd className="font-medium text-gray-800 dark:text-gray-200">
+                    {protocolSummary.voice_enabled ? "Enabled" : "Disabled"}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          )}
         </div>
       </main>
     </div>

--- a/frontend/app/incidents/page.tsx
+++ b/frontend/app/incidents/page.tsx
@@ -18,6 +18,7 @@ export default function IncidentsPage() {
   const [incidents, setIncidents] = useState<Incident[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [filter, setFilter] = useState<"all" | "waiting_driver" | "ready">("all");
 
   useEffect(() => {
     // Fetch the list of incidents once the user is available.
@@ -53,6 +54,25 @@ export default function IncidentsPage() {
     });
   }
 
+  function isWaitingOnDriver(incident: Incident): boolean {
+    const driverResponse = incident.driver_response;
+    if (typeof driverResponse?.awaiting_driver_action === "boolean") {
+      return driverResponse.awaiting_driver_action;
+    }
+    const notificationSent = Boolean(driverResponse?.notification_sent_at_utc);
+    if (!notificationSent) return false;
+    const acknowledged = Boolean(driverResponse?.acknowledged_at_utc);
+    const uploadsComplete = Boolean(driverResponse?.uploads_complete);
+    return !acknowledged || !uploadsComplete;
+  }
+
+  const waitingCount = incidents.filter(isWaitingOnDriver).length;
+  const visibleIncidents = incidents.filter((incident) => {
+    if (filter === "waiting_driver") return isWaitingOnDriver(incident);
+    if (filter === "ready") return !isWaitingOnDriver(incident);
+    return true;
+  });
+
   return (
     <MainLayout title="Incidents">
       {/* Page header */}
@@ -61,6 +81,38 @@ export default function IncidentsPage() {
         <p className="text-sm text-gray-600 dark:text-gray-400">
           View and manage all recorded incidents.  Monitor evidence capture and export status.
         </p>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <button
+            onClick={() => setFilter("all")}
+            className={`rounded-full px-3 py-1 text-xs font-medium ${
+              filter === "all"
+                ? "bg-blue-600 text-white"
+                : "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300"
+            }`}
+          >
+            All ({incidents.length})
+          </button>
+          <button
+            onClick={() => setFilter("waiting_driver")}
+            className={`rounded-full px-3 py-1 text-xs font-medium ${
+              filter === "waiting_driver"
+                ? "bg-yellow-500 text-white"
+                : "bg-yellow-100 text-yellow-800"
+            }`}
+          >
+            Waiting on driver ({waitingCount})
+          </button>
+          <button
+            onClick={() => setFilter("ready")}
+            className={`rounded-full px-3 py-1 text-xs font-medium ${
+              filter === "ready"
+                ? "bg-green-600 text-white"
+                : "bg-green-100 text-green-800"
+            }`}
+          >
+            Driver action complete ({incidents.length - waitingCount})
+          </button>
+        </div>
       </div>
 
       {/* Loading and error states */}
@@ -71,9 +123,12 @@ export default function IncidentsPage() {
       {!loading && incidents.length === 0 && (
         <p className="text-gray-500">No incidents found.</p>
       )}
+      {!loading && incidents.length > 0 && visibleIncidents.length === 0 && (
+        <p className="text-gray-500">No incidents match the selected filter.</p>
+      )}
 
       {/* Incident table */}
-      {!loading && incidents.length > 0 && (
+      {!loading && visibleIncidents.length > 0 && (
         <div className="overflow-hidden rounded-lg border bg-white shadow dark:border-gray-700 dark:bg-gray-800">
           <table className="w-full text-left text-sm">
             <thead className="bg-gray-50 dark:bg-gray-700">
@@ -86,10 +141,11 @@ export default function IncidentsPage() {
               </tr>
             </thead>
             <tbody className="divide-y dark:divide-gray-700">
-              {incidents.map((inc) => {
+              {visibleIncidents.map((inc) => {
                 const captured = inc.evidence_captured ?? 0;
                 const total = inc.evidence_total ?? 0;
                 const pct = total > 0 ? Math.round((captured / total) * 100) : 0;
+                const waitingOnDriver = isWaitingOnDriver(inc);
                 return (
                   <tr
                     key={inc.incident_id}
@@ -110,13 +166,20 @@ export default function IncidentsPage() {
                       {inc.adc_vehicle_id ?? "—"}
                     </td>
                     <td className="px-4 py-3">
-                      <span
-                        className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${statusColor(
-                          inc.status
-                        )}`}
-                      >
-                        {friendlyStatus(inc.status)}
-                      </span>
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        <span
+                          className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${statusColor(
+                            inc.status
+                          )}`}
+                        >
+                          {friendlyStatus(inc.status)}
+                        </span>
+                        {waitingOnDriver && (
+                          <span className="inline-block rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800">
+                            Waiting on driver
+                          </span>
+                        )}
+                      </div>
                     </td>
                     <td className="px-4 py-3">
                       <div className="flex items-center gap-2">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -122,6 +122,24 @@ export interface Incident {
   created_at_utc?: string;
   evidence_captured?: number;
   evidence_total?: number;
+  driver_response?: DriverResponseSummary | null;
+  driver_protocol_summary?: DriverProtocolSummary | null;
+}
+
+export interface DriverResponseSummary {
+  notification_sent_at_utc?: string | null;
+  acknowledged_at_utc?: string | null;
+  uploads_complete?: boolean;
+  uploads_completed_at_utc?: string | null;
+  awaiting_driver_action?: boolean;
+}
+
+export interface DriverProtocolSummary {
+  instruction_source?: string;
+  require_ack?: boolean;
+  sms_enabled?: boolean;
+  voice_enabled?: boolean;
+  safety_manager_phone?: string | null;
 }
 
 export interface ArtifactSummary {


### PR DESCRIPTION
### Motivation

- Surface driver workflow state (notification, acknowledgement, uploads) on incident pages so investigators can see whether incidents are awaiting driver action. 
- Reuse existing admin driver-protocol settings to provide context for driver behavior and make protocol configuration visible in incident UI.

### Description

- Extended the incidents API typings in `frontend/lib/api.ts` with `DriverResponseSummary` and `DriverProtocolSummary` and added optional `driver_response` and `driver_protocol_summary` fields on `Incident` so incident screens can consume driver workflow payloads. 
- Added a new "D) Driver response" panel to `frontend/app/incidents/[id]/IncidentDetailClient.tsx` showing notification sent time, acknowledgement time, uploads-complete status/time, an overall badge for "Waiting on driver action" vs "Driver response complete", and a read-only driver protocol configuration summary (falls back to `getDriverProtocolSettings()` when incident-level protocol summary is absent). 
- Added list-level filters and badges to `frontend/app/incidents/page.tsx` to surface incidents waiting on driver action (filters: All / Waiting on driver / Driver action complete) and a per-row "Waiting on driver" badge in the Status column; waiting logic uses `awaiting_driver_action` when present, otherwise derives state from notification/ack/uploads fields. 
- Minor UI/UX: status badges and counts were added; the incident detail uses the admin settings API (`getDriverProtocolSettings()`) as a fallback for protocol context.

### Testing

- Ran lint: `cd frontend && npm run lint`; command completed and reported a single pre-existing warning in `frontend/app/dashboard/page.tsx` for an unused variable (no new lint errors). 
- Built the frontend: `cd frontend && npm run build`; Next.js production build completed successfully and pages compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd3da447a083219e14719b72292daa)