### PR TITLE
Add AWS Secrets Manager support for runtime settings and rotation runbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ adc-mvp/
 ├── contracts/
 │   └── schemas/                       # JSON schemas (single source of truth)
 ├── infra/
-│   └── docker-compose.yml             # Docker Compose stack
+│   ├── docker-compose.yml             # Docker Compose stack
+│   └── production/                    # Production manifests + secret provider refs
 ├── scripts/                           # Utility scripts
 │   ├── create_admin.py                # Create admin user
 │   └── validate_schemas.py            # Validate JSON schemas
@@ -152,6 +153,19 @@ uvicorn app.main:app --reload
 cd backend && pytest tests/ -v
 python scripts/validate_schemas.py
 ```
+
+
+### Production secret-loading
+
+Backend runtime settings can be loaded from AWS Secrets Manager by setting:
+
+- `SECRET_PROVIDER=aws_secrets_manager`
+- `AWS_SECRETS_MANAGER_SECRET_ID=<secret-name>`
+- `AWS_REGION=<region>`
+
+The secret payload should be JSON with setting keys (for example `DATABASE_URL`, `JWT_SECRET_KEY`, `TWILIO_AUTH_TOKEN`).
+
+Reference manifests are in `infra/production/` and use External Secrets to sync secrets from AWS Secrets Manager into Kubernetes.
 
 ### Driver App (Expo)
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,13 +1,79 @@
 """Application configuration."""
 
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import boto3
 from pydantic import model_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+)
+
+
+class AwsSecretsManagerSettingsSource(PydanticBaseSettingsSource):
+    """Load settings from AWS Secrets Manager when enabled."""
+
+    def __init__(self, settings_cls: type[BaseSettings]):
+        super().__init__(settings_cls)
+        self._data = self._load_secret_data()
+
+    def get_field_value(self, field, field_name: str) -> tuple[Any, str, bool]:
+        return self._data.get(field_name), field_name, False
+
+    def __call__(self) -> dict[str, Any]:
+        return self._data
+
+    def _load_secret_data(self) -> dict[str, Any]:
+        provider = os.getenv("SECRET_PROVIDER", "env").strip().lower()
+        if provider != "aws_secrets_manager":
+            return {}
+
+        secret_id = os.getenv("AWS_SECRETS_MANAGER_SECRET_ID", "").strip()
+        if not secret_id:
+            raise ValueError(
+                "AWS_SECRETS_MANAGER_SECRET_ID must be set when "
+                "SECRET_PROVIDER=aws_secrets_manager"
+            )
+
+        region = os.getenv("AWS_SECRETS_MANAGER_REGION") or os.getenv("AWS_REGION") or "us-east-1"
+        version_stage = os.getenv("AWS_SECRETS_MANAGER_VERSION_STAGE", "AWSCURRENT")
+
+        client = boto3.client("secretsmanager", region_name=region)
+        response = client.get_secret_value(SecretId=secret_id, VersionStage=version_stage)
+
+        secret_string = response.get("SecretString", "")
+        if not secret_string:
+            raise ValueError(
+                "AWS Secrets Manager secret must contain SecretString JSON payload"
+            )
+
+        try:
+            decoded = json.loads(secret_string)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                "AWS Secrets Manager secret payload must be valid JSON"
+            ) from exc
+
+        if not isinstance(decoded, dict):
+            raise ValueError("AWS Secrets Manager secret payload must decode to an object")
+
+        return {str(k): v for k, v in decoded.items()}
 
 
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
     APP_ENV: str = "dev"
+
+    # Secret loading strategy
+    SECRET_PROVIDER: str = "env"
+    AWS_SECRETS_MANAGER_SECRET_ID: str = ""
+    AWS_SECRETS_MANAGER_REGION: str = "us-east-1"
+    AWS_SECRETS_MANAGER_VERSION_STAGE: str = "AWSCURRENT"
 
     DATABASE_URL: str = "postgresql://localhost/adc_mvp"
     REDIS_URL: str = "redis://localhost:6379/0"
@@ -50,6 +116,24 @@ class Settings(BaseSettings):
     JWT_SECRET_KEY: str = "change-me-in-production"
     JWT_ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        # Explicit constructor args / env vars always win over remote secrets.
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            AwsSecretsManagerSettingsSource(settings_cls),
+            file_secret_settings,
+        )
 
     @property
     def is_prod(self) -> bool:
@@ -105,6 +189,10 @@ class Settings(BaseSettings):
         self.APP_ENV = self.APP_ENV.strip().lower()
         if self.APP_ENV not in {"dev", "staging", "prod"}:
             raise ValueError("APP_ENV must be one of: dev, staging, prod")
+
+        self.SECRET_PROVIDER = self.SECRET_PROVIDER.strip().lower()
+        if self.SECRET_PROVIDER not in {"env", "aws_secrets_manager"}:
+            raise ValueError("SECRET_PROVIDER must be one of: env, aws_secrets_manager")
 
         return self
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,5 +1,7 @@
 """Tests for environment configuration validation."""
 
+import json
+
 import pytest
 
 from app.core.config import Settings
@@ -42,3 +44,70 @@ class TestSettingsValidation:
     def test_invalid_app_env_fails(self):
         with pytest.raises(ValueError, match="APP_ENV must be one of"):
             Settings(APP_ENV="production")
+
+    def test_invalid_secret_provider_fails(self):
+        with pytest.raises(ValueError, match="SECRET_PROVIDER must be one of"):
+            Settings(SECRET_PROVIDER="vault")
+
+
+class TestAwsSecretsManagerSource:
+    def test_loads_runtime_settings_from_aws_secrets_manager(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        class FakeSecretsClient:
+            def get_secret_value(self, SecretId: str, VersionStage: str):  # noqa: N803
+                assert SecretId == "adc/runtime"
+                assert VersionStage == "AWSCURRENT"
+                return {
+                    "SecretString": json.dumps(
+                        {
+                            "JWT_SECRET_KEY": "jwt-from-secret",
+                            "DATABASE_URL": "postgresql://prod/db",
+                            "TWILIO_AUTH_TOKEN": "token-from-secret",
+                        }
+                    )
+                }
+
+        monkeypatch.setenv("SECRET_PROVIDER", "aws_secrets_manager")
+        monkeypatch.setenv("AWS_SECRETS_MANAGER_SECRET_ID", "adc/runtime")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+
+        monkeypatch.setattr("app.core.config.boto3.client", lambda *args, **kwargs: FakeSecretsClient())
+
+        settings = Settings()
+
+        assert settings.JWT_SECRET_KEY == "jwt-from-secret"
+        assert settings.DATABASE_URL == "postgresql://prod/db"
+        assert settings.TWILIO_AUTH_TOKEN == "token-from-secret"
+
+    def test_environment_overrides_aws_secret_values(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        class FakeSecretsClient:
+            def get_secret_value(self, SecretId: str, VersionStage: str):  # noqa: N803
+                return {
+                    "SecretString": json.dumps(
+                        {
+                            "JWT_SECRET_KEY": "jwt-from-secret",
+                            "DATABASE_URL": "postgresql://prod/db",
+                        }
+                    )
+                }
+
+        monkeypatch.setenv("SECRET_PROVIDER", "aws_secrets_manager")
+        monkeypatch.setenv("AWS_SECRETS_MANAGER_SECRET_ID", "adc/runtime")
+        monkeypatch.setenv("JWT_SECRET_KEY", "jwt-from-env")
+        monkeypatch.setattr("app.core.config.boto3.client", lambda *args, **kwargs: FakeSecretsClient())
+
+        settings = Settings()
+
+        assert settings.JWT_SECRET_KEY == "jwt-from-env"
+
+    def test_aws_provider_requires_secret_id(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("SECRET_PROVIDER", "aws_secrets_manager")
+        monkeypatch.delenv("AWS_SECRETS_MANAGER_SECRET_ID", raising=False)
+
+        with pytest.raises(ValueError, match="AWS_SECRETS_MANAGER_SECRET_ID"):
+            Settings()

--- a/docs/api-keys-rotation-runbook.md
+++ b/docs/api-keys-rotation-runbook.md
@@ -1,0 +1,26 @@
+# API Keys Rotation Runbook
+
+## Scope
+Rotate provider API keys stored in runtime secrets (for example `SAMSARA_API_KEY`).
+
+## Preconditions
+- Provider console access.
+- Access to AWS Secrets Manager runtime secret.
+- Observability access for provider integration errors.
+
+## Procedure
+1. Create a new key in the provider console.
+2. Update corresponding key in AWS Secrets Manager JSON payload.
+3. Promote new secret version to `AWSCURRENT`.
+4. Restart backend and worker.
+5. Run provider-specific smoke test (e.g., list vehicles/events).
+6. Revoke old provider key only after successful verification.
+
+## Verification
+- API calls authenticate with no `401/403` failures.
+- Background sync/task logs show successful calls.
+
+## Rollback
+1. Move `AWSCURRENT` to prior secret version.
+2. Restart backend and worker.
+3. Re-enable previous provider key if already revoked.

--- a/docs/db-credentials-rotation-runbook.md
+++ b/docs/db-credentials-rotation-runbook.md
@@ -1,0 +1,28 @@
+# DB Credentials Rotation Runbook
+
+## Scope
+Rotate `DATABASE_URL` credential for PostgreSQL.
+
+## Preconditions
+- Database admin access.
+- Dual-user or phased password rotation plan.
+- Access to AWS Secrets Manager runtime secret.
+
+## Procedure
+1. Create a new DB credential (new password or new service user).
+2. Validate connectivity from a staging shell/client.
+3. Update `DATABASE_URL` in AWS Secrets Manager JSON.
+4. Promote updated secret version to `AWSCURRENT`.
+5. Roll backend and worker deployments.
+6. Confirm migrations and app queries succeed.
+7. Decommission old DB credential.
+
+## Verification
+- Backend starts without DB auth errors.
+- Read/write smoke tests pass.
+- Worker tasks touching DB complete.
+
+## Rollback
+1. Restore prior `DATABASE_URL` version label.
+2. Restart backend and worker.
+3. Re-enable old DB credential if disabled.

--- a/docs/jwt-key-rotation-runbook.md
+++ b/docs/jwt-key-rotation-runbook.md
@@ -1,0 +1,28 @@
+# JWT Key Rotation Runbook
+
+## Scope
+Rotate `JWT_SECRET_KEY` used by backend token signing/verification.
+
+## Preconditions
+- Access to AWS Secrets Manager secret used by `AWS_SECRETS_MANAGER_SECRET_ID`.
+- Ability to deploy backend + worker.
+- Planned maintenance window (JWT revocation event).
+
+## Procedure
+1. Generate a new random signing key (at least 256 bits).
+2. Update the runtime secret JSON in AWS Secrets Manager:
+   - Replace `JWT_SECRET_KEY`.
+   - Keep other keys unchanged.
+3. Move staging label (`AWSCURRENT` by default) to the new version.
+4. Roll backend and worker deployments so they reload settings.
+5. Invalidate active sessions if policy requires forced re-authentication.
+
+## Verification
+- Confirm `/health` (or app readiness) is green after rollout.
+- Perform login and confirm newly minted JWTs validate.
+- Confirm old JWTs are rejected if forced session invalidation was performed.
+
+## Rollback
+1. Move `AWSCURRENT` back to prior secret version.
+2. Restart backend and worker.
+3. Validate login/token flows.

--- a/docs/twilio-credentials-rotation-runbook.md
+++ b/docs/twilio-credentials-rotation-runbook.md
@@ -1,0 +1,31 @@
+# Twilio Credentials Rotation Runbook
+
+## Scope
+Rotate Twilio keys used by OTP and notifications:
+- `TWILIO_ACCOUNT_SID`
+- `TWILIO_AUTH_TOKEN`
+- `TWILIO_VERIFY_SERVICE_SID`
+- `TWILIO_SMS_FROM`
+- `TWILIO_VOICE_FROM`
+
+## Preconditions
+- Twilio Console admin access.
+- Access to AWS Secrets Manager runtime secret.
+- Ability to restart backend + worker.
+
+## Procedure
+1. In Twilio Console, create/regenerate the new auth token and verify service details.
+2. Update AWS Secrets Manager JSON payload with new Twilio values.
+3. Promote new secret version to `AWSCURRENT`.
+4. Restart backend and worker deployments.
+5. Execute test OTP send + verify flows and notification send task.
+
+## Verification
+- OTP request endpoint succeeds.
+- OTP verification endpoint succeeds.
+- Alert delivery task emits no Twilio auth errors.
+
+## Rollback
+1. Revert Twilio values to previous known-good secret version.
+2. Move `AWSCURRENT` label back.
+3. Restart backend and worker.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -6,19 +6,14 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - DATABASE_URL=postgresql://adc:adc@db:5432/adc_mvp
-      - REDIS_URL=redis://redis:6379/0
-      - JWT_SECRET_KEY=change-me-in-production
+      - APP_ENV=${APP_ENV:-staging}
+      - SECRET_PROVIDER=${SECRET_PROVIDER:-aws_secrets_manager}
+      - AWS_SECRETS_MANAGER_SECRET_ID=${AWS_SECRETS_MANAGER_SECRET_ID:?set by your secret provider}
+      - AWS_SECRETS_MANAGER_VERSION_STAGE=${AWS_SECRETS_MANAGER_VERSION_STAGE:-AWSCURRENT}
+      - AWS_REGION=${AWS_REGION:-us-east-1}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
       - STORAGE_BACKEND=fs
       - VAULT_ROOT=/var/adc/vault
-      - TWILIO_ACCOUNT_SID=${TWILIO_ACCOUNT_SID:-}
-      - TWILIO_AUTH_TOKEN=${TWILIO_AUTH_TOKEN:-}
-      - TWILIO_VERIFY_SERVICE_SID=${TWILIO_VERIFY_SERVICE_SID:-}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
-      - AWS_REGION=${AWS_REGION:-us-east-1}
-      - S3_ARTIFACTS_BUCKET=${S3_ARTIFACTS_BUCKET:-adc-mvp-artifacts}
-      - S3_EXPORTS_BUCKET=${S3_EXPORTS_BUCKET:-adc-mvp-exports}
     volumes:
       - vaultdata:/var/adc/vault
     depends_on:
@@ -29,18 +24,14 @@ services:
     build: ../backend
     command: celery -A app.tasks.celery_app worker --loglevel=info
     environment:
-      - DATABASE_URL=postgresql://adc:adc@db:5432/adc_mvp
-      - REDIS_URL=redis://redis:6379/0
+      - APP_ENV=${APP_ENV:-staging}
+      - SECRET_PROVIDER=${SECRET_PROVIDER:-aws_secrets_manager}
+      - AWS_SECRETS_MANAGER_SECRET_ID=${AWS_SECRETS_MANAGER_SECRET_ID:?set by your secret provider}
+      - AWS_SECRETS_MANAGER_VERSION_STAGE=${AWS_SECRETS_MANAGER_VERSION_STAGE:-AWSCURRENT}
+      - AWS_REGION=${AWS_REGION:-us-east-1}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
       - STORAGE_BACKEND=fs
       - VAULT_ROOT=/var/adc/vault
-      - TWILIO_ACCOUNT_SID=${TWILIO_ACCOUNT_SID:-}
-      - TWILIO_AUTH_TOKEN=${TWILIO_AUTH_TOKEN:-}
-      - TWILIO_VERIFY_SERVICE_SID=${TWILIO_VERIFY_SERVICE_SID:-}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
-      - AWS_REGION=${AWS_REGION:-us-east-1}
-      - S3_ARTIFACTS_BUCKET=${S3_ARTIFACTS_BUCKET:-adc-mvp-artifacts}
-      - S3_EXPORTS_BUCKET=${S3_EXPORTS_BUCKET:-adc-mvp-exports}
     volumes:
       - vaultdata:/var/adc/vault
     depends_on:

--- a/infra/production/backend-deployment.yaml
+++ b/infra/production/backend-deployment.yaml
@@ -1,0 +1,110 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: adc-backend
+  namespace: adc
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: adc-backend
+  template:
+    metadata:
+      labels:
+        app: adc-backend
+    spec:
+      serviceAccountName: adc-backend
+      containers:
+        - name: app
+          image: ghcr.io/your-org/adc-backend:latest
+          ports:
+            - containerPort: 8000
+          env:
+            - name: APP_ENV
+              value: prod
+            - name: SECRET_PROVIDER
+              value: aws_secrets_manager
+            - name: AWS_REGION
+              value: us-east-1
+            - name: AWS_SECRETS_MANAGER_SECRET_ID
+              valueFrom:
+                secretKeyRef:
+                  name: adc-runtime-secret-ref
+                  key: secret_id
+            - name: AWS_SECRETS_MANAGER_VERSION_STAGE
+              valueFrom:
+                secretKeyRef:
+                  name: adc-runtime-secret-ref
+                  key: version_stage
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: adc-runtime-settings
+                  key: REDIS_URL
+            - name: STORAGE_BACKEND
+              value: s3
+            - name: S3_ARTIFACTS_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: adc-runtime-settings
+                  key: S3_ARTIFACTS_BUCKET
+            - name: S3_EXPORTS_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: adc-runtime-settings
+                  key: S3_EXPORTS_BUCKET
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: adc-worker
+  namespace: adc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: adc-worker
+  template:
+    metadata:
+      labels:
+        app: adc-worker
+    spec:
+      serviceAccountName: adc-backend
+      containers:
+        - name: worker
+          image: ghcr.io/your-org/adc-backend:latest
+          command: ["celery", "-A", "app.tasks.celery_app", "worker", "--loglevel=info"]
+          env:
+            - name: APP_ENV
+              value: prod
+            - name: SECRET_PROVIDER
+              value: aws_secrets_manager
+            - name: AWS_REGION
+              value: us-east-1
+            - name: AWS_SECRETS_MANAGER_SECRET_ID
+              valueFrom:
+                secretKeyRef:
+                  name: adc-runtime-secret-ref
+                  key: secret_id
+            - name: AWS_SECRETS_MANAGER_VERSION_STAGE
+              valueFrom:
+                secretKeyRef:
+                  name: adc-runtime-secret-ref
+                  key: version_stage
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: adc-runtime-settings
+                  key: REDIS_URL
+            - name: STORAGE_BACKEND
+              value: s3
+            - name: S3_ARTIFACTS_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: adc-runtime-settings
+                  key: S3_ARTIFACTS_BUCKET
+            - name: S3_EXPORTS_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: adc-runtime-settings
+                  key: S3_EXPORTS_BUCKET

--- a/infra/production/externalsecret.yaml
+++ b/infra/production/externalsecret.yaml
@@ -1,0 +1,42 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: adc-aws-secrets
+  namespace: adc
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: us-east-1
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: adc-backend
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: adc-runtime-settings
+  namespace: adc
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: adc-aws-secrets
+  target:
+    name: adc-runtime-settings
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: adc/prod/runtime-settings
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: adc-runtime-secret-ref
+  namespace: adc
+type: Opaque
+stringData:
+  # This secret only contains an identifier pointer; actual values live in AWS Secrets Manager.
+  secret_id: adc/prod/runtime-settings
+  version_stage: AWSCURRENT


### PR DESCRIPTION
### Motivation

- Support production-safe secret loading for backend runtime settings via a pluggable secret provider (e.g. AWS Secrets Manager) instead of plaintext env defaults.
- Provide operator runbooks for rotating critical credentials (JWT signing key, Twilio, DB, provider API keys).
- Ensure deployment manifests reference secret providers (External Secrets / secret refs) rather than embedding secrets.

### Description

- Implemented an `AwsSecretsManagerSettingsSource` and integrated it into `Settings` in `backend/app/core/config.py`, added `SECRET_PROVIDER` and AWS secret-related fields, ordering so explicit args/env override remote secrets, and validation for `SECRET_PROVIDER`.
- Expanded `backend/tests/test_config.py` to cover AWS Secrets Manager loading, env-over-secret precedence, missing secret id behavior, and invalid provider validation.
- Updated `infra/docker-compose.yml` to emit secret-provider related env wiring (`SECRET_PROVIDER`, `AWS_SECRETS_MANAGER_SECRET_ID`, `AWS_SECRETS_MANAGER_VERSION_STAGE`, `AWS_REGION`) instead of plaintext defaults for sensitive values.
- Added production Kubernetes manifests under `infra/production/` demonstrating External Secrets integration (`externalsecret.yaml`) and deployment wiring that sources runtime values from synced secrets (`backend-deployment.yaml`).
- Added rotation runbooks in `docs/` for `JWT_SECRET_KEY`, Twilio credentials, DB credentials, and provider API keys, and documented production secret-loading expectations in `README.md`.

### Testing

- Ran linter checks (`ruff`) on modified files and they passed (`ruff check` passed).
- Ran unit tests for config and AWS secrets behavior: `pytest backend/tests/test_config.py -v` and all config tests passed.
- Ran full test suite via `make test` and all backend tests passed (`248 passed`), plus schema validation succeeded.
- Ran `make lint` and it completed with all checks passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1c43986a48321bed5646fb5bd9192)