### PR TITLE
Refactor frontend auth to cookie-based sessions

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -11,15 +11,10 @@ async function request<T>(
   path: string,
   init?: RequestInit
 ): Promise<T> {
-  const token =
-    typeof window !== "undefined" ? localStorage.getItem("token") : null;
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     ...(init?.headers as Record<string, string>),
   };
-  if (token) {
-    headers["Authorization"] = `Bearer ${token}`;
-  }
 
   const res = await fetch(`${API_BASE}${path}`, {
     ...init,
@@ -28,8 +23,8 @@ async function request<T>(
   });
 
   if (res.status === 401) {
-    if (typeof window !== "undefined") {
-      localStorage.removeItem("token");
+    const isAuthMutation = path === "/auth/login" || path === "/auth/register";
+    if (typeof window !== "undefined" && !isAuthMutation) {
       window.location.href = "/login";
     }
     throw new Error("Unauthorized");
@@ -40,32 +35,38 @@ async function request<T>(
     throw new Error(body.detail ?? res.statusText);
   }
 
-  return res.json() as Promise<T>;
+  if (res.status === 204) {
+    return undefined as T;
+  }
+
+  const contentType = res.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    return res.json() as Promise<T>;
+  }
+  return undefined as T;
 }
 
 /* ── Auth ──────────────────────────────────────────────────────── */
 
 export interface LoginResponse {
-  access_token: string;
-  token_type: string;
-  role: string;
+  user: MeResponse;
 }
 
 export async function login(email: string, password: string) {
-  const data = await request<LoginResponse>("/auth/login", {
+  await request<void>("/auth/login", {
     method: "POST",
     body: JSON.stringify({ email, password }),
   });
-  localStorage.setItem("token", data.access_token);
-  return data;
+  const user = await getMe();
+  return { user } satisfies LoginResponse;
 }
 
 export interface RegisterResponse {
+  user: MeResponse;
   user_id: string;
   email: string;
   role: string;
   org_id: string;
-  access_token: string;
 }
 
 export async function register(
@@ -78,25 +79,18 @@ export async function register(
     method: "POST",
     body: JSON.stringify({ email, password, role, org_name: orgName }),
   });
-  localStorage.setItem("token", data.access_token);
-  return data;
+  const user = await getMe();
+  return { ...data, user };
 }
 
 export function logout() {
-  const token = localStorage.getItem("token");
-  if (token) {
-    // Fire-and-forget; clear local state regardless
-    fetch(`${API_BASE}/auth/logout`, {
-      method: "POST",
-      credentials: "include",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-    }).catch(() => {});
-  }
-  localStorage.removeItem("token");
-  window.location.href = "/login";
+  return request<void>("/auth/logout", {
+    method: "POST",
+  }).finally(() => {
+    if (typeof window !== "undefined") {
+      window.location.href = "/login";
+    }
+  });
 }
 
 export interface MeResponse {

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,30 +1,24 @@
-/** Token handling utilities for authentication. */
+/** Session utilities for httpOnly-cookie authentication. */
 
-const TOKEN_KEY = "token";
+import { getMe } from "@/lib/api";
 
-/** Store a JWT token in localStorage. */
-export function setToken(token: string): void {
-  if (typeof window !== "undefined") {
-    localStorage.setItem(TOKEN_KEY, token);
+/**
+ * Validate whether the current browser has a server-side authenticated session.
+ * This relies on httpOnly cookies and never checks client-side token storage.
+ */
+export async function isAuthenticated(): Promise<boolean> {
+  try {
+    await getMe();
+    return true;
+  } catch {
+    return false;
   }
 }
 
-/** Retrieve the stored JWT token, or null if absent. */
-export function getToken(): string | null {
-  if (typeof window !== "undefined") {
-    return localStorage.getItem(TOKEN_KEY);
-  }
-  return null;
-}
-
-/** Remove the stored JWT token. */
-export function clearToken(): void {
-  if (typeof window !== "undefined") {
-    localStorage.removeItem(TOKEN_KEY);
-  }
-}
-
-/** Check whether a token is currently stored. */
-export function isAuthenticated(): boolean {
-  return getToken() !== null;
+/**
+ * Clear any in-memory auth state.
+ * Cookie clearing must be performed by the backend via /auth/logout.
+ */
+export function clearClientAuthState(): void {
+  // Intentionally empty: no persistent client-side auth token is stored.
 }

--- a/frontend/lib/useAuth.ts
+++ b/frontend/lib/useAuth.ts
@@ -6,7 +6,7 @@ import { getMe, type MeResponse } from "@/lib/api";
 
 /**
  * Hook that validates the current session by calling /auth/me.
- * Redirects to /login if the token is missing or invalid.
+ * Redirects to /login when the server-side session is missing or invalid.
  */
 export function useAuth() {
   const router = useRouter();
@@ -14,18 +14,9 @@ export function useAuth() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const token = localStorage.getItem("token");
-    if (!token) {
-      router.replace("/login");
-      return;
-    }
-
     getMe()
       .then(setUser)
-      .catch(() => {
-        localStorage.removeItem("token");
-        router.replace("/login");
-      })
+      .catch(() => router.replace("/login"))
       .finally(() => setLoading(false));
   }, [router]);
 


### PR DESCRIPTION
### Motivation
- Move away from storing bearer tokens in `localStorage` and adopt secure httpOnly cookie sessions for authentication.
- Ensure frontend always sends credentials (`credentials: "include"`) and validates sessions via `/auth/me` rather than client-side token presence.
- Make logout a server-side cookie-clear operation while only updating client-side navigation/state.

### Description
- Removed client-side `localStorage` token handling and helper setters/getters and replaced with `isAuthenticated()` that validates the server-side session via `getMe()` in `frontend/lib/auth.ts`.
- Updated `frontend/lib/api.ts` to stop attaching `Authorization: Bearer` headers from browser storage, preserve `credentials: "include"`, handle `401` by redirecting (except during auth mutation requests), and return `undefined` for `204` or non-JSON responses; also changed auth typings so `login`/`register` return session user data fetched from `/auth/me` rather than saving an `access_token`.
- Reworked `logout()` to call `/auth/logout` (server-side cookie clearing) and then perform client-side redirect, without removing any local token.
- Simplified `useAuth` hook in `frontend/lib/useAuth.ts` so it validates sessions solely via `/auth/me` and no longer inspects local token presence.

### Testing
- Ran `npm run lint` in `frontend`, which completed successfully but reported a pre-existing warning in `frontend/components/marketing/Hero.tsx` about an unused variable.
- Ran `npx tsc --noEmit` in `frontend`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1417f1bb08321b4c7a06f80586e58)