### PR TITLE
Use Redis-backed OTP rate limiting for driver auth endpoints

### DIFF
--- a/backend/app/api/routes_driver_auth.py
+++ b/backend/app/api/routes_driver_auth.py
@@ -3,10 +3,10 @@
 import hashlib
 import hmac
 import logging
-import threading
 import time
 from datetime import datetime, timezone
 
+import redis
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
@@ -34,9 +34,37 @@ router = APIRouter()
 _REQUEST_LIMIT = settings.OTP_REQUEST_RATE_LIMIT
 _VERIFY_LIMIT = settings.OTP_VERIFY_RATE_LIMIT
 _RATE_LIMIT_WINDOW_SECONDS = settings.OTP_RATE_LIMIT_WINDOW_SECONDS
-_rate_limit_lock = threading.Lock()
-_request_timestamps: dict[str, list[float]] = {}
-_verify_timestamps: dict[str, list[float]] = {}
+
+_RATE_LIMIT_SCRIPT = """
+local key = KEYS[1]
+local now_ms = tonumber(ARGV[1])
+local window_ms = tonumber(ARGV[2])
+local max_calls = tonumber(ARGV[3])
+
+redis.call('ZREMRANGEBYSCORE', key, 0, now_ms - window_ms)
+local current = redis.call('ZCARD', key)
+if current >= max_calls then
+    local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+    local retry_after = 1
+    if oldest[2] then
+        retry_after = math.ceil((tonumber(oldest[2]) + window_ms - now_ms) / 1000)
+        if retry_after < 1 then
+            retry_after = 1
+        end
+    end
+    return {0, retry_after}
+end
+
+local request_id = tostring(now_ms) .. '-' .. tostring(redis.call('INCR', key .. ':seq'))
+redis.call('ZADD', key, now_ms, request_id)
+local ttl_seconds = math.ceil(window_ms / 1000)
+redis.call('EXPIRE', key, ttl_seconds)
+redis.call('EXPIRE', key .. ':seq', ttl_seconds)
+return {1, 0}
+"""
+
+_rate_limit_script_sha: str | None = None
+_redis_client: redis.Redis | None = None
 
 
 def _phone_hash(phone_e164: str) -> str:
@@ -48,24 +76,44 @@ def _phone_hash(phone_e164: str) -> str:
     ).hexdigest()
 
 
-def _enforce_rate_limit(
-    bucket: dict[str, list[float]],
-    key: str,
-    max_calls: int,
-):
-    now = time.time()
-    window_start = now - _RATE_LIMIT_WINDOW_SECONDS
-    with _rate_limit_lock:
-        calls = [ts for ts in bucket.get(key, []) if ts >= window_start]
-        if len(calls) >= max_calls:
-            retry_after = max(1, int(calls[0] + _RATE_LIMIT_WINDOW_SECONDS - now))
-            raise HTTPException(
-                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                detail="Too many OTP attempts. Please retry later.",
-                headers={"Retry-After": str(retry_after)},
-            )
-        calls.append(now)
-        bucket[key] = calls
+def _get_redis_client() -> redis.Redis:
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = redis.Redis.from_url(settings.REDIS_URL, decode_responses=False)
+    return _redis_client
+
+
+def _rate_limit_redis_key(bucket_name: str, phone_e164: str) -> str:
+    return f"otp:ratelimit:{bucket_name}:{_phone_hash(phone_e164)}:{_RATE_LIMIT_WINDOW_SECONDS}s"
+
+
+def _run_rate_limit_script(redis_client: redis.Redis, redis_key: str, max_calls: int):
+    global _rate_limit_script_sha
+    now_ms = int(time.time() * 1000)
+    window_ms = _RATE_LIMIT_WINDOW_SECONDS * 1000
+    args = [now_ms, window_ms, max_calls]
+    if _rate_limit_script_sha is None:
+        _rate_limit_script_sha = redis_client.script_load(_RATE_LIMIT_SCRIPT)
+    try:
+        return redis_client.evalsha(_rate_limit_script_sha, 1, redis_key, *args)
+    except redis.exceptions.NoScriptError:
+        _rate_limit_script_sha = redis_client.script_load(_RATE_LIMIT_SCRIPT)
+        return redis_client.evalsha(_rate_limit_script_sha, 1, redis_key, *args)
+
+
+def _enforce_rate_limit(bucket_name: str, phone_e164: str, max_calls: int):
+    redis_client = _get_redis_client()
+    allowed, retry_after = _run_rate_limit_script(
+        redis_client,
+        _rate_limit_redis_key(bucket_name, phone_e164),
+        max_calls,
+    )
+    if int(allowed) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many OTP attempts. Please retry later.",
+            headers={"Retry-After": str(int(retry_after))},
+        )
 
 
 # ── POST /driver/auth/request-otp ──────────────────────────────────
@@ -85,7 +133,7 @@ def request_otp(body: DriverOtpRequest, db: Session = Depends(get_db)):
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Invalid phone number",
         )
-    _enforce_rate_limit(_request_timestamps, _phone_hash(phone_e164), _REQUEST_LIMIT)
+    _enforce_rate_limit("request", phone_e164, _REQUEST_LIMIT)
 
     # Try to start Twilio verification; fall back gracefully
     twilio_sid: str | None = None
@@ -122,7 +170,7 @@ def verify_otp(body: DriverOtpVerifyRequest, db: Session = Depends(get_db)):
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Invalid phone number",
         )
-    _enforce_rate_limit(_verify_timestamps, _phone_hash(phone_e164), _VERIFY_LIMIT)
+    _enforce_rate_limit("verify", phone_e164, _VERIFY_LIMIT)
 
     # Find the latest challenge for this phone, then branch by challenge status.
     challenge = get_latest_otp_challenge_by_phone(db, phone_e164)

--- a/backend/tests/helpers/__init__.py
+++ b/backend/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Test helper package."""

--- a/backend/tests/helpers/fake_redis.py
+++ b/backend/tests/helpers/fake_redis.py
@@ -1,0 +1,51 @@
+"""Test doubles for Redis-backed rate limiting."""
+
+import threading
+import time
+
+
+class FakeRedisRateLimiter:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._zsets: dict[str, list[tuple[int, str]]] = {}
+        self._seq: dict[str, int] = {}
+        self._expires_at: dict[str, float] = {}
+
+    def script_load(self, _script: str) -> str:
+        return "fake-rate-limit-script"
+
+    def evalsha(self, _sha: str, numkeys: int, redis_key: str, *args):
+        assert numkeys == 1
+        now_ms = int(args[0])
+        window_ms = int(args[1])
+        max_calls = int(args[2])
+        with self._lock:
+            self._purge_expired()
+            calls = [
+                (score, member)
+                for score, member in self._zsets.get(redis_key, [])
+                if score > now_ms - window_ms
+            ]
+            self._zsets[redis_key] = calls
+            if len(calls) >= max_calls:
+                retry_after = max(1, ((calls[0][0] + window_ms - now_ms + 999) // 1000))
+                return [0, retry_after]
+
+            seq_key = f"{redis_key}:seq"
+            seq = self._seq.get(seq_key, 0) + 1
+            self._seq[seq_key] = seq
+            calls.append((now_ms, f"{now_ms}-{seq}"))
+            self._zsets[redis_key] = calls
+            ttl_seconds = (window_ms + 999) // 1000
+            expires_at = time.time() + ttl_seconds
+            self._expires_at[redis_key] = expires_at
+            self._expires_at[seq_key] = expires_at
+            return [1, 0]
+
+    def _purge_expired(self):
+        now = time.time()
+        for key, expires_at in list(self._expires_at.items()):
+            if expires_at <= now:
+                self._expires_at.pop(key, None)
+                self._zsets.pop(key, None)
+                self._seq.pop(key, None)

--- a/backend/tests/test_driver_auth_endpoints.py
+++ b/backend/tests/test_driver_auth_endpoints.py
@@ -1,5 +1,4 @@
 """Tests for driver auth OTP endpoints."""
-
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
@@ -13,6 +12,7 @@ from app.api import routes_driver_auth
 from app.db.models import Base, Driver, Org, OtpChallenge
 from app.db.session import get_db
 from app.main import app
+from tests.helpers.fake_redis import FakeRedisRateLimiter
 
 
 @pytest.fixture()
@@ -64,11 +64,11 @@ def driver(db_session):
 
 @pytest.fixture(autouse=True)
 def reset_rate_limits():
-    routes_driver_auth._request_timestamps.clear()
-    routes_driver_auth._verify_timestamps.clear()
+    routes_driver_auth._redis_client = FakeRedisRateLimiter()
+    routes_driver_auth._rate_limit_script_sha = None
     yield
-    routes_driver_auth._request_timestamps.clear()
-    routes_driver_auth._verify_timestamps.clear()
+    routes_driver_auth._redis_client = None
+    routes_driver_auth._rate_limit_script_sha = None
 
 
 def test_driver_otp_flow(client, db_session, driver):

--- a/backend/tests/test_driver_auth_rate_limit_redis.py
+++ b/backend/tests/test_driver_auth_rate_limit_redis.py
@@ -1,0 +1,75 @@
+"""Redis-backed OTP rate-limiting behavior tests."""
+
+from concurrent.futures import ThreadPoolExecutor
+
+from fastapi import HTTPException
+import pytest
+
+from app.api import routes_driver_auth
+from tests.helpers.fake_redis import FakeRedisRateLimiter
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limit_state():
+    routes_driver_auth._redis_client = None
+    routes_driver_auth._rate_limit_script_sha = None
+    yield
+    routes_driver_auth._redis_client = None
+    routes_driver_auth._rate_limit_script_sha = None
+
+
+def test_rate_limit_blocks_concurrent_requests():
+    fake_redis = FakeRedisRateLimiter()
+    routes_driver_auth._redis_client = fake_redis
+    routes_driver_auth._rate_limit_script_sha = None
+    phone = "+15550001234"
+
+    def _attempt():
+        try:
+            routes_driver_auth._enforce_rate_limit(
+                "request",
+                phone,
+                routes_driver_auth._REQUEST_LIMIT,
+            )
+            return True
+        except HTTPException:
+            return False
+
+    with ThreadPoolExecutor(max_workers=12) as pool:
+        results = list(pool.map(lambda _i: _attempt(), range(12)))
+
+    assert sum(results) == routes_driver_auth._REQUEST_LIMIT
+
+
+def test_rate_limit_state_shared_across_instances():
+    shared_fake_redis = FakeRedisRateLimiter()
+    phone = "+15559990000"
+
+    routes_driver_auth._redis_client = shared_fake_redis
+    routes_driver_auth._rate_limit_script_sha = None
+    for _ in range(routes_driver_auth._REQUEST_LIMIT - 1):
+        routes_driver_auth._enforce_rate_limit(
+            "request",
+            phone,
+            routes_driver_auth._REQUEST_LIMIT,
+        )
+
+    routes_driver_auth._redis_client = shared_fake_redis
+    routes_driver_auth._rate_limit_script_sha = None
+    routes_driver_auth._enforce_rate_limit(
+        "request",
+        phone,
+        routes_driver_auth._REQUEST_LIMIT,
+    )
+
+    blocked = False
+    try:
+        routes_driver_auth._enforce_rate_limit(
+            "request",
+            phone,
+            routes_driver_auth._REQUEST_LIMIT,
+        )
+    except HTTPException:
+        blocked = True
+
+    assert blocked is True


### PR DESCRIPTION
### Motivation
- Replace in-process, module-level rate-limit state so OTP limits work correctly when multiple app instances are running. 
- Implement an atomic, windowed rate-limiter to avoid race conditions and make enforcement consistent across processes. 
- Add deterministic tests that exercise concurrent and multi-instance behavior without requiring a live Redis server.

### Description
- Replaced module-level dictionaries and thread lock with a Redis-backed sliding-window limiter implemented as a Lua script using `ZREMRANGEBYSCORE`/`ZCARD`/`ZADD` plus a per-key sequence and TTL, and added SHA caching with `NOSCRIPT` fallback. (`backend/app/api/routes_driver_auth.py`).
- Added `_get_redis_client`, `_rate_limit_redis_key`, `_run_rate_limit_script`, and updated `_enforce_rate_limit` to use Redis; endpoints now call `_enforce_rate_limit(bucket_name, phone, limit)` with `request`/`verify` buckets. (`backend/app/api/routes_driver_auth.py`).
- Added a thread-safe test double `FakeRedisRateLimiter` that models the Lua script and TTL behavior for deterministic tests. (`backend/tests/helpers/fake_redis.py`).
- Updated existing driver auth tests to use the fake Redis client and reset Redis state between tests. (`backend/tests/test_driver_auth_endpoints.py`).
- Added new tests for concurrent requests and shared-state (multi-instance) behavior using the fake Redis to validate atomic enforcement. (`backend/tests/test_driver_auth_rate_limit_redis.py`).

### Testing
- Ran the relevant test suite with `cd backend && pytest tests/test_driver_auth_endpoints.py tests/test_driver_auth_rate_limit_redis.py -q`, which completed successfully with `9 passed, 1 warning`.
- Ran linter checks with `cd backend && ruff check app/api/routes_driver_auth.py tests/test_driver_auth_endpoints.py tests/test_driver_auth_rate_limit_redis.py tests/helpers/fake_redis.py`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d141b8a21c83219523c88130ccc1f9)