### PR TITLE
Harden Celery tasks with idempotency guards, retries, and dead-letter routing

### DIFF
--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -1,8 +1,13 @@
 """Celery application configuration."""
 
+import logging
+
 from celery import Celery
+from celery.signals import task_failure
 
 from app.core.config import settings
+
+logger = logging.getLogger(__name__)
 
 celery_app = Celery(
     "adc_mvp",
@@ -18,6 +23,12 @@ celery_app.conf.update(
     enable_utc=True,
     task_acks_late=True,
     task_reject_on_worker_lost=True,
+    worker_prefetch_multiplier=1,
+    task_default_retry_delay=30,
+    broker_transport_options={
+        "visibility_timeout": 3600,
+    },
+    task_create_missing_queues=True,
     task_routes={
         "app.tasks.evidence_tasks.capture_dashcam": {"queue": "evidence"},
         "app.tasks.evidence_tasks.capture_telematics_bundle": {"queue": "evidence"},
@@ -26,6 +37,33 @@ celery_app.conf.update(
             "queue": "notifications"
         },
         "app.tasks.notify_tasks.notify_safety": {"queue": "notifications"},
+        "app.tasks.celery_app.record_dead_letter": {"queue": "dead_letter"},
+    },
+    task_annotations={
+        "app.tasks.evidence_tasks.capture_dashcam": {
+            "autoretry_for": (Exception,),
+            "retry_backoff": True,
+            "retry_backoff_max": 300,
+            "retry_jitter": True,
+        },
+        "app.tasks.evidence_tasks.capture_telematics_bundle": {
+            "autoretry_for": (Exception,),
+            "retry_backoff": True,
+            "retry_backoff_max": 300,
+            "retry_jitter": True,
+        },
+        "app.tasks.export_tasks.build_export": {
+            "autoretry_for": (Exception,),
+            "retry_backoff": True,
+            "retry_backoff_max": 180,
+            "retry_jitter": True,
+        },
+        "app.tasks.notification_tasks.notify_safety_manager": {
+            "autoretry_for": (Exception,),
+            "retry_backoff": True,
+            "retry_backoff_max": 120,
+            "retry_jitter": True,
+        },
     },
 )
 
@@ -37,3 +75,43 @@ celery_app.conf.update(
 def hello_world():
     """Minimal task used to verify that the Celery worker is wired up."""
     return {"message": "hello world", "status": "ok"}
+
+
+@celery_app.task(name="app.tasks.celery_app.record_dead_letter")
+def record_dead_letter(payload: dict):
+    """Persist terminal task failure payload to a dead-letter queue."""
+    logger.error("Dead-letter task received: %s", payload)
+    return {"status": "recorded", "task_name": payload.get("task_name")}
+
+
+@task_failure.connect
+def route_terminal_failures_to_dead_letter(
+    sender=None,
+    task_id=None,
+    exception=None,
+    args=None,
+    kwargs=None,
+    einfo=None,
+    **extra,
+):
+    """Push non-retriable terminal failures to a dedicated dead-letter queue."""
+    if sender is None:
+        return
+    max_retries = getattr(sender, "max_retries", 0) or 0
+    current_retries = getattr(getattr(sender, "request", None), "retries", 0) or 0
+    if current_retries < max_retries:
+        return
+
+    payload = {
+        "task_name": getattr(sender, "name", "unknown"),
+        "task_id": task_id,
+        "args": list(args or []),
+        "kwargs": kwargs or {},
+        "exception": str(exception),
+    }
+    logger.error("Routing task failure to dead-letter queue: %s", payload)
+    celery_app.send_task(
+        "app.tasks.celery_app.record_dead_letter",
+        kwargs={"payload": payload},
+        queue="dead_letter",
+    )

--- a/backend/app/tasks/evidence_tasks.py
+++ b/backend/app/tasks/evidence_tasks.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from app.tasks.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
+_IDEMPOTENCY_UUID_NAMESPACE = _uuid.UUID("f10f5c65-1d84-42bf-b95c-d6253aac3020")
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -17,6 +18,17 @@ logger = logging.getLogger(__name__)
 def _hash_bytes(data: bytes) -> str:
     """Return hex-encoded SHA-256 digest of *data*."""
     return hashlib.sha256(data).hexdigest()
+
+
+def _idempotency_key(*parts: str | None) -> str:
+    """Return a deterministic idempotency key from stable task inputs."""
+    normalized = [p or "none" for p in parts]
+    return _hash_bytes("|".join(normalized).encode())
+
+
+def _deterministic_uuid(key: str) -> _uuid.UUID:
+    """Return a stable UUID for a deterministic key."""
+    return _uuid.uuid5(_IDEMPOTENCY_UUID_NAMESPACE, key)
 
 
 def _parse_iso(value: str | None) -> datetime | None:
@@ -60,6 +72,37 @@ def _emit(db, incident_id, event_type, payload=None):
     )
 
 
+def _event_exists(db, incident_id, event_type: str, idempotency_key: str) -> bool:
+    """Check whether an event with a matching idempotency key already exists."""
+    from app.db.repo.events import get_events_by_incident
+
+    existing_events = get_events_by_incident(db, incident_id)
+    return any(
+        ev.event_type == event_type
+        and isinstance(ev.payload, dict)
+        and ev.payload.get("idempotency_key") == idempotency_key
+        for ev in existing_events
+    )
+
+
+def _emit_once(db, incident_id, event_type, idempotency_key: str, payload=None):
+    """Emit an event exactly once for a given idempotency key."""
+    full_payload = {
+        "idempotency_key": idempotency_key,
+        **(payload or {}),
+    }
+    if _event_exists(db, incident_id, event_type, idempotency_key):
+        return None
+    return _emit(db, incident_id, event_type, full_payload)
+
+
+def _artifact_exists(db, artifact_id: _uuid.UUID) -> bool:
+    """Check whether an artifact with this deterministic identifier exists."""
+    from app.db.models import Artifact
+
+    return db.query(Artifact).filter(Artifact.artifact_id == artifact_id).first() is not None
+
+
 # ---------------------------------------------------------------------------
 # Task: capture_dashcam
 # ---------------------------------------------------------------------------
@@ -91,6 +134,9 @@ def capture_dashcam(
     from app.services.vault_s3 import VaultS3
 
     inc_uuid = _uuid.UUID(incident_id)
+    workflow_key = _idempotency_key(
+        "evidence", "dashcam", incident_id, window_start, window_end
+    )
     ws_dt = _parse_iso(window_start)
     we_dt = _parse_iso(window_end)
     db = _get_db()
@@ -98,20 +144,35 @@ def capture_dashcam(
     try:
         org_id = _get_org_id(db, inc_uuid)
         # 1. Emit EVIDENCE_CAPTURE_REQUESTED
-        _emit(
+        if _event_exists(
+            db,
+            inc_uuid,
+            SystemEventType.EVIDENCE_CAPTURE_SUCCEEDED,
+            workflow_key,
+        ):
+            return {
+                "incident_id": incident_id,
+                "type": "dashcam",
+                "status": "skipped_duplicate",
+                "idempotency_key": workflow_key,
+            }
+
+        _emit_once(
             db,
             inc_uuid,
             SystemEventType.EVIDENCE_CAPTURE_REQUESTED,
+            workflow_key,
             {
                 "type": "dashcam",
                 "window_start": window_start,
                 "window_end": window_end,
             },
         )
-        _emit(
+        _emit_once(
             db,
             inc_uuid,
             SystemEventType.EVIDENCE_CAPTURE_ATTEMPTED,
+            workflow_key,
             {
                 "type": "dashcam",
                 "window_start": window_start,
@@ -140,7 +201,12 @@ def capture_dashcam(
                     raise ValueError(f"No footage returned for {stream_label}")
 
                 # 3a. Upload to S3
-                art_id = _uuid.uuid4()
+                artifact_key = _idempotency_key(
+                    workflow_key, stream_label, artifact_type, "video"
+                )
+                art_id = _deterministic_uuid(artifact_key)
+                if _artifact_exists(db, art_id):
+                    continue
                 s3_key = s3_key_builder.dashcam_key(
                     org_id=org_id,
                     incident_id=incident_id,
@@ -153,10 +219,11 @@ def capture_dashcam(
                 sha = _hash_bytes(video_bytes)
 
                 # 3c. Emit ARTIFACT_RECORDED
-                _emit(
+                _emit_once(
                     db,
                     inc_uuid,
                     SystemEventType.ARTIFACT_RECORDED,
+                    artifact_key,
                     {
                         "artifact_type": artifact_type,
                         "stream": stream_label,
@@ -166,10 +233,11 @@ def capture_dashcam(
                 )
 
                 # 3d. Emit ARTIFACT_HASHED
-                _emit(
+                _emit_once(
                     db,
                     inc_uuid,
                     SystemEventType.ARTIFACT_HASHED,
+                    artifact_key,
                     {
                         "artifact_type": artifact_type,
                         "sha256": sha,
@@ -201,10 +269,11 @@ def capture_dashcam(
                     reason,
                 )
 
-                _emit(
+                _emit_once(
                     db,
                     inc_uuid,
                     SystemEventType.ARTIFACT_RECORDED,
+                    _idempotency_key(workflow_key, stream_label, artifact_type, "unavailable"),
                     {
                         "artifact_type": artifact_type,
                         "stream": stream_label,
@@ -213,35 +282,48 @@ def capture_dashcam(
                     },
                 )
 
-                create_artifact(
-                    db,
-                    incident_id=inc_uuid,
-                    artifact_type=artifact_type,
-                    status="unavailable",
-                    capture_window_start_utc=ws_dt,
-                    capture_window_end_utc=we_dt,
-                    unavailable_reason_code="stream_unavailable",
-                    unavailable_reason_detail=reason,
+                unavailable_key = _idempotency_key(
+                    workflow_key, stream_label, artifact_type, "unavailable"
                 )
+                unavailable_art_id = _deterministic_uuid(unavailable_key)
+                if not _artifact_exists(db, unavailable_art_id):
+                    create_artifact(
+                        db,
+                        incident_id=inc_uuid,
+                        artifact_type=artifact_type,
+                        status="unavailable",
+                        artifact_id=unavailable_art_id,
+                        capture_window_start_utc=ws_dt,
+                        capture_window_end_utc=we_dt,
+                        unavailable_reason_code="stream_unavailable",
+                        unavailable_reason_detail=reason,
+                    )
 
         # 4. Emit EVIDENCE_CAPTURE_SUCCEEDED
-        _emit(
+        _emit_once(
             db,
             inc_uuid,
             SystemEventType.EVIDENCE_CAPTURE_SUCCEEDED,
+            workflow_key,
             {
                 "type": "dashcam",
             },
         )
 
-        return {"incident_id": incident_id, "type": "dashcam", "status": "captured"}
+        return {
+            "incident_id": incident_id,
+            "type": "dashcam",
+            "status": "captured",
+            "idempotency_key": workflow_key,
+        }
 
     except Exception as exc:
         logger.exception("Dashcam capture failed for incident %s", incident_id)
-        _emit(
+        _emit_once(
             db,
             inc_uuid,
             SystemEventType.EVIDENCE_CAPTURE_FAILED,
+            workflow_key,
             {
                 "type": "dashcam",
                 "reason": str(exc),
@@ -296,26 +378,44 @@ def capture_telematics_bundle(
     from app.services.normalizers.vehicle_state import normalize_vehicle_state
 
     inc_uuid = _uuid.UUID(incident_id)
+    workflow_key = _idempotency_key(
+        "evidence", "telematics", incident_id, window_start, window_end
+    )
     ws_dt = _parse_iso(window_start)
     we_dt = _parse_iso(window_end)
     db = _get_db()
 
     try:
         org_id = _get_org_id(db, inc_uuid)
-        _emit(
+        if _event_exists(
+            db,
+            inc_uuid,
+            SystemEventType.EVIDENCE_CAPTURE_SUCCEEDED,
+            workflow_key,
+        ):
+            return {
+                "incident_id": incident_id,
+                "type": "telematics",
+                "status": "skipped_duplicate",
+                "idempotency_key": workflow_key,
+            }
+
+        _emit_once(
             db,
             inc_uuid,
             SystemEventType.EVIDENCE_CAPTURE_REQUESTED,
+            workflow_key,
             {
                 "type": "telematics",
                 "window_start": window_start,
                 "window_end": window_end,
             },
         )
-        _emit(
+        _emit_once(
             db,
             inc_uuid,
             SystemEventType.EVIDENCE_CAPTURE_ATTEMPTED,
+            workflow_key,
             {
                 "type": "telematics",
                 "window_start": window_start,
@@ -377,7 +477,10 @@ def capture_telematics_bundle(
 
                 # 4. Upload JSON to S3
                 json_bytes = json.dumps(normalized, default=str).encode()
-                json_art_id = _uuid.uuid4()
+                json_key_id = _idempotency_key(
+                    workflow_key, dataset_name, spec["artifact_type"], "json"
+                )
+                json_art_id = _deterministic_uuid(json_key_id)
                 json_key = s3_key_builder.telematics_key(
                     org_id=org_id,
                     incident_id=incident_id,
@@ -385,44 +488,47 @@ def capture_telematics_bundle(
                     artifact_id=str(json_art_id),
                     extension="json",
                 )
-                s3.put_bytes(json_key, json_bytes)
-                json_sha = _hash_bytes(json_bytes)
+                if not _artifact_exists(db, json_art_id):
+                    s3.put_bytes(json_key, json_bytes)
+                    json_sha = _hash_bytes(json_bytes)
 
-                _emit(
-                    db,
-                    inc_uuid,
-                    SystemEventType.ARTIFACT_RECORDED,
-                    {
-                        "artifact_type": spec["artifact_type"],
-                        "format": "json",
-                        "s3_key": json_key,
-                        "status": "captured",
-                    },
-                )
-                _emit(
-                    db,
-                    inc_uuid,
-                    SystemEventType.ARTIFACT_HASHED,
-                    {
-                        "artifact_type": spec["artifact_type"],
-                        "format": "json",
-                        "sha256": json_sha,
-                    },
-                )
+                    _emit_once(
+                        db,
+                        inc_uuid,
+                        SystemEventType.ARTIFACT_RECORDED,
+                        json_key_id,
+                        {
+                            "artifact_type": spec["artifact_type"],
+                            "format": "json",
+                            "s3_key": json_key,
+                            "status": "captured",
+                        },
+                    )
+                    _emit_once(
+                        db,
+                        inc_uuid,
+                        SystemEventType.ARTIFACT_HASHED,
+                        json_key_id,
+                        {
+                            "artifact_type": spec["artifact_type"],
+                            "format": "json",
+                            "sha256": json_sha,
+                        },
+                    )
 
-                create_artifact(
-                    db,
-                    incident_id=inc_uuid,
-                    artifact_type=spec["artifact_type"],
-                    status="captured",
-                    artifact_id=json_art_id,
-                    capture_window_start_utc=ws_dt,
-                    capture_window_end_utc=we_dt,
-                    s3_bucket=settings.S3_BUCKET,
-                    s3_key=json_key,
-                    sha256=json_sha,
-                    byte_size=len(json_bytes),
-                )
+                    create_artifact(
+                        db,
+                        incident_id=inc_uuid,
+                        artifact_type=spec["artifact_type"],
+                        status="captured",
+                        artifact_id=json_art_id,
+                        capture_window_start_utc=ws_dt,
+                        capture_window_end_utc=we_dt,
+                        s3_bucket=settings.S3_BUCKET,
+                        s3_key=json_key,
+                        sha256=json_sha,
+                        byte_size=len(json_bytes),
+                    )
 
                 # 5. Generate CSV rendering
                 if normalized:
@@ -434,7 +540,10 @@ def capture_telematics_bundle(
                 else:
                     csv_bytes = b""
 
-                csv_art_id = _uuid.uuid4()
+                csv_key_id = _idempotency_key(
+                    workflow_key, dataset_name, spec["artifact_type"], "csv"
+                )
+                csv_art_id = _deterministic_uuid(csv_key_id)
                 csv_key = s3_key_builder.telematics_key(
                     org_id=org_id,
                     incident_id=incident_id,
@@ -442,51 +551,57 @@ def capture_telematics_bundle(
                     artifact_id=str(csv_art_id),
                     extension="csv",
                 )
-                s3.put_bytes(csv_key, csv_bytes)
-                csv_sha = _hash_bytes(csv_bytes)
+                if not _artifact_exists(db, csv_art_id):
+                    s3.put_bytes(csv_key, csv_bytes)
+                    csv_sha = _hash_bytes(csv_bytes)
 
-                _emit(
-                    db,
-                    inc_uuid,
-                    SystemEventType.ARTIFACT_RECORDED,
-                    {
-                        "artifact_type": spec["artifact_type"],
-                        "format": "csv",
-                        "s3_key": csv_key,
-                        "status": "captured",
-                    },
-                )
-                _emit(
-                    db,
-                    inc_uuid,
-                    SystemEventType.ARTIFACT_HASHED,
-                    {
-                        "artifact_type": spec["artifact_type"],
-                        "format": "csv",
-                        "sha256": csv_sha,
-                    },
-                )
+                    _emit_once(
+                        db,
+                        inc_uuid,
+                        SystemEventType.ARTIFACT_RECORDED,
+                        csv_key_id,
+                        {
+                            "artifact_type": spec["artifact_type"],
+                            "format": "csv",
+                            "s3_key": csv_key,
+                            "status": "captured",
+                        },
+                    )
+                    _emit_once(
+                        db,
+                        inc_uuid,
+                        SystemEventType.ARTIFACT_HASHED,
+                        csv_key_id,
+                        {
+                            "artifact_type": spec["artifact_type"],
+                            "format": "csv",
+                            "sha256": csv_sha,
+                        },
+                    )
 
-                create_artifact(
-                    db,
-                    incident_id=inc_uuid,
-                    artifact_type=spec["artifact_type"],
-                    status="captured",
-                    artifact_id=csv_art_id,
-                    capture_window_start_utc=ws_dt,
-                    capture_window_end_utc=we_dt,
-                    s3_bucket=settings.S3_BUCKET,
-                    s3_key=csv_key,
-                    sha256=csv_sha,
-                    byte_size=len(csv_bytes),
-                )
+                    create_artifact(
+                        db,
+                        incident_id=inc_uuid,
+                        artifact_type=spec["artifact_type"],
+                        status="captured",
+                        artifact_id=csv_art_id,
+                        capture_window_start_utc=ws_dt,
+                        capture_window_end_utc=we_dt,
+                        s3_bucket=settings.S3_BUCKET,
+                        s3_key=csv_key,
+                        sha256=csv_sha,
+                        byte_size=len(csv_bytes),
+                    )
 
                 # 6. Generate PDF rendering
                 pdf_bytes = render_pdf(
                     f"{dataset_name}_report",
                     {"records": normalized, "incident_id": incident_id},
                 )
-                pdf_art_id = _uuid.uuid4()
+                pdf_key_id = _idempotency_key(
+                    workflow_key, dataset_name, spec["artifact_type"], "pdf"
+                )
+                pdf_art_id = _deterministic_uuid(pdf_key_id)
                 pdf_key = s3_key_builder.telematics_key(
                     org_id=org_id,
                     incident_id=incident_id,
@@ -494,44 +609,47 @@ def capture_telematics_bundle(
                     artifact_id=str(pdf_art_id),
                     extension="pdf",
                 )
-                s3.put_bytes(pdf_key, pdf_bytes)
-                pdf_sha = _hash_bytes(pdf_bytes)
+                if not _artifact_exists(db, pdf_art_id):
+                    s3.put_bytes(pdf_key, pdf_bytes)
+                    pdf_sha = _hash_bytes(pdf_bytes)
 
-                _emit(
-                    db,
-                    inc_uuid,
-                    SystemEventType.ARTIFACT_RECORDED,
-                    {
-                        "artifact_type": spec["artifact_type"],
-                        "format": "pdf",
-                        "s3_key": pdf_key,
-                        "status": "captured",
-                    },
-                )
-                _emit(
-                    db,
-                    inc_uuid,
-                    SystemEventType.ARTIFACT_HASHED,
-                    {
-                        "artifact_type": spec["artifact_type"],
-                        "format": "pdf",
-                        "sha256": pdf_sha,
-                    },
-                )
+                    _emit_once(
+                        db,
+                        inc_uuid,
+                        SystemEventType.ARTIFACT_RECORDED,
+                        pdf_key_id,
+                        {
+                            "artifact_type": spec["artifact_type"],
+                            "format": "pdf",
+                            "s3_key": pdf_key,
+                            "status": "captured",
+                        },
+                    )
+                    _emit_once(
+                        db,
+                        inc_uuid,
+                        SystemEventType.ARTIFACT_HASHED,
+                        pdf_key_id,
+                        {
+                            "artifact_type": spec["artifact_type"],
+                            "format": "pdf",
+                            "sha256": pdf_sha,
+                        },
+                    )
 
-                create_artifact(
-                    db,
-                    incident_id=inc_uuid,
-                    artifact_type=spec["artifact_type"],
-                    status="captured",
-                    artifact_id=pdf_art_id,
-                    capture_window_start_utc=ws_dt,
-                    capture_window_end_utc=we_dt,
-                    s3_bucket=settings.S3_BUCKET,
-                    s3_key=pdf_key,
-                    sha256=pdf_sha,
-                    byte_size=len(pdf_bytes),
-                )
+                    create_artifact(
+                        db,
+                        incident_id=inc_uuid,
+                        artifact_type=spec["artifact_type"],
+                        status="captured",
+                        artifact_id=pdf_art_id,
+                        capture_window_start_utc=ws_dt,
+                        capture_window_end_utc=we_dt,
+                        s3_bucket=settings.S3_BUCKET,
+                        s3_key=pdf_key,
+                        sha256=pdf_sha,
+                        byte_size=len(pdf_bytes),
+                    )
 
             except Exception as ds_exc:
                 reason = str(ds_exc)
@@ -542,10 +660,11 @@ def capture_telematics_bundle(
                     reason,
                 )
 
-                _emit(
+                _emit_once(
                     db,
                     inc_uuid,
                     SystemEventType.ARTIFACT_RECORDED,
+                    _idempotency_key(workflow_key, dataset_name, "unavailable"),
                     {
                         "artifact_type": spec["artifact_type"],
                         "status": "unavailable",
@@ -553,34 +672,47 @@ def capture_telematics_bundle(
                     },
                 )
 
-                create_artifact(
-                    db,
-                    incident_id=inc_uuid,
-                    artifact_type=spec["artifact_type"],
-                    status="unavailable",
-                    capture_window_start_utc=ws_dt,
-                    capture_window_end_utc=we_dt,
-                    unavailable_reason_code="dataset_unavailable",
-                    unavailable_reason_detail=reason,
+                unavailable_key = _idempotency_key(
+                    workflow_key, dataset_name, "unavailable"
                 )
+                unavailable_art_id = _deterministic_uuid(unavailable_key)
+                if not _artifact_exists(db, unavailable_art_id):
+                    create_artifact(
+                        db,
+                        incident_id=inc_uuid,
+                        artifact_type=spec["artifact_type"],
+                        status="unavailable",
+                        artifact_id=unavailable_art_id,
+                        capture_window_start_utc=ws_dt,
+                        capture_window_end_utc=we_dt,
+                        unavailable_reason_code="dataset_unavailable",
+                        unavailable_reason_detail=reason,
+                    )
 
-        _emit(
+        _emit_once(
             db,
             inc_uuid,
             SystemEventType.EVIDENCE_CAPTURE_SUCCEEDED,
+            workflow_key,
             {
                 "type": "telematics",
             },
         )
 
-        return {"incident_id": incident_id, "type": "telematics", "status": "captured"}
+        return {
+            "incident_id": incident_id,
+            "type": "telematics",
+            "status": "captured",
+            "idempotency_key": workflow_key,
+        }
 
     except Exception as exc:
         logger.exception("Telematics capture failed for incident %s", incident_id)
-        _emit(
+        _emit_once(
             db,
             inc_uuid,
             SystemEventType.EVIDENCE_CAPTURE_FAILED,
+            workflow_key,
             {
                 "type": "telematics",
                 "reason": str(exc),

--- a/backend/app/tasks/export_tasks.py
+++ b/backend/app/tasks/export_tasks.py
@@ -35,6 +35,12 @@ def _hash_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def _idempotency_key(*parts: str | None) -> str:
+    """Return a deterministic idempotency key from stable task inputs."""
+    normalized = [p or "none" for p in parts]
+    return _hash_bytes("|".join(normalized).encode())
+
+
 def _get_db():
     """Return a new database session (non-generator helper for tasks)."""
     from app.db.session import SessionLocal
@@ -64,6 +70,25 @@ def _emit(db, incident_id, event_type, payload=None):
         actor_id="celery",
         payload=payload,
     )
+
+
+def _event_exists(db, incident_id, event_type: str, idempotency_key: str) -> bool:
+    from app.db.repo.events import get_events_by_incident
+
+    events = get_events_by_incident(db, incident_id)
+    return any(
+        ev.event_type == event_type
+        and isinstance(ev.payload, dict)
+        and ev.payload.get("idempotency_key") == idempotency_key
+        for ev in events
+    )
+
+
+def _emit_once(db, incident_id, event_type, idempotency_key: str, payload=None):
+    full_payload = {"idempotency_key": idempotency_key, **(payload or {})}
+    if _event_exists(db, incident_id, event_type, idempotency_key):
+        return None
+    return _emit(db, incident_id, event_type, full_payload)
 
 
 def _artifact_filename(s3_key):
@@ -110,13 +135,14 @@ def build_export(self, incident_id: str, export_id: str):
     from app.core.config import settings
     from app.db.repo.artifacts import get_artifacts_by_incident
     from app.db.repo.events import get_events_by_incident
-    from app.db.repo.exports import update_export
+    from app.db.repo.exports import get_export, update_export
     from app.domain.system_event_types import SystemEventType
     from app.services import s3_key_builder
     from app.services.vault_s3 import VaultS3
 
     inc_uuid = _uuid.UUID(incident_id)
     exp_uuid = _uuid.UUID(export_id)
+    workflow_key = _idempotency_key("export", incident_id, export_id)
     db = _get_db()
 
     try:
@@ -130,14 +156,32 @@ def build_export(self, incident_id: str, export_id: str):
             for e in existing_events
         )
         if not already_requested:
-            _emit(
+            _emit_once(
                 db,
                 inc_uuid,
                 SystemEventType.EXPORT_REQUESTED,
+                workflow_key,
                 {
                     "export_id": export_id,
                 },
             )
+        export_row = get_export(db, exp_uuid)
+        if (
+            export_row is not None
+            and export_row.status == "ready"
+            and export_row.s3_key
+            and _event_exists(
+                db, inc_uuid, SystemEventType.EXPORT_GENERATED, workflow_key
+            )
+        ):
+            return {
+                "export_id": export_id,
+                "incident_id": incident_id,
+                "status": "ready",
+                "idempotency_key": workflow_key,
+                "s3_key": export_row.s3_key,
+                "duplicate": True,
+            }
 
         # 2. Read artifacts and events
         artifacts = get_artifacts_by_incident(db, inc_uuid)
@@ -309,10 +353,11 @@ def build_export(self, incident_id: str, export_id: str):
         )
 
         # 9. Emit EXPORT_GENERATED
-        _emit(
+        _emit_once(
             db,
             inc_uuid,
             SystemEventType.EXPORT_GENERATED,
+            workflow_key,
             {
                 "export_id": export_id,
                 "s3_key": zip_key,
@@ -325,14 +370,17 @@ def build_export(self, incident_id: str, export_id: str):
             "export_id": export_id,
             "incident_id": incident_id,
             "status": "ready",
+            "idempotency_key": workflow_key,
+            "duplicate": False,
         }
 
     except Exception:
         logger.exception("Export %s failed for incident %s", export_id, incident_id)
-        _emit(
+        _emit_once(
             db,
             inc_uuid,
             SystemEventType.EXPORT_FAILED,
+            workflow_key,
             {
                 "export_id": export_id,
             },

--- a/backend/app/tasks/notification_tasks.py
+++ b/backend/app/tasks/notification_tasks.py
@@ -41,6 +41,30 @@ def _emit(db, incident_id, event_type, payload=None):
     )
 
 
+def _idempotency_key(*parts: str | None) -> str:
+    normalized = [p or "none" for p in parts]
+    return "|".join(normalized)
+
+
+def _event_exists(db, incident_id, event_type: str, idempotency_key: str) -> bool:
+    from app.db.repo.events import get_events_by_incident
+
+    events = get_events_by_incident(db, incident_id)
+    return any(
+        ev.event_type == event_type
+        and isinstance(ev.payload, dict)
+        and ev.payload.get("idempotency_key") == idempotency_key
+        for ev in events
+    )
+
+
+def _emit_once(db, incident_id, event_type, idempotency_key: str, payload=None):
+    full_payload = {"idempotency_key": idempotency_key, **(payload or {})}
+    if _event_exists(db, incident_id, event_type, idempotency_key):
+        return None
+    return _emit(db, incident_id, event_type, full_payload)
+
+
 def _format_value(value: str | None, fallback: str) -> str:
     return value or fallback
 
@@ -76,6 +100,7 @@ def notify_safety_manager(self, incident_id: str):
     from app.services.twilio_notify import build_voice_twiml, place_call, send_sms
 
     inc_uuid = _uuid.UUID(incident_id)
+    workflow_key = _idempotency_key("notify_safety_manager", incident_id)
     db = _get_db()
 
     try:
@@ -96,20 +121,22 @@ def notify_safety_manager(self, incident_id: str):
         if not phone:
             reason = PHONE_MISSING_MESSAGE
             if org.sms_enabled:
-                _emit(
+                _emit_once(
                     db,
                     inc_uuid,
                     SystemEventType.SAFETY_MANAGER_SMS_FAILED,
+                    f"{workflow_key}:sms_failed",
                     {
                         "phone": None,
                         "reason": reason,
                     },
                 )
             if org.voice_enabled:
-                _emit(
+                _emit_once(
                     db,
                     inc_uuid,
                     SystemEventType.SAFETY_MANAGER_CALL_FAILED,
+                    f"{workflow_key}:call_failed",
                     {
                         "phone": None,
                         "reason": reason,
@@ -120,60 +147,86 @@ def notify_safety_manager(self, incident_id: str):
         message = _compose_sms(incident)
         twiml = build_voice_twiml(_compose_voice(incident))
         errors = []
-        result = {"incident_id": incident_id}
+        result = {
+            "incident_id": incident_id,
+            "idempotency_key": workflow_key,
+        }
 
         if org.sms_enabled:
-            try:
-                sms_sid = send_sms(phone, message)
-                result["sms_sid"] = sms_sid
-                _emit(
-                    db,
-                    inc_uuid,
-                    SystemEventType.SAFETY_MANAGER_SMS_SENT,
-                    {
-                        "phone": phone,
-                        "sms_sid": sms_sid,
-                    },
-                )
-            except (httpx.HTTPError, ValueError) as exc:
-                _emit(
-                    db,
-                    inc_uuid,
-                    SystemEventType.SAFETY_MANAGER_SMS_FAILED,
-                    {
-                        "phone": phone,
-                        "reason": str(exc),
-                    },
-                )
-                errors.append(f"SMS failed: {exc}")
+            sms_event_key = f"{workflow_key}:sms_sent"
+            if _event_exists(
+                db, inc_uuid, SystemEventType.SAFETY_MANAGER_SMS_SENT, sms_event_key
+            ):
+                result["sms_status"] = "already_sent"
+            else:
+                try:
+                    sms_sid = send_sms(phone, message)
+                    result["sms_sid"] = sms_sid
+                    _emit_once(
+                        db,
+                        inc_uuid,
+                        SystemEventType.SAFETY_MANAGER_SMS_SENT,
+                        sms_event_key,
+                        {
+                            "phone": phone,
+                            "sms_sid": sms_sid,
+                        },
+                    )
+                except (httpx.HTTPError, ValueError) as exc:
+                    _emit_once(
+                        db,
+                        inc_uuid,
+                        SystemEventType.SAFETY_MANAGER_SMS_FAILED,
+                        f"{workflow_key}:sms_failed",
+                        {
+                            "phone": phone,
+                            "reason": str(exc),
+                        },
+                    )
+                    errors.append(f"SMS failed: {exc}")
 
         if org.voice_enabled:
-            try:
-                call_sid = place_call(phone, twiml)
-                result["call_sid"] = call_sid
-                _emit(
-                    db,
-                    inc_uuid,
-                    SystemEventType.SAFETY_MANAGER_CALL_PLACED,
-                    {
-                        "phone": phone,
-                        "call_sid": call_sid,
-                    },
-                )
-            except (httpx.HTTPError, ValueError) as exc:
-                _emit(
-                    db,
-                    inc_uuid,
-                    SystemEventType.SAFETY_MANAGER_CALL_FAILED,
-                    {
-                        "phone": phone,
-                        "reason": str(exc),
-                    },
-                )
-                errors.append(f"Call failed: {exc}")
+            call_event_key = f"{workflow_key}:call_placed"
+            if _event_exists(
+                db, inc_uuid, SystemEventType.SAFETY_MANAGER_CALL_PLACED, call_event_key
+            ):
+                result["call_status"] = "already_placed"
+            else:
+                try:
+                    call_sid = place_call(phone, twiml)
+                    result["call_sid"] = call_sid
+                    _emit_once(
+                        db,
+                        inc_uuid,
+                        SystemEventType.SAFETY_MANAGER_CALL_PLACED,
+                        call_event_key,
+                        {
+                            "phone": phone,
+                            "call_sid": call_sid,
+                        },
+                    )
+                except (httpx.HTTPError, ValueError) as exc:
+                    _emit_once(
+                        db,
+                        inc_uuid,
+                        SystemEventType.SAFETY_MANAGER_CALL_FAILED,
+                        f"{workflow_key}:call_failed",
+                        {
+                            "phone": phone,
+                            "reason": str(exc),
+                        },
+                    )
+                    errors.append(f"Call failed: {exc}")
 
         if errors:
             raise RuntimeError(f"Notification failures: {'; '.join(errors)}")
+
+        if result.get("sms_status") == "already_sent" and result.get(
+            "call_status"
+        ) == "already_placed":
+            result["status"] = "skipped_duplicate"
+        else:
+            result["status"] = "notified"
 
         return result
 

--- a/backend/docs/operations/celery-task-reliability.md
+++ b/backend/docs/operations/celery-task-reliability.md
@@ -1,0 +1,58 @@
+# Celery task reliability: idempotency, retries, and dead letters
+
+## Deterministic idempotency keys
+
+The async incident workflows now generate stable idempotency keys so retries and duplicate deliveries are safe:
+
+- `capture_dashcam`: key derived from `incident_id + window_start + window_end`.
+- `capture_telematics_bundle`: key derived from `incident_id + window_start + window_end`.
+- `build_export`: key derived from `incident_id + export_id`.
+- `notify_safety_manager`: key derived from `incident_id`.
+
+Each workflow writes `idempotency_key` in task-generated event payloads and uses it to guard duplicate event emission.
+
+## Duplicate-processing guards
+
+The task layer now uses idempotent guards to prevent duplicate side effects:
+
+- Evidence tasks derive deterministic artifact UUIDs per stream/dataset/format and skip writes when artifact IDs already exist.
+- Evidence tasks short-circuit as `skipped_duplicate` when the same workflow has already emitted a successful completion event.
+- Export generation short-circuits if export row is already `ready` and a generated event exists for the same idempotency key.
+- Notifications skip duplicate SMS/call sends when corresponding success events already exist for that incident workflow.
+
+## Retry/backoff strategy
+
+`backend/app/tasks/celery_app.py` configures task-level retry policy via Celery annotations:
+
+- `autoretry_for=(Exception,)` on evidence/export/notification tasks.
+- Exponential backoff enabled via `retry_backoff=True`.
+- Capped backoff:
+  - Evidence: max 300 seconds.
+  - Export: max 180 seconds.
+  - Notifications: max 120 seconds.
+- Jitter enabled via `retry_jitter=True` to reduce thundering herds.
+
+Global worker transport defaults also set:
+
+- `task_default_retry_delay=30`
+- `worker_prefetch_multiplier=1`
+- `broker_transport_options.visibility_timeout=3600`
+
+## Dead-letter strategy
+
+When a task reaches terminal failure (retries exhausted), a `task_failure` signal handler routes metadata to a dedicated `dead_letter` queue using `record_dead_letter`.
+
+Payload includes:
+
+- task name and ID
+- args/kwargs
+- terminal exception text
+
+Use this queue for operator triage, alerting, and replay tooling.
+
+## Operations checklist
+
+1. Monitor queue depths for `evidence`, `exports`, `notifications`, and `dead_letter`.
+2. Alert on sustained growth in `dead_letter`.
+3. Investigate dead-letter payloads and classify transient vs permanent failures.
+4. Replay only after root-cause mitigation; idempotency controls prevent duplicate side effects for already-completed workflows.

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -123,6 +123,19 @@ class TestCeleryAppConfig:
         assert "app.tasks.export_tasks.build_export" in routes
         assert "app.tasks.notification_tasks.notify_safety_manager" in routes
 
+    def test_retry_annotations_defined(self):
+        from app.tasks.celery_app import celery_app
+
+        annotations = celery_app.conf.task_annotations
+        assert annotations["app.tasks.evidence_tasks.capture_dashcam"]["retry_backoff"]
+        assert annotations["app.tasks.export_tasks.build_export"]["retry_jitter"]
+
+    def test_dead_letter_route_defined(self):
+        from app.tasks.celery_app import celery_app
+
+        routes = celery_app.conf.task_routes
+        assert "app.tasks.celery_app.record_dead_letter" in routes
+
 
 # ── capture_dashcam ─────────────────────────────────────────────────
 
@@ -348,6 +361,34 @@ class TestCaptureDashcam:
         )
         for a in artifacts:
             assert a.sha256 == expected_sha
+
+    @patch("app.tasks.evidence_tasks._get_db")
+    @patch("app.services.vault_s3.VaultS3")
+    @patch("app.services.samsara_client.SamsaraClient")
+    def test_duplicate_run_is_skipped(
+        self, MockSamsara, MockS3, mock_get_db, db_session, incident
+    ):
+        mock_get_db.return_value = db_session
+
+        samsara_inst = MagicMock()
+        samsara_inst.fetch_dashcam_stream.return_value = b"data"
+        MockSamsara.return_value = samsara_inst
+        MockS3.return_value = MagicMock()
+
+        from app.tasks.evidence_tasks import capture_dashcam
+
+        first = capture_dashcam(
+            str(incident.incident_id),
+            "2024-01-01T00:00:00Z",
+            "2024-01-01T01:00:00Z",
+        )
+        second = capture_dashcam(
+            str(incident.incident_id),
+            "2024-01-01T00:00:00Z",
+            "2024-01-01T01:00:00Z",
+        )
+        assert first["status"] == "captured"
+        assert second["status"] == "skipped_duplicate"
 
 
 # ── capture_telematics_bundle ───────────────────────────────────────
@@ -728,6 +769,31 @@ class TestBuildExport:
         )
         assert len(events) == 1
 
+    @patch("app.tasks.export_tasks._get_db")
+    @patch("app.services.vault_s3.VaultS3")
+    def test_export_duplicate_run_returns_duplicate(
+        self, MockS3, mock_get_db, db_session, incident, export_row
+    ):
+        mock_get_db.return_value = db_session
+
+        s3_inst = MagicMock()
+        s3_inst.put_bytes.return_value = "s3://b/k"
+        s3_inst.download.return_value = b"file-content"
+        MockS3.return_value = s3_inst
+
+        from app.tasks.export_tasks import build_export
+
+        first = build_export(
+            str(incident.incident_id),
+            str(export_row.export_id),
+        )
+        second = build_export(
+            str(incident.incident_id),
+            str(export_row.export_id),
+        )
+        assert first["duplicate"] is False
+        assert second["duplicate"] is True
+
 
 # ── repo_exports.update_export ──────────────────────────────────────
 
@@ -812,3 +878,28 @@ class TestNotifySafetyManager:
         event_types = {event.event_type for event in events}
         assert SystemEventType.SAFETY_MANAGER_SMS_SENT in event_types
         assert SystemEventType.SAFETY_MANAGER_CALL_PLACED in event_types
+
+    @patch("app.tasks.notification_tasks._get_db")
+    @patch("app.services.twilio_notify.place_call")
+    @patch("app.services.twilio_notify.send_sms")
+    @patch("app.services.twilio_notify.build_voice_twiml", return_value="<Response/>")
+    def test_notify_safety_manager_is_idempotent(
+        self,
+        _mock_twiml,
+        mock_send_sms,
+        mock_place_call,
+        mock_get_db,
+        db_session,
+        incident_with_org,
+    ):
+        mock_get_db.return_value = db_session
+        mock_send_sms.return_value = "SM123"
+        mock_place_call.return_value = "CA123"
+
+        first = notify_safety_manager(str(incident_with_org.incident_id))
+        second = notify_safety_manager(str(incident_with_org.incident_id))
+
+        assert first["status"] == "notified"
+        assert second["status"] == "skipped_duplicate"
+        assert mock_send_sms.call_count == 1
+        assert mock_place_call.call_count == 1


### PR DESCRIPTION
### Motivation
- Prevent duplicate side effects from retried or duplicated Celery deliveries for incident workflows by introducing deterministic idempotency keys and guards.  
- Make evidence/export/notification tasks safe to retry and easier to operate by adding retry/backoff defaults and a dead-letter routing path.  

### Description
- Added deterministic idempotency primitives and artifact-level dedupe to evidence workflows in `backend/app/tasks/evidence_tasks.py` by introducing `_idempotency_key`, `_deterministic_uuid`, `_emit_once`, and artifact existence checks so artifact S3/uploads and DB rows are skipped on duplicates.  
- Hardened the export flow in `backend/app/tasks/export_tasks.py` with a workflow idempotency key, `get_export` checks, and `_emit_once` usage so `build_export` short-circuits when an export is already generated for the same key.  
- Made notification sends idempotent in `backend/app/tasks/notification_tasks.py` by guarding SMS/call sends with event checks and emitting deduplicated success/failure events, returning `notified` vs `skipped_duplicate`.  
- Configured Celery reliability in `backend/app/tasks/celery_app.py` by setting `worker_prefetch_multiplier`, `task_default_retry_delay`, `broker_transport_options.visibility_timeout`, per-task `task_annotations` with `autoretry_for`, exponential `retry_backoff`/`retry_jitter` caps, and added a `record_dead_letter` task plus a `task_failure` signal handler to route terminal failures to a `dead_letter` queue.  
- Added operational documentation at `backend/docs/operations/celery-task-reliability.md` describing idempotency keys, duplicate guards, retry/backoff parameters, dead-letter flow, and a short ops checklist.  
- Extended tests in `backend/tests/test_celery_tasks.py` to assert Celery annotations, dead-letter route, and idempotent behavior for duplicate dashcam/export/notification runs.  

### Testing
- Ran linter checks with `ruff` against changed files and the test suite via `cd backend && ruff check app tests` and all lint checks passed.  
- Ran focused tests with `cd backend && pytest tests/test_celery_tasks.py -q` and full test suite with `cd backend && pytest tests -q`, and all tests passed (`256 passed`, `3 warnings`).  
- Smoke-verified the new docs file `backend/docs/operations/celery-task-reliability.md` was added to repository content for operator reference.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d27b0385d48321b04d3aa84ae018c6)