### PR TITLE
Harden production config validation and startup checks

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,10 +1,13 @@
 """Application configuration."""
 
+from pydantic import model_validator
 from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
+
+    APP_ENV: str = "dev"
 
     DATABASE_URL: str = "postgresql://localhost/adc_mvp"
     REDIS_URL: str = "redis://localhost:6379/0"
@@ -47,6 +50,63 @@ class Settings(BaseSettings):
     JWT_SECRET_KEY: str = "change-me-in-production"
     JWT_ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+
+    @property
+    def is_prod(self) -> bool:
+        return self.APP_ENV == "prod"
+
+    def _prod_validation_errors(self) -> list[str]:
+        errors: list[str] = []
+
+        required_secrets = {
+            "JWT_SECRET_KEY": self.JWT_SECRET_KEY,
+            "OTP_HASH_PEPPER": self.OTP_HASH_PEPPER,
+            "DATABASE_URL": self.DATABASE_URL,
+        }
+        insecure_defaults = {
+            "JWT_SECRET_KEY": "change-me-in-production",
+            "OTP_HASH_PEPPER": "change-me-in-production",
+            "DATABASE_URL": "postgresql://localhost/adc_mvp",
+        }
+
+        for key, value in required_secrets.items():
+            normalized = value.strip()
+            if not normalized:
+                errors.append(f"{key} must be set in prod")
+                continue
+            if normalized == insecure_defaults[key]:
+                errors.append(f"{key} cannot use development default in prod")
+
+        if not self.COOKIE_SECURE:
+            errors.append("COOKIE_SECURE must be true in prod")
+
+        for key, value in (
+            ("FRONTEND_ORIGIN", self.FRONTEND_ORIGIN),
+            ("PUBLIC_APP_BASE_URL", self.PUBLIC_APP_BASE_URL),
+        ):
+            if value.strip().lower().startswith("http://localhost"):
+                errors.append(f"{key} cannot point to localhost over http in prod")
+
+        return errors
+
+    def validate_production_invariants(self) -> None:
+        """Raise if production configuration invariants are violated."""
+
+        if not self.is_prod:
+            return
+
+        errors = self._prod_validation_errors()
+        if errors:
+            joined = "; ".join(errors)
+            raise ValueError(f"Invalid prod configuration: {joined}")
+
+    @model_validator(mode="after")
+    def validate_environment(self):
+        self.APP_ENV = self.APP_ENV.strip().lower()
+        if self.APP_ENV not in {"dev", "staging", "prod"}:
+            raise ValueError("APP_ENV must be one of: dev, staging, prod")
+
+        return self
 
     class Config:
         env_file = ".env"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,3 +34,10 @@ app.include_router(twilio_router, prefix="/twilio", tags=["twilio"])
 @app.get("/health")
 async def health_check():
     return {"status": "ok"}
+
+
+@app.on_event("startup")
+async def validate_startup_config() -> None:
+    """Fail fast if environment invariants are broken."""
+
+    settings.validate_production_invariants()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,44 @@
+"""Tests for environment configuration validation."""
+
+import pytest
+
+from app.core.config import Settings
+
+
+class TestSettingsValidation:
+    def test_prod_requires_non_default_secrets(self):
+        settings = Settings(
+            APP_ENV="prod",
+            JWT_SECRET_KEY="change-me-in-production",
+            OTP_HASH_PEPPER="change-me-in-production",
+            DATABASE_URL="postgresql://localhost/adc_mvp",
+            COOKIE_SECURE=True,
+            FRONTEND_ORIGIN="https://app.example.com",
+            PUBLIC_APP_BASE_URL="https://app.example.com",
+        )
+
+        with pytest.raises(ValueError, match="Invalid prod configuration"):
+            settings.validate_production_invariants()
+
+    def test_prod_rejects_insecure_cookie_and_localhost_urls(self):
+        settings = Settings(
+            APP_ENV="prod",
+            JWT_SECRET_KEY="super-secret",
+            OTP_HASH_PEPPER="pepper-secret",
+            DATABASE_URL="postgresql://db.example.com/adc",
+            COOKIE_SECURE=False,
+            FRONTEND_ORIGIN="http://localhost:3000",
+            PUBLIC_APP_BASE_URL="http://localhost:3000",
+        )
+
+        with pytest.raises(ValueError, match="COOKIE_SECURE must be true in prod"):
+            settings.validate_production_invariants()
+
+    def test_non_prod_allows_local_defaults(self):
+        settings = Settings(APP_ENV="dev")
+
+        settings.validate_production_invariants()
+
+    def test_invalid_app_env_fails(self):
+        with pytest.raises(ValueError, match="APP_ENV must be one of"):
+            Settings(APP_ENV="production")


### PR DESCRIPTION
### Motivation
- Ensure the app cannot start in production with insecure or default secrets and insecure cookie/CORS settings.
- Make environment mode explicit via `APP_ENV` and validate it to avoid ambiguous behavior across dev/staging/prod.
- Fail fast at startup when production invariants are violated so misconfiguration is detected early.

### Description
- Add `APP_ENV` setting and an `@model_validator(mode="after")` to normalize and validate allowed values (`dev`, `staging`, `prod`) in `backend/app/core/config.py`.
- Implement `validate_production_invariants()` with `_prod_validation_errors()` to require non-empty/non-default `JWT_SECRET_KEY`, `OTP_HASH_PEPPER`, and `DATABASE_URL`, require `COOKIE_SECURE=True`, and reject `FRONTEND_ORIGIN` / `PUBLIC_APP_BASE_URL` values that start with `http://localhost` when `APP_ENV` is `prod` in `backend/app/core/config.py`.
- Wire a FastAPI startup check that calls `settings.validate_production_invariants()` in `backend/app/main.py` to refuse boot when production invariants fail.
- Add unit tests in `backend/tests/test_config.py` covering prod secret/default rejection, localhost URL rejection and cookie requirement in prod, permissive non-prod behavior, and invalid `APP_ENV` handling.

### Testing
- Ran linter checks with `cd backend && ruff check app tests` and they passed.
- Ran the backend test suite with `cd backend && pytest tests/ -v` and all tests passed (`242 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d13e2532188321a6969cb9488068d4)