### PR TITLE
Standardize org authorization checks and add cross-org denial coverage

### DIFF
--- a/backend/app/api/routes_admin.py
+++ b/backend/app/api/routes_admin.py
@@ -19,7 +19,10 @@ from app.api.schemas import (
     RotateQrResponse,
 )
 from app.core.config import settings
-from app.core.deps import get_current_user
+from app.core.deps import (
+    get_current_user_org_ids,
+    require_user_role,
+)
 from app.db.models import (
     DriverInstructionSet,
     DriverInstructionStep as DriverInstructionStepModel,
@@ -29,7 +32,6 @@ from app.db.models import (
     VehicleQrToken,
 )
 from app.db.session import get_db
-from app.db.repo.users import get_user_org_ids
 from app.domain.system_event_types import SystemEventType
 
 logger = logging.getLogger(__name__)
@@ -63,20 +65,8 @@ ADMIN_VEHICLES = [
 ]
 
 
-def _require_admin(current_user: User = Depends(get_current_user)) -> User:
-    """Ensure the authenticated user has the admin role."""
-    if current_user.role != "admin":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Admin access required",
-        )
-    return current_user
-
-
-def _get_admin_org(db: Session, admin: User) -> Org:
-    org_ids = get_user_org_ids(db, admin.id)
-    org_id = org_ids[0] if org_ids else None
-    org = db.query(Org).filter(Org.id == org_id).first() if org_id else None
+def _get_admin_org(db: Session, admin_org_id: uuid.UUID) -> Org:
+    org = db.query(Org).filter(Org.id == admin_org_id).first()
     if org is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -151,9 +141,10 @@ def _serialize_instruction_steps(
 )
 def get_driver_protocol_settings(
     db: Session = Depends(get_db),
-    admin: User = Depends(_require_admin),
+    admin_org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
+    admin: User = Depends(require_user_role("admin")),
 ):
-    org = _get_admin_org(db, admin)
+    org = _get_admin_org(db, admin_org_ids[0])
     return DriverProtocolSettingsResponse(
         instruction_source=org.instruction_source,
         require_ack=org.require_driver_ack,
@@ -170,9 +161,10 @@ def get_driver_protocol_settings(
 def update_driver_protocol_settings(
     body: DriverProtocolSettingsRequest,
     db: Session = Depends(get_db),
-    admin: User = Depends(_require_admin),
+    admin_org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
+    admin: User = Depends(require_user_role("admin")),
 ):
-    org = _get_admin_org(db, admin)
+    org = _get_admin_org(db, admin_org_ids[0])
     org.instruction_source = _normalize_instruction_scope(body.instruction_source)
     org.require_driver_ack = body.require_ack
     org.sms_enabled = body.sms_enabled
@@ -195,9 +187,10 @@ def update_driver_protocol_settings(
 def get_driver_protocol_instructions(
     scope: str | None = None,
     db: Session = Depends(get_db),
-    admin: User = Depends(_require_admin),
+    admin_org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
+    admin: User = Depends(require_user_role("admin")),
 ):
-    org = _get_admin_org(db, admin)
+    org = _get_admin_org(db, admin_org_ids[0])
     resolved_scope = _normalize_instruction_scope(scope or org.instruction_source)
     instruction_set = _get_or_create_instruction_set(db, org.id, resolved_scope)
     steps = (
@@ -226,9 +219,10 @@ def get_driver_protocol_instructions(
 def update_driver_protocol_instructions(
     body: DriverInstructionSetRequest,
     db: Session = Depends(get_db),
-    admin: User = Depends(_require_admin),
+    admin_org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
+    admin: User = Depends(require_user_role("admin")),
 ):
-    org = _get_admin_org(db, admin)
+    org = _get_admin_org(db, admin_org_ids[0])
     resolved_scope = _normalize_instruction_scope(body.scope)
     instruction_set = _get_or_create_instruction_set(db, org.id, resolved_scope)
     db.query(DriverInstructionStepModel).filter(
@@ -261,9 +255,10 @@ def update_driver_protocol_instructions(
 def reset_driver_protocol_instructions(
     scope: str | None = None,
     db: Session = Depends(get_db),
-    admin: User = Depends(_require_admin),
+    admin_org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
+    admin: User = Depends(require_user_role("admin")),
 ):
-    org = _get_admin_org(db, admin)
+    org = _get_admin_org(db, admin_org_ids[0])
     resolved_scope = _normalize_instruction_scope(scope or org.instruction_source)
     instruction_set = _get_or_create_instruction_set(db, org.id, resolved_scope)
     db.query(DriverInstructionStepModel).filter(
@@ -280,7 +275,7 @@ def reset_driver_protocol_instructions(
 
 
 @router.get("/vehicles", response_model=list[AdminVehicleSummary])
-def list_admin_vehicles(admin: User = Depends(_require_admin)):
+def list_admin_vehicles(admin: User = Depends(require_user_role("admin"))):
     return [AdminVehicleSummary(**vehicle) for vehicle in ADMIN_VEHICLES]
 
 
@@ -292,7 +287,8 @@ def list_admin_vehicles(admin: User = Depends(_require_admin)):
 def rotate_qr(
     vehicle_id: str,
     db: Session = Depends(get_db),
-    admin: User = Depends(_require_admin),
+    admin_org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
+    admin: User = Depends(require_user_role("admin")),
 ):
     """Revoke the current active QR token for a vehicle and issue a new one."""
     # Revoke existing active token(s)
@@ -301,6 +297,7 @@ def rotate_qr(
         .filter(
             VehicleQrToken.adc_vehicle_id == vehicle_id,
             VehicleQrToken.status == "active",
+            VehicleQrToken.org_id.in_(admin_org_ids),
         )
         .all()
     )
@@ -311,8 +308,7 @@ def rotate_qr(
     new_token = secrets.token_urlsafe(32)
 
     # Determine org_id from the admin's org membership
-    org_ids = get_user_org_ids(db, admin.id)
-    org_id = org_ids[0] if org_ids else None
+    org_id = admin_org_ids[0]
 
     qr = VehicleQrToken(
         qr_token=new_token,
@@ -351,7 +347,7 @@ def rotate_qr(
 @router.get("/vehicles/{vehicle_id}/qr", response_model=QrPayloadResponse)
 def get_qr_payload(
     vehicle_id: str,
-    admin: User = Depends(_require_admin),
+    admin: User = Depends(require_user_role("admin")),
 ):
     """Return the deep link string for QR code generation."""
     scheme = settings.DRIVER_APP_DEEPLINK_SCHEME

--- a/backend/app/api/routes_driver.py
+++ b/backend/app/api/routes_driver.py
@@ -8,7 +8,6 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import desc
 from sqlalchemy.orm import Session
 
@@ -30,7 +29,8 @@ from app.api.schemas import (
     VehicleInfo,
 )
 from app.core.config import settings
-from app.core.security import create_access_token, decode_access_token
+from app.core.deps import get_current_driver
+from app.core.security import create_access_token
 from app.db.models import (
     Driver,
     DriverInstructionSet,
@@ -51,7 +51,6 @@ from app.tasks.notification_tasks import notify_safety_manager
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-_bearer = HTTPBearer(auto_error=False)
 OTP_EXPIRATION_MINUTES = 10
 MAX_OTP_ATTEMPTS = 5
 
@@ -66,54 +65,6 @@ def _hash_otp_code(code: str) -> str:
         code.encode(),
         hashlib.sha256,
     ).hexdigest()
-
-
-def _get_current_driver(
-    creds: HTTPAuthorizationCredentials | None = Depends(_bearer),
-    db: Session = Depends(get_db),
-):
-    """Decode driver JWT and return active driver."""
-    if creds is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Driver not authenticated",
-        )
-
-    payload = decode_access_token(creds.credentials)
-    if payload is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid or expired token",
-        )
-
-    driver_id = payload.get("sub")
-    if driver_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Token missing subject",
-        )
-    try:
-        driver_uuid = uuid.UUID(driver_id)
-    except ValueError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid token subject",
-        ) from exc
-
-    driver = (
-        db.query(Driver)
-        .filter(
-            Driver.driver_id == driver_uuid,
-            Driver.is_active.is_(True),
-        )
-        .first()
-    )
-    if driver is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Driver not found or inactive",
-        )
-    return driver
 
 
 def _get_or_create_default_org(db: Session) -> Org:
@@ -263,7 +214,7 @@ def verify_driver_otp(body: DriverOtpVerifyRequest, db: Session = Depends(get_db
 
 @router.get("/me", response_model=DriverMeResponse)
 def driver_me(
-    driver: Driver = Depends(_get_current_driver),
+    driver: Driver = Depends(get_current_driver),
     db: Session = Depends(get_db),
 ):
     """Return the authenticated driver profile and current vehicle (if any)."""
@@ -295,7 +246,7 @@ def driver_me(
 @router.post("/vehicle/resolve-qr", response_model=ResolveQrResponse)
 def resolve_qr(
     body: ResolveQrRequest,
-    driver: Driver = Depends(_get_current_driver),
+    driver: Driver = Depends(get_current_driver),
     db: Session = Depends(get_db),
 ):
     """Resolve a QR token to a vehicle. Only active tokens are accepted."""
@@ -304,6 +255,7 @@ def resolve_qr(
         .filter(
             VehicleQrToken.qr_token == body.qr_token,
             VehicleQrToken.status == "active",
+            VehicleQrToken.org_id == driver.org_id,
         )
         .first()
     )
@@ -449,7 +401,7 @@ def _evidence_capture_state(events: list, incident_status: str) -> str:
 @router.post("/incidents/initiate", response_model=DriverIncidentInitiateResponse)
 def initiate_incident(
     body: DriverIncidentInitiateRequest,
-    driver: Driver = Depends(_get_current_driver),
+    driver: Driver = Depends(get_current_driver),
     db: Session = Depends(get_db),
 ):
     """Initiate a driver incident protocol and start evidence capture."""
@@ -513,7 +465,7 @@ def initiate_incident(
 
 @router.get("/instructions/active", response_model=DriverInstructionSetResponse)
 def get_active_instructions(
-    driver: Driver = Depends(_get_current_driver),
+    driver: Driver = Depends(get_current_driver),
     db: Session = Depends(get_db),
 ):
     """Return the active instruction set for the driver's org."""
@@ -541,7 +493,7 @@ def get_active_instructions(
 @router.post("/instructions/ack", response_model=DriverInstructionAckResponse)
 def acknowledge_instructions(
     body: DriverInstructionAckRequest,
-    driver: Driver = Depends(_get_current_driver),
+    driver: Driver = Depends(get_current_driver),
     db: Session = Depends(get_db),
 ):
     """Acknowledge the active driver instruction set if required."""
@@ -581,7 +533,7 @@ def acknowledge_instructions(
 )
 def driver_incident_status(
     incident_id: uuid.UUID,
-    driver: Driver = Depends(_get_current_driver),
+    driver: Driver = Depends(get_current_driver),
     db: Session = Depends(get_db),
 ):
     """Return status and evidence capture state for an incident."""

--- a/backend/app/api/routes_exports.py
+++ b/backend/app/api/routes_exports.py
@@ -7,13 +7,16 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.api.schemas import DownloadExportResponse
-from app.core.deps import get_current_user
+from app.core.deps import (
+    enforce_resource_org_ownership,
+    get_current_user,
+    get_current_user_org_ids,
+)
 from app.db.models import User
 from app.db.session import get_db
 from app.db.repo.exports import get_export, list_exports_for_org_ids
 from app.db.repo.events import create_event
 from app.db.repo.incidents import get_incident
-from app.db.repo.users import get_user_org_ids
 from app.domain.system_event_types import SystemEventType
 from app.core.config import settings
 from app.services.vault_s3 import (
@@ -41,9 +44,9 @@ def _get_export_owner_org_id(db: Session, export):
 @router.get("/")
 def list_exports_endpoint(
     db: Session = Depends(get_db),
+    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
     current_user: User = Depends(get_current_user),
 ):
-    org_ids = get_user_org_ids(db, current_user.id)
     exports = list_exports_for_org_ids(db, org_ids)
     return [
         {
@@ -60,16 +63,15 @@ def list_exports_endpoint(
 def get_export_endpoint(
     export_id: uuid.UUID,
     db: Session = Depends(get_db),
+    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
     current_user: User = Depends(get_current_user),
 ):
-    org_ids = get_user_org_ids(db, current_user.id)
     export = get_export(db, export_id)
     if not export:
         raise HTTPException(status_code=404, detail="Export not found")
 
     export_org_id = _get_export_owner_org_id(db, export)
-    if export_org_id is None or export_org_id not in org_ids:
-        raise HTTPException(status_code=403, detail="Forbidden")
+    enforce_resource_org_ownership(export_org_id, org_ids)
 
     return {
         "export_id": str(export.export_id),
@@ -82,16 +84,15 @@ def get_export_endpoint(
 def download_export_endpoint(
     export_id: uuid.UUID,
     db: Session = Depends(get_db),
+    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
     current_user: User = Depends(get_current_user),
 ):
-    org_ids = get_user_org_ids(db, current_user.id)
     export = get_export(db, export_id)
     if not export:
         raise HTTPException(status_code=404, detail="Export not found")
 
     export_org_id = _get_export_owner_org_id(db, export)
-    if export_org_id is None or export_org_id not in org_ids:
-        raise HTTPException(status_code=403, detail="Forbidden")
+    enforce_resource_org_ownership(export_org_id, org_ids)
 
     if export.status != "ready":
         raise HTTPException(status_code=409, detail="Export is not ready")

--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -16,14 +16,18 @@ from app.api.schemas import (
     IncidentDetailResponse,
     IncidentListItem,
 )
-from app.core.deps import get_current_user
+from app.core.deps import (
+    enforce_resource_org_ownership,
+    get_current_user,
+    get_current_user_org_ids,
+    get_current_user_primary_org_id,
+)
 from app.db.models import User
 from app.db.session import get_db
 from app.db.repo.incidents import create_incident, get_incident, list_incidents
 from app.db.repo.events import create_event, get_events_by_incident
 from app.db.repo.artifacts import get_artifacts_by_incident
 from app.db.repo.exports import create_export, get_exports_by_incident
-from app.db.repo.users import get_user_org_ids
 from app.domain.system_event_types import SystemEventType
 from app.tasks.evidence_tasks import capture_dashcam, capture_telematics_bundle
 from app.tasks.export_tasks import build_export
@@ -36,9 +40,9 @@ router = APIRouter()
 @router.get("/", response_model=list[IncidentListItem])
 def list_incidents_endpoint(
     db: Session = Depends(get_db),
+    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
     current_user: User = Depends(get_current_user),
 ):
-    org_ids = get_user_org_ids(db, current_user.id)
     incidents = list_incidents(db, org_ids=org_ids)
     result = []
     for inc in incidents:
@@ -66,12 +70,9 @@ def list_incidents_endpoint(
 def create_incident_endpoint(
     body: CreateIncidentRequest,
     db: Session = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_current_user_primary_org_id),
     current_user: User = Depends(get_current_user),
 ):
-    # Use the first org the user belongs to
-    org_ids = get_user_org_ids(db, current_user.id)
-    org_id = org_ids[0] if org_ids else None
-
     # 1. Create the incident record
     incident = create_incident(
         db,
@@ -126,12 +127,13 @@ def create_incident_endpoint(
 def get_incident_endpoint(
     incident_id: uuid.UUID,
     db: Session = Depends(get_db),
+    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
     current_user: User = Depends(get_current_user),
 ):
-    org_ids = get_user_org_ids(db, current_user.id)
-    incident = get_incident(db, incident_id, org_ids=org_ids)
+    incident = get_incident(db, incident_id)
     if not incident:
         raise HTTPException(status_code=404, detail="Incident not found")
+    enforce_resource_org_ownership(incident.org_id, org_ids)
 
     artifacts = get_artifacts_by_incident(db, incident_id)
     exports = get_exports_by_incident(db, incident_id)
@@ -193,12 +195,13 @@ def get_incident_endpoint(
 def request_export_endpoint(
     incident_id: uuid.UUID,
     db: Session = Depends(get_db),
+    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
     current_user: User = Depends(get_current_user),
 ):
-    org_ids = get_user_org_ids(db, current_user.id)
-    incident = get_incident(db, incident_id, org_ids=org_ids)
+    incident = get_incident(db, incident_id)
     if not incident:
         raise HTTPException(status_code=404, detail="Incident not found")
+    enforce_resource_org_ownership(incident.org_id, org_ids)
 
     export = create_export(
         db,

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -1,38 +1,61 @@
-"""FastAPI dependency for extracting and validating the current user."""
+"""FastAPI dependencies and authorization helpers."""
 
 import uuid
+from collections.abc import Callable
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 
 from app.core.security import decode_access_token
+from app.db.models import Driver, User
+from app.db.repo.drivers import get_driver_by_id
+from app.db.repo.users import get_user_by_id, get_user_org_ids
 from app.db.session import get_db
-from app.db.repo.users import get_user_by_id
 
 _bearer = HTTPBearer(auto_error=False)
+
+
+def _read_access_token(
+    request: Request,
+    creds: HTTPAuthorizationCredentials | None,
+) -> str:
+    """Resolve JWT from Authorization header or access_token cookie."""
+    if creds is not None:
+        return creds.credentials
+
+    token = request.cookies.get("access_token")
+    if token is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
+    return token
+
+
+def _decode_subject_uuid(payload: dict, *, detail: str = "Invalid subject in token") -> uuid.UUID:
+    subject = payload.get("sub")
+    if subject is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token missing subject",
+        )
+    try:
+        return uuid.UUID(subject)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=detail,
+        ) from exc
 
 
 def get_current_user(
     request: Request,
     creds: HTTPAuthorizationCredentials | None = Depends(_bearer),
     db: Session = Depends(get_db),
-):
-    """Decode Bearer token (header or httpOnly cookie) and return the active User row."""
-    token = None
-
-    # Prefer Authorization header
-    if creds is not None:
-        token = creds.credentials
-    else:
-        # Fall back to httpOnly cookie
-        token = request.cookies.get("access_token")
-
-    if token is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Not authenticated",
-        )
+) -> User:
+    """Decode a user JWT and return the active User row."""
+    token = _read_access_token(request, creds)
 
     payload = decode_access_token(token)
     if payload is None:
@@ -41,14 +64,8 @@ def get_current_user(
             detail="Invalid or expired token",
         )
 
-    user_id = payload.get("sub")
-    if user_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Token missing subject",
-        )
-
-    user = get_user_by_id(db, uuid.UUID(user_id))
+    user_id = _decode_subject_uuid(payload)
+    user = get_user_by_id(db, user_id)
     if user is None or not user.is_active:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -61,21 +78,9 @@ def get_current_driver(
     request: Request,
     creds: HTTPAuthorizationCredentials | None = Depends(_bearer),
     db: Session = Depends(get_db),
-):
+) -> Driver:
     """Decode a driver-scoped JWT and return the active Driver row."""
-    from app.db.repo.drivers import get_driver_by_id
-
-    token = None
-    if creds is not None:
-        token = creds.credentials
-    else:
-        token = request.cookies.get("access_token")
-
-    if token is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Not authenticated",
-        )
+    token = _read_access_token(request, creds)
 
     payload = decode_access_token(token)
     if payload is None:
@@ -90,25 +95,60 @@ def get_current_driver(
             detail="Not a driver token",
         )
 
-    driver_id = payload.get("sub")
-    if driver_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Token missing subject",
-        )
-
-    try:
-        driver_uuid = uuid.UUID(driver_id)
-    except ValueError:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid subject in token",
-        )
-
-    driver = get_driver_by_id(db, driver_uuid)
+    driver_id = _decode_subject_uuid(payload)
+    driver = get_driver_by_id(db, driver_id)
     if driver is None or not driver.is_active:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Driver not found or inactive",
         )
     return driver
+
+
+def require_user_role(*allowed_roles: str) -> Callable[[User], User]:
+    """Create a dependency that enforces a user's role."""
+
+    allowed = set(allowed_roles)
+
+    def _require_role(current_user: User = Depends(get_current_user)) -> User:
+        if current_user.role not in allowed:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Insufficient role",
+            )
+        return current_user
+
+    return _require_role
+
+
+def get_current_user_org_ids(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[uuid.UUID]:
+    """Return org IDs for the current user and require at least one membership."""
+    org_ids = get_user_org_ids(db, current_user.id)
+    if not org_ids:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Organization membership required",
+        )
+    return org_ids
+
+
+def get_current_user_primary_org_id(
+    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
+) -> uuid.UUID:
+    """Return the first org ID for the current user."""
+    return org_ids[0]
+
+
+def enforce_resource_org_ownership(
+    resource_org_id: uuid.UUID | None,
+    member_org_ids: list[uuid.UUID],
+) -> None:
+    """Raise 403 if a resource does not belong to one of the caller's orgs."""
+    if resource_org_id is None or resource_org_id not in member_org_ids:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Forbidden",
+        )

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -334,6 +334,21 @@ class TestGetIncident:
         resp = client.get(f"/incidents/{fake_id}", headers=auth_headers)
         assert resp.status_code == 404
 
+    def test_get_incident_forbidden_for_other_org(
+        self, client, db_session, auth_headers
+    ):
+        other_org = Org(name="Other Org")
+        db_session.add(other_org)
+        db_session.commit()
+        db_session.refresh(other_org)
+        inc = Incident(status="open", org_id=other_org.id)
+        db_session.add(inc)
+        db_session.commit()
+        db_session.refresh(inc)
+
+        resp = client.get(f"/incidents/{inc.incident_id}", headers=auth_headers)
+        assert resp.status_code == 403
+
 
 # ── GET /incidents (list) ───────────────────────────────────────────
 
@@ -445,6 +460,21 @@ class TestRequestExport:
         fake_id = str(uuid.uuid4())
         resp = client.post(f"/incidents/{fake_id}/exports", headers=auth_headers)
         assert resp.status_code == 404
+
+    def test_request_export_forbidden_for_other_org_incident(
+        self, client, db_session, auth_headers
+    ):
+        other_org = Org(name="Other Org")
+        db_session.add(other_org)
+        db_session.commit()
+        db_session.refresh(other_org)
+        inc = Incident(status="open", org_id=other_org.id)
+        db_session.add(inc)
+        db_session.commit()
+        db_session.refresh(inc)
+
+        resp = client.post(f"/incidents/{inc.incident_id}/exports", headers=auth_headers)
+        assert resp.status_code == 403
 
 
 # ── GET /exports/{export_id}/download ───────────────────────────────
@@ -775,8 +805,7 @@ class TestGetExport:
 class TestListExports:
     def test_list_exports_no_org_links_returns_empty(self, client, no_org_auth_headers):
         resp = client.get("/exports/", headers=no_org_auth_headers)
-        assert resp.status_code == 200
-        assert resp.json() == []
+        assert resp.status_code == 403
 
     def test_get_export_denied_for_user_with_no_org_links(
         self, client, db_session, test_org, no_org_auth_headers

--- a/backend/tests/test_driver_admin_endpoints.py
+++ b/backend/tests/test_driver_admin_endpoints.py
@@ -116,7 +116,7 @@ def test_driver(db_session, test_org):
 
 @pytest.fixture()
 def driver_headers(test_driver):
-    token = create_access_token({"sub": str(test_driver.driver_id), "role": "driver"})
+    token = create_access_token({"sub": str(test_driver.driver_id), "scope": "driver"})
     return {"Authorization": f"Bearer {token}"}
 
 
@@ -268,6 +268,30 @@ class TestResolveQr:
         resp = client.post(
             "/driver/vehicle/resolve-qr",
             json={"qr_token": "nonexistent-token"},
+            headers=driver_headers,
+        )
+        assert resp.status_code == 404
+
+    def test_resolve_qr_other_org_token_returns_404(
+        self, client, db_session, test_driver, driver_headers
+    ):
+        other_org = Org(name="Other Org")
+        db_session.add(other_org)
+        db_session.commit()
+        db_session.refresh(other_org)
+        db_session.add(
+            VehicleQrToken(
+                qr_token="other-org-token",
+                org_id=other_org.id,
+                adc_vehicle_id="veh-901",
+                status="active",
+            )
+        )
+        db_session.commit()
+
+        resp = client.post(
+            "/driver/vehicle/resolve-qr",
+            json={"qr_token": "other-org-token"},
             headers=driver_headers,
         )
         assert resp.status_code == 404


### PR DESCRIPTION
### Motivation
- Reduce duplicated auth logic across API routes and ensure read/write operations consistently enforce org scoping and roles.
- Add negative test coverage for cross-org access attempts to prevent information leakage and unauthorized actions.

### Description
- Add reusable authorization helpers in `backend/app/core/deps.py`: `get_current_user`, `get_current_driver`, `_read_access_token`, `_decode_subject_uuid`, `require_user_role`, `get_current_user_org_ids`, `get_current_user_primary_org_id`, and `enforce_resource_org_ownership` to centralize token parsing, role enforcement, org membership, and resource ownership checks.
- Update routes to use the new helpers and enforce org ownership consistently: `backend/app/api/routes_incidents.py` (list/get/create/export-request), `backend/app/api/routes_exports.py` (list/get/download), `backend/app/api/routes_admin.py` (admin role + primary org for settings and QR rotation; limit active-token revocation to admin org(s)), and `backend/app/api/routes_driver.py` (reuse `get_current_driver` and enforce same-org QR token resolution).
- Tighten QR and driver flows so driver QR resolution and driver-initiated vehicle resolution only succeed for tokens belonging to the driver's org.
- Add and update tests to cover cross-org denial behavior and driver token scope: `backend/tests/test_api_endpoints.py` and `backend/tests/test_driver_admin_endpoints.py` include negative cases for cross-org incident/export/access and ensure the driver JWT uses `scope: "driver"` where applicable.

### Testing
- Ran linting with `make lint`; ruff checks completed successfully (All checks passed). 
- Ran the full test suite with `make test`; result was `247 passed, 0 failed` (test run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1c43b4db08321bd90906b95bb433f)