### PR TITLE
Strengthen API validation and add runtime contract tests/checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Validate schemas
         run: python scripts/validate_schemas.py
 
+      - name: Check runtime API contract drift
+        run: python scripts/generate_runtime_api_contract.py --check
+
   frontend:
     name: Frontend (lint + build)
     runs-on: ubuntu-latest

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -1,52 +1,84 @@
 """Pydantic request / response schemas for the API."""
 
 import uuid
-from typing import Optional
+from datetime import datetime
+from typing import Annotated, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+
+EmailStrLike = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        min_length=6,
+        max_length=254,
+        pattern=r"^[^\s@]+@[^\s@]+\.[^\s@]+$",
+    ),
+]
+PhoneE164 = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        pattern=r"^\+[1-9]\d{1,14}$",
+    ),
+]
+OtpCode = Annotated[str, StringConstraints(pattern=r"^\d{4,8}$")]
+ShortText = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=255)]
+LongText = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=4000)]
+VehicleId = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=64, pattern=r"^[A-Za-z0-9._:-]+$")]
+DriverId = VehicleId
+QrToken = Annotated[str, StringConstraints(strip_whitespace=True, min_length=8, max_length=256, pattern=r"^[A-Za-z0-9_-]+$")]
+
+UserRole = Literal["admin", "safety_manager"]
+InstructionScope = Literal["default", "company", "insurer"]
+IncidentSeverity = Literal["minor", "serious", "critical"]
+IncidentStatus = Literal["open", "evidence_capturing", "closed"]
+ArtifactStatus = Literal["pending", "captured", "unavailable"]
+ExportStatus = Literal["requested", "processing", "ready", "failed"]
+VehicleStrategy = Literal["qr", "last_assigned"]
+CaptureState = Literal["failed", "complete", "in_progress", "requested", "lockdown", "closed", "pending"]
 
 
 # ── Auth ────────────────────────────────────────────────────────────
 
 
 class LoginRequest(BaseModel):
-    email: str
-    password: str
+    email: EmailStrLike
+    password: Annotated[str, StringConstraints(min_length=4, max_length=256)]
 
 
 class RequestOtpRequest(BaseModel):
-    phone_e164: str = Field(
-        pattern=r"^\+[1-9]\d{1,14}$",
+    phone_e164: PhoneE164 = Field(
         description="Phone number in E.164 format, e.g. +15551234567.",
     )
 
 
 class LoginResponse(BaseModel):
-    access_token: str
-    token_type: str = "bearer"
-    role: str
+    access_token: Annotated[str, StringConstraints(min_length=16)]
+    token_type: Literal["bearer"] = "bearer"
+    role: UserRole
 
 
 class RegisterRequest(BaseModel):
-    email: str
-    password: str
-    role: str = "safety_manager"
-    org_name: str = "Default"
+    email: EmailStrLike
+    password: Annotated[str, StringConstraints(min_length=4, max_length=256)]
+    role: UserRole = "safety_manager"
+    org_name: ShortText = "Default"
 
 
 class RegisterResponse(BaseModel):
     user_id: uuid.UUID
-    email: str
-    role: str
+    email: EmailStrLike
+    role: UserRole
     org_id: uuid.UUID
-    access_token: str
+    access_token: Annotated[str, StringConstraints(min_length=16)]
 
 
 class MeResponse(BaseModel):
     user_id: uuid.UUID
-    email: str
-    role: str
-    org_ids: list[uuid.UUID] = []
+    email: EmailStrLike
+    role: UserRole
+    org_ids: list[uuid.UUID] = Field(default_factory=list)
     active_org_id: Optional[uuid.UUID] = None
 
 
@@ -58,63 +90,63 @@ class LogoutResponse(BaseModel):
 
 
 class CreateIncidentRequest(BaseModel):
-    severity: str
-    adc_vehicle_id: str
-    samsara_vehicle_id: str
-    adc_driver_id: str
-    window_start: Optional[str] = None
-    window_end: Optional[str] = None
+    severity: IncidentSeverity
+    adc_vehicle_id: VehicleId
+    samsara_vehicle_id: VehicleId
+    adc_driver_id: DriverId
+    window_start: Optional[datetime] = None
+    window_end: Optional[datetime] = None
 
 
 class CreateIncidentResponse(BaseModel):
     incident_id: uuid.UUID
-    status: str
+    status: IncidentStatus
 
 
 class ArtifactSummary(BaseModel):
     artifact_id: uuid.UUID
-    artifact_type: str
-    status: str
-    captured_at_utc: Optional[str] = None
-    unavailable_reason: Optional[str] = None
+    artifact_type: ShortText
+    status: ArtifactStatus
+    captured_at_utc: Optional[datetime] = None
+    unavailable_reason: Optional[ShortText] = None
 
 
 class ExportSummary(BaseModel):
     export_id: uuid.UUID
-    status: str
-    created_at_utc: Optional[str] = None
+    status: ExportStatus
+    created_at_utc: Optional[datetime] = None
 
 
 class EventSummary(BaseModel):
-    event_type: str
-    occurred_at_utc: str
-    actor_type: str
+    event_type: ShortText
+    occurred_at_utc: datetime
+    actor_type: ShortText
     payload: Optional[dict] = None
 
 
 class IncidentListItem(BaseModel):
     incident_id: uuid.UUID
-    status: str
-    severity: Optional[str] = None
-    adc_vehicle_id: Optional[str] = None
-    samsara_vehicle_id: Optional[str] = None
-    adc_driver_id: Optional[str] = None
-    created_at_utc: Optional[str] = None
-    evidence_captured: int = 0
-    evidence_total: int = 0
+    status: IncidentStatus
+    severity: Optional[IncidentSeverity] = None
+    adc_vehicle_id: Optional[VehicleId] = None
+    samsara_vehicle_id: Optional[VehicleId] = None
+    adc_driver_id: Optional[DriverId] = None
+    created_at_utc: Optional[datetime] = None
+    evidence_captured: int = Field(default=0, ge=0)
+    evidence_total: int = Field(default=0, ge=0)
 
 
 class IncidentDetailResponse(BaseModel):
     incident_id: uuid.UUID
-    status: str
-    severity: Optional[str] = None
-    adc_vehicle_id: Optional[str] = None
-    samsara_vehicle_id: Optional[str] = None
-    adc_driver_id: Optional[str] = None
-    created_at_utc: Optional[str] = None
-    evidence_inventory: list[ArtifactSummary] = []
-    export_status: list[ExportSummary] = []
-    timeline: list[EventSummary] = []
+    status: IncidentStatus
+    severity: Optional[IncidentSeverity] = None
+    adc_vehicle_id: Optional[VehicleId] = None
+    samsara_vehicle_id: Optional[VehicleId] = None
+    adc_driver_id: Optional[DriverId] = None
+    created_at_utc: Optional[datetime] = None
+    evidence_inventory: list[ArtifactSummary] = Field(default_factory=list)
+    export_status: list[ExportSummary] = Field(default_factory=list)
+    timeline: list[EventSummary] = Field(default_factory=list)
 
 
 # ── Exports ─────────────────────────────────────────────────────────
@@ -122,33 +154,33 @@ class IncidentDetailResponse(BaseModel):
 
 class CreateExportResponse(BaseModel):
     export_id: uuid.UUID
-    status: str
+    status: ExportStatus
 
 
 class DownloadExportResponse(BaseModel):
     export_id: uuid.UUID
-    url: str
-    status: str
+    url: Annotated[str, StringConstraints(min_length=1, max_length=4096)]
+    status: ExportStatus
 
 
 # ── Driver ──────────────────────────────────────────────────────────
 
 
 class VehicleInfo(BaseModel):
-    adc_vehicle_id: str
-    display_label: str
+    adc_vehicle_id: VehicleId
+    display_label: ShortText
 
 
 class DriverMeResponse(BaseModel):
     driver_id: uuid.UUID
     org_id: uuid.UUID
-    phone_e164: str
-    display_name: str
+    phone_e164: PhoneE164
+    display_name: ShortText
     vehicle: Optional[VehicleInfo] = None
 
 
 class DriverOtpRequest(BaseModel):
-    phone_e164: str
+    phone_e164: PhoneE164
 
 
 class DriverOtpRequestResponse(BaseModel):
@@ -156,33 +188,33 @@ class DriverOtpRequestResponse(BaseModel):
 
 
 class DriverOtpVerifyRequest(BaseModel):
-    phone_e164: str
-    otp_code: str
+    phone_e164: PhoneE164
+    otp_code: OtpCode
 
 
 class DriverOtpVerifyResponse(BaseModel):
-    access_token: str
-    token_type: str = "bearer"
+    access_token: Annotated[str, StringConstraints(min_length=16)]
+    token_type: Literal["bearer"] = "bearer"
 
 
 class ResolveQrRequest(BaseModel):
-    qr_token: str
+    qr_token: QrToken
 
 
 class ResolveQrResponse(BaseModel):
-    adc_vehicle_id: str
-    display_label: str
+    adc_vehicle_id: VehicleId
+    display_label: ShortText
 
 
 # ── Admin driver protocol ─────────────────────────────────────────
 
 
 class DriverProtocolSettingsRequest(BaseModel):
-    instruction_source: str
+    instruction_source: InstructionScope
     require_ack: bool
     sms_enabled: bool
     voice_enabled: bool
-    safety_manager_phone: Optional[str] = None
+    safety_manager_phone: Optional[PhoneE164] = None
 
 
 class DriverProtocolSettingsResponse(DriverProtocolSettingsRequest):
@@ -191,40 +223,41 @@ class DriverProtocolSettingsResponse(DriverProtocolSettingsRequest):
 
 class DriverInstructionStep(BaseModel):
     step_id: Optional[uuid.UUID] = None
-    order: int
-    title: str
-    body: str
+    order: int = Field(ge=1, le=100)
+    title: ShortText
+    body: LongText
     enabled: bool = True
 
 
 class DriverInstructionSetRequest(BaseModel):
-    scope: str
-    steps: list[DriverInstructionStep]
+    scope: InstructionScope
+    steps: list[DriverInstructionStep] = Field(min_length=1, max_length=50)
 
 
 class DriverInstructionStepResponse(BaseModel):
     step_id: uuid.UUID
     step_order: int
-    title: str
-    body: str
+    title: ShortText
+    body: LongText
 
 
 class DriverInstructionSetResponse(DriverInstructionSetRequest):
     instruction_set_id: uuid.UUID
     require_ack: Optional[bool] = None
-    steps: list[DriverInstructionStep | DriverInstructionStepResponse] = []  # type: ignore[assignment]
+    steps: list[DriverInstructionStep | DriverInstructionStepResponse] = Field(default_factory=list)
+    model_config = ConfigDict(extra="ignore")
 
 
 # ── Driver incident / instruction responses ────────────────────────
 
 
 class DriverIncidentInitiateRequest(BaseModel):
-    vehicle_strategy: str
-    qr_token: Optional[str] = None
+    vehicle_strategy: VehicleStrategy
+    qr_token: Optional[QrToken] = None
     device_location: Optional[dict] = None
     device: Optional[dict] = None
-    window_start: Optional[str] = None
-    window_end: Optional[str] = None
+    window_start: Optional[datetime] = None
+    window_end: Optional[datetime] = None
 
 
 class DriverIncidentInitiateResponse(BaseModel):
@@ -243,23 +276,23 @@ class DriverInstructionAckResponse(BaseModel):
 
 class DriverIncidentStatusResponse(BaseModel):
     incident_id: uuid.UUID
-    status: str
+    status: IncidentStatus
     safety_notified: bool
-    capture_state: str
-    last_evidence_update_utc: Optional[str] = None
+    capture_state: CaptureState
+    last_evidence_update_utc: Optional[datetime] = None
 
 
 # ── Admin vehicles / QR ────────────────────────────────────────────
 
 
 class AdminVehicleSummary(BaseModel):
-    adc_vehicle_id: str
-    display_label: str
+    adc_vehicle_id: VehicleId
+    display_label: ShortText
 
 
 class RotateQrResponse(BaseModel):
-    qr_token: str
+    qr_token: QrToken
 
 
 class QrPayloadResponse(BaseModel):
-    deep_link: str
+    deep_link: Annotated[str, StringConstraints(min_length=1, max_length=4096)]

--- a/backend/tests/test_frontend_contracts.py
+++ b/backend/tests/test_frontend_contracts.py
@@ -1,0 +1,229 @@
+"""Contract tests ensuring backend JSON matches frontend/lib/api.ts expectations."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.security import create_access_token, hash_password
+from app.db.models import Base, Org, User, UserOrg
+from app.db.session import get_db
+from app.main import app
+
+
+@pytest.fixture()
+def db_session():
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine)
+    session = TestSession()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def test_org(db_session):
+    org = Org(name="Contract Org")
+    db_session.add(org)
+    db_session.commit()
+    db_session.refresh(org)
+    return org
+
+
+@pytest.fixture()
+def test_user(db_session, test_org):
+    user = User(
+        email="contracts@example.com",
+        password_hash=hash_password("supersecure"),
+        role="safety_manager",
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    db_session.add(UserOrg(user_id=user.id, org_id=test_org.id))
+    db_session.commit()
+    return user
+
+
+@pytest.fixture()
+def auth_headers(test_user):
+    token = create_access_token({"sub": str(test_user.id), "role": test_user.role})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def _assert_uuid(value: str):
+    assert isinstance(value, str)
+    uuid.UUID(value)
+
+
+def _assert_iso_datetime(value: str):
+    assert isinstance(value, str)
+    normalized = value.replace("Z", "+00:00")
+    datetime.fromisoformat(normalized)
+
+
+@patch("app.api.routes_incidents.capture_telematics_bundle")
+@patch("app.api.routes_incidents.capture_dashcam")
+def test_incident_list_contract_matches_frontend(
+    mock_dash,
+    mock_tele,
+    client: TestClient,
+    auth_headers: dict[str, str],
+):
+    mock_dash.delay = MagicMock()
+    mock_tele.delay = MagicMock()
+
+    create_resp = client.post(
+        "/incidents/",
+        json={
+            "severity": "serious",
+            "adc_vehicle_id": "veh-123",
+            "samsara_vehicle_id": "sm-456",
+            "adc_driver_id": "drv-789",
+        },
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201
+
+    resp = client.get("/incidents/", headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    assert body
+
+    item = body[0]
+    # Required frontend Incident fields.
+    for field in (
+        "incident_id",
+        "status",
+        "severity",
+        "adc_vehicle_id",
+        "samsara_vehicle_id",
+        "adc_driver_id",
+    ):
+        assert field in item
+
+    _assert_uuid(item["incident_id"])
+    assert isinstance(item["status"], str)
+    assert item["severity"] in {"minor", "serious", "critical", None}
+    assert isinstance(item["adc_vehicle_id"], str) or item["adc_vehicle_id"] is None
+    assert isinstance(item["samsara_vehicle_id"], str) or item["samsara_vehicle_id"] is None
+    assert isinstance(item["adc_driver_id"], str) or item["adc_driver_id"] is None
+
+    if item.get("created_at_utc"):
+        _assert_iso_datetime(item["created_at_utc"])
+    if "evidence_captured" in item:
+        assert isinstance(item["evidence_captured"], int)
+    if "evidence_total" in item:
+        assert isinstance(item["evidence_total"], int)
+
+
+@patch("app.api.routes_incidents.capture_telematics_bundle")
+@patch("app.api.routes_incidents.capture_dashcam")
+def test_incident_detail_contract_matches_frontend(
+    mock_dash,
+    mock_tele,
+    client: TestClient,
+    auth_headers: dict[str, str],
+):
+    mock_dash.delay = MagicMock()
+    mock_tele.delay = MagicMock()
+
+    create_resp = client.post(
+        "/incidents/",
+        json={
+            "severity": "minor",
+            "adc_vehicle_id": "veh-abc",
+            "samsara_vehicle_id": "sm-def",
+            "adc_driver_id": "drv-ghi",
+        },
+        headers=auth_headers,
+    )
+    incident_id = create_resp.json()["incident_id"]
+
+    detail_resp = client.get(f"/incidents/{incident_id}", headers=auth_headers)
+    assert detail_resp.status_code == 200
+
+    detail = detail_resp.json()
+    for field in (
+        "incident_id",
+        "status",
+        "severity",
+        "adc_vehicle_id",
+        "samsara_vehicle_id",
+        "adc_driver_id",
+        "evidence_inventory",
+        "export_status",
+        "timeline",
+    ):
+        assert field in detail
+
+    _assert_uuid(detail["incident_id"])
+    assert isinstance(detail["evidence_inventory"], list)
+    assert isinstance(detail["export_status"], list)
+    assert isinstance(detail["timeline"], list)
+
+
+@patch("app.api.routes_incidents.build_export")
+@patch("app.api.routes_incidents.capture_telematics_bundle")
+@patch("app.api.routes_incidents.capture_dashcam")
+def test_export_response_contract_matches_frontend(
+    mock_dash,
+    mock_tele,
+    mock_build_export,
+    client: TestClient,
+    auth_headers: dict[str, str],
+):
+    mock_dash.delay = MagicMock()
+    mock_tele.delay = MagicMock()
+    mock_build_export.delay = MagicMock()
+
+    create_resp = client.post(
+        "/incidents/",
+        json={
+            "severity": "critical",
+            "adc_vehicle_id": "veh-z9",
+            "samsara_vehicle_id": "sm-z9",
+            "adc_driver_id": "drv-z9",
+        },
+        headers=auth_headers,
+    )
+    incident_id = create_resp.json()["incident_id"]
+
+    export_resp = client.post(f"/incidents/{incident_id}/exports", headers=auth_headers)
+    assert export_resp.status_code == 201
+    payload = export_resp.json()
+
+    for field in ("export_id", "status"):
+        assert field in payload
+    _assert_uuid(payload["export_id"])
+    assert payload["status"] in {"requested", "processing", "ready", "failed"}

--- a/backend/tests/test_runtime_contract_snapshot.py
+++ b/backend/tests/test_runtime_contract_snapshot.py
@@ -1,0 +1,21 @@
+"""Ensure committed runtime contract snapshot matches backend schemas."""
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.generate_runtime_api_contract import build_snapshot  # noqa: E402
+
+
+def test_runtime_contract_snapshot_has_no_drift():
+    contract_path = REPO_ROOT / "contracts" / "schemas" / "runtime_api_contracts.json"
+
+    expected = build_snapshot()
+    rendered = json.dumps(expected, indent=2, sort_keys=True) + "\n"
+
+    assert contract_path.exists(), "runtime_api_contracts.json missing"
+    assert contract_path.read_text() == rendered

--- a/contracts/schemas/README.md
+++ b/contracts/schemas/README.md
@@ -40,3 +40,11 @@ All artifact JSON files share a common envelope:
 ## Validation
 - Validate JSON artifacts against the schema file with the same name.
 - Fail loudly: if validation fails, emit capture-failed events + unavailable artifacts (no silent gaps).
+
+
+## Runtime API contract snapshot
+- `runtime_api_contracts.json` is generated from `backend/app/api/schemas.py` and captures the backend response/request contract consumed by the frontend.
+- Regenerate after backend schema updates:
+  - `python scripts/generate_runtime_api_contract.py`
+- CI and backend tests both enforce drift detection:
+  - `python scripts/generate_runtime_api_contract.py --check`

--- a/contracts/schemas/runtime_api_contracts.json
+++ b/contracts/schemas/runtime_api_contracts.json
@@ -1,0 +1,888 @@
+{
+  "meta": {
+    "models": [
+      "LoginRequest",
+      "RegisterRequest",
+      "MeResponse",
+      "CreateIncidentRequest",
+      "CreateIncidentResponse",
+      "IncidentListItem",
+      "IncidentDetailResponse",
+      "CreateExportResponse",
+      "DownloadExportResponse",
+      "DriverProtocolSettingsResponse",
+      "DriverInstructionSetResponse",
+      "AdminVehicleSummary",
+      "RotateQrResponse",
+      "QrPayloadResponse"
+    ],
+    "source": "backend/app/api/schemas.py"
+  },
+  "schemas": {
+    "AdminVehicleSummary": {
+      "properties": {
+        "adc_vehicle_id": {
+          "maxLength": 64,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9._:-]+$",
+          "title": "Adc Vehicle Id",
+          "type": "string"
+        },
+        "display_label": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "adc_vehicle_id",
+        "display_label"
+      ],
+      "title": "AdminVehicleSummary",
+      "type": "object"
+    },
+    "CreateExportResponse": {
+      "properties": {
+        "export_id": {
+          "format": "uuid",
+          "title": "Export Id",
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "requested",
+            "processing",
+            "ready",
+            "failed"
+          ],
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "export_id",
+        "status"
+      ],
+      "title": "CreateExportResponse",
+      "type": "object"
+    },
+    "CreateIncidentRequest": {
+      "properties": {
+        "adc_driver_id": {
+          "maxLength": 64,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9._:-]+$",
+          "title": "Adc Driver Id",
+          "type": "string"
+        },
+        "adc_vehicle_id": {
+          "maxLength": 64,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9._:-]+$",
+          "title": "Adc Vehicle Id",
+          "type": "string"
+        },
+        "samsara_vehicle_id": {
+          "maxLength": 64,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9._:-]+$",
+          "title": "Samsara Vehicle Id",
+          "type": "string"
+        },
+        "severity": {
+          "enum": [
+            "minor",
+            "serious",
+            "critical"
+          ],
+          "title": "Severity",
+          "type": "string"
+        },
+        "window_end": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Window End"
+        },
+        "window_start": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Window Start"
+        }
+      },
+      "required": [
+        "severity",
+        "adc_vehicle_id",
+        "samsara_vehicle_id",
+        "adc_driver_id"
+      ],
+      "title": "CreateIncidentRequest",
+      "type": "object"
+    },
+    "CreateIncidentResponse": {
+      "properties": {
+        "incident_id": {
+          "format": "uuid",
+          "title": "Incident Id",
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "open",
+            "evidence_capturing",
+            "closed"
+          ],
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "incident_id",
+        "status"
+      ],
+      "title": "CreateIncidentResponse",
+      "type": "object"
+    },
+    "DownloadExportResponse": {
+      "properties": {
+        "export_id": {
+          "format": "uuid",
+          "title": "Export Id",
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "requested",
+            "processing",
+            "ready",
+            "failed"
+          ],
+          "title": "Status",
+          "type": "string"
+        },
+        "url": {
+          "maxLength": 4096,
+          "minLength": 1,
+          "title": "Url",
+          "type": "string"
+        }
+      },
+      "required": [
+        "export_id",
+        "url",
+        "status"
+      ],
+      "title": "DownloadExportResponse",
+      "type": "object"
+    },
+    "DriverInstructionSetResponse": {
+      "$defs": {
+        "DriverInstructionStep": {
+          "properties": {
+            "body": {
+              "maxLength": 4000,
+              "minLength": 1,
+              "title": "Body",
+              "type": "string"
+            },
+            "enabled": {
+              "default": true,
+              "title": "Enabled",
+              "type": "boolean"
+            },
+            "order": {
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Order",
+              "type": "integer"
+            },
+            "step_id": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Step Id"
+            },
+            "title": {
+              "maxLength": 255,
+              "minLength": 1,
+              "title": "Title",
+              "type": "string"
+            }
+          },
+          "required": [
+            "order",
+            "title",
+            "body"
+          ],
+          "title": "DriverInstructionStep",
+          "type": "object"
+        },
+        "DriverInstructionStepResponse": {
+          "properties": {
+            "body": {
+              "maxLength": 4000,
+              "minLength": 1,
+              "title": "Body",
+              "type": "string"
+            },
+            "step_id": {
+              "format": "uuid",
+              "title": "Step Id",
+              "type": "string"
+            },
+            "step_order": {
+              "title": "Step Order",
+              "type": "integer"
+            },
+            "title": {
+              "maxLength": 255,
+              "minLength": 1,
+              "title": "Title",
+              "type": "string"
+            }
+          },
+          "required": [
+            "step_id",
+            "step_order",
+            "title",
+            "body"
+          ],
+          "title": "DriverInstructionStepResponse",
+          "type": "object"
+        }
+      },
+      "properties": {
+        "instruction_set_id": {
+          "format": "uuid",
+          "title": "Instruction Set Id",
+          "type": "string"
+        },
+        "require_ack": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Require Ack"
+        },
+        "scope": {
+          "enum": [
+            "default",
+            "company",
+            "insurer"
+          ],
+          "title": "Scope",
+          "type": "string"
+        },
+        "steps": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/DriverInstructionStep"
+              },
+              {
+                "$ref": "#/$defs/DriverInstructionStepResponse"
+              }
+            ]
+          },
+          "title": "Steps",
+          "type": "array"
+        }
+      },
+      "required": [
+        "scope",
+        "instruction_set_id"
+      ],
+      "title": "DriverInstructionSetResponse",
+      "type": "object"
+    },
+    "DriverProtocolSettingsResponse": {
+      "properties": {
+        "instruction_source": {
+          "enum": [
+            "default",
+            "company",
+            "insurer"
+          ],
+          "title": "Instruction Source",
+          "type": "string"
+        },
+        "require_ack": {
+          "title": "Require Ack",
+          "type": "boolean"
+        },
+        "safety_manager_phone": {
+          "anyOf": [
+            {
+              "pattern": "^\\+[1-9]\\d{1,14}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Safety Manager Phone"
+        },
+        "sms_enabled": {
+          "title": "Sms Enabled",
+          "type": "boolean"
+        },
+        "voice_enabled": {
+          "title": "Voice Enabled",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "instruction_source",
+        "require_ack",
+        "sms_enabled",
+        "voice_enabled"
+      ],
+      "title": "DriverProtocolSettingsResponse",
+      "type": "object"
+    },
+    "IncidentDetailResponse": {
+      "$defs": {
+        "ArtifactSummary": {
+          "properties": {
+            "artifact_id": {
+              "format": "uuid",
+              "title": "Artifact Id",
+              "type": "string"
+            },
+            "artifact_type": {
+              "maxLength": 255,
+              "minLength": 1,
+              "title": "Artifact Type",
+              "type": "string"
+            },
+            "captured_at_utc": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Captured At Utc"
+            },
+            "status": {
+              "enum": [
+                "pending",
+                "captured",
+                "unavailable"
+              ],
+              "title": "Status",
+              "type": "string"
+            },
+            "unavailable_reason": {
+              "anyOf": [
+                {
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Unavailable Reason"
+            }
+          },
+          "required": [
+            "artifact_id",
+            "artifact_type",
+            "status"
+          ],
+          "title": "ArtifactSummary",
+          "type": "object"
+        },
+        "EventSummary": {
+          "properties": {
+            "actor_type": {
+              "maxLength": 255,
+              "minLength": 1,
+              "title": "Actor Type",
+              "type": "string"
+            },
+            "event_type": {
+              "maxLength": 255,
+              "minLength": 1,
+              "title": "Event Type",
+              "type": "string"
+            },
+            "occurred_at_utc": {
+              "format": "date-time",
+              "title": "Occurred At Utc",
+              "type": "string"
+            },
+            "payload": {
+              "anyOf": [
+                {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Payload"
+            }
+          },
+          "required": [
+            "event_type",
+            "occurred_at_utc",
+            "actor_type"
+          ],
+          "title": "EventSummary",
+          "type": "object"
+        },
+        "ExportSummary": {
+          "properties": {
+            "created_at_utc": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Created At Utc"
+            },
+            "export_id": {
+              "format": "uuid",
+              "title": "Export Id",
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "requested",
+                "processing",
+                "ready",
+                "failed"
+              ],
+              "title": "Status",
+              "type": "string"
+            }
+          },
+          "required": [
+            "export_id",
+            "status"
+          ],
+          "title": "ExportSummary",
+          "type": "object"
+        }
+      },
+      "properties": {
+        "adc_driver_id": {
+          "anyOf": [
+            {
+              "maxLength": 64,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9._:-]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Adc Driver Id"
+        },
+        "adc_vehicle_id": {
+          "anyOf": [
+            {
+              "maxLength": 64,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9._:-]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Adc Vehicle Id"
+        },
+        "created_at_utc": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Created At Utc"
+        },
+        "evidence_inventory": {
+          "items": {
+            "$ref": "#/$defs/ArtifactSummary"
+          },
+          "title": "Evidence Inventory",
+          "type": "array"
+        },
+        "export_status": {
+          "items": {
+            "$ref": "#/$defs/ExportSummary"
+          },
+          "title": "Export Status",
+          "type": "array"
+        },
+        "incident_id": {
+          "format": "uuid",
+          "title": "Incident Id",
+          "type": "string"
+        },
+        "samsara_vehicle_id": {
+          "anyOf": [
+            {
+              "maxLength": 64,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9._:-]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Samsara Vehicle Id"
+        },
+        "severity": {
+          "anyOf": [
+            {
+              "enum": [
+                "minor",
+                "serious",
+                "critical"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Severity"
+        },
+        "status": {
+          "enum": [
+            "open",
+            "evidence_capturing",
+            "closed"
+          ],
+          "title": "Status",
+          "type": "string"
+        },
+        "timeline": {
+          "items": {
+            "$ref": "#/$defs/EventSummary"
+          },
+          "title": "Timeline",
+          "type": "array"
+        }
+      },
+      "required": [
+        "incident_id",
+        "status"
+      ],
+      "title": "IncidentDetailResponse",
+      "type": "object"
+    },
+    "IncidentListItem": {
+      "properties": {
+        "adc_driver_id": {
+          "anyOf": [
+            {
+              "maxLength": 64,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9._:-]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Adc Driver Id"
+        },
+        "adc_vehicle_id": {
+          "anyOf": [
+            {
+              "maxLength": 64,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9._:-]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Adc Vehicle Id"
+        },
+        "created_at_utc": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Created At Utc"
+        },
+        "evidence_captured": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Evidence Captured",
+          "type": "integer"
+        },
+        "evidence_total": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Evidence Total",
+          "type": "integer"
+        },
+        "incident_id": {
+          "format": "uuid",
+          "title": "Incident Id",
+          "type": "string"
+        },
+        "samsara_vehicle_id": {
+          "anyOf": [
+            {
+              "maxLength": 64,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9._:-]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Samsara Vehicle Id"
+        },
+        "severity": {
+          "anyOf": [
+            {
+              "enum": [
+                "minor",
+                "serious",
+                "critical"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Severity"
+        },
+        "status": {
+          "enum": [
+            "open",
+            "evidence_capturing",
+            "closed"
+          ],
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "incident_id",
+        "status"
+      ],
+      "title": "IncidentListItem",
+      "type": "object"
+    },
+    "LoginRequest": {
+      "properties": {
+        "email": {
+          "maxLength": 254,
+          "minLength": 6,
+          "pattern": "^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$",
+          "title": "Email",
+          "type": "string"
+        },
+        "password": {
+          "maxLength": 256,
+          "minLength": 4,
+          "title": "Password",
+          "type": "string"
+        }
+      },
+      "required": [
+        "email",
+        "password"
+      ],
+      "title": "LoginRequest",
+      "type": "object"
+    },
+    "MeResponse": {
+      "properties": {
+        "active_org_id": {
+          "anyOf": [
+            {
+              "format": "uuid",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Active Org Id"
+        },
+        "email": {
+          "maxLength": 254,
+          "minLength": 6,
+          "pattern": "^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$",
+          "title": "Email",
+          "type": "string"
+        },
+        "org_ids": {
+          "items": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "title": "Org Ids",
+          "type": "array"
+        },
+        "role": {
+          "enum": [
+            "admin",
+            "safety_manager"
+          ],
+          "title": "Role",
+          "type": "string"
+        },
+        "user_id": {
+          "format": "uuid",
+          "title": "User Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "user_id",
+        "email",
+        "role"
+      ],
+      "title": "MeResponse",
+      "type": "object"
+    },
+    "QrPayloadResponse": {
+      "properties": {
+        "deep_link": {
+          "maxLength": 4096,
+          "minLength": 1,
+          "title": "Deep Link",
+          "type": "string"
+        }
+      },
+      "required": [
+        "deep_link"
+      ],
+      "title": "QrPayloadResponse",
+      "type": "object"
+    },
+    "RegisterRequest": {
+      "properties": {
+        "email": {
+          "maxLength": 254,
+          "minLength": 6,
+          "pattern": "^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$",
+          "title": "Email",
+          "type": "string"
+        },
+        "org_name": {
+          "default": "Default",
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Org Name",
+          "type": "string"
+        },
+        "password": {
+          "maxLength": 256,
+          "minLength": 4,
+          "title": "Password",
+          "type": "string"
+        },
+        "role": {
+          "default": "safety_manager",
+          "enum": [
+            "admin",
+            "safety_manager"
+          ],
+          "title": "Role",
+          "type": "string"
+        }
+      },
+      "required": [
+        "email",
+        "password"
+      ],
+      "title": "RegisterRequest",
+      "type": "object"
+    },
+    "RotateQrResponse": {
+      "properties": {
+        "qr_token": {
+          "maxLength": 256,
+          "minLength": 8,
+          "pattern": "^[A-Za-z0-9_-]+$",
+          "title": "Qr Token",
+          "type": "string"
+        }
+      },
+      "required": [
+        "qr_token"
+      ],
+      "title": "RotateQrResponse",
+      "type": "object"
+    }
+  }
+}

--- a/scripts/generate_runtime_api_contract.py
+++ b/scripts/generate_runtime_api_contract.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Generate runtime API contract snapshots from backend Pydantic schemas.
+
+Usage:
+  python scripts/generate_runtime_api_contract.py          # writes snapshot
+  python scripts/generate_runtime_api_contract.py --check  # fails on drift
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BACKEND_DIR = REPO_ROOT / "backend"
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from app.api import schemas as api_schemas  # noqa: E402
+
+CONTRACT_PATH = REPO_ROOT / "contracts" / "schemas" / "runtime_api_contracts.json"
+
+CONTRACT_MODELS: dict[str, type] = {
+    # Auth
+    "LoginRequest": api_schemas.LoginRequest,
+    "RegisterRequest": api_schemas.RegisterRequest,
+    "MeResponse": api_schemas.MeResponse,
+    # Incidents / exports used by frontend/lib/api.ts
+    "CreateIncidentRequest": api_schemas.CreateIncidentRequest,
+    "CreateIncidentResponse": api_schemas.CreateIncidentResponse,
+    "IncidentListItem": api_schemas.IncidentListItem,
+    "IncidentDetailResponse": api_schemas.IncidentDetailResponse,
+    "CreateExportResponse": api_schemas.CreateExportResponse,
+    "DownloadExportResponse": api_schemas.DownloadExportResponse,
+    # Admin + driver protocol
+    "DriverProtocolSettingsResponse": api_schemas.DriverProtocolSettingsResponse,
+    "DriverInstructionSetResponse": api_schemas.DriverInstructionSetResponse,
+    # Admin vehicles / qr
+    "AdminVehicleSummary": api_schemas.AdminVehicleSummary,
+    "RotateQrResponse": api_schemas.RotateQrResponse,
+    "QrPayloadResponse": api_schemas.QrPayloadResponse,
+}
+
+
+def build_snapshot() -> dict[str, object]:
+    return {
+        "meta": {
+            "source": "backend/app/api/schemas.py",
+            "models": list(CONTRACT_MODELS.keys()),
+        },
+        "schemas": {
+            name: model.model_json_schema(mode="validation")
+            for name, model in CONTRACT_MODELS.items()
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    snapshot = build_snapshot()
+    rendered = json.dumps(snapshot, indent=2, sort_keys=True) + "\n"
+
+    if args.check:
+        if not CONTRACT_PATH.exists():
+            print(f"FAIL: missing contract snapshot at {CONTRACT_PATH}")
+            return 1
+        existing = CONTRACT_PATH.read_text()
+        if existing != rendered:
+            print("FAIL: runtime API contract drift detected.")
+            print(
+                "Run: python scripts/generate_runtime_api_contract.py "
+                "and commit updated contracts/schemas/runtime_api_contracts.json"
+            )
+            return 1
+        print("OK: runtime API contract snapshot is up to date")
+        return 0
+
+    CONTRACT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CONTRACT_PATH.write_text(rendered)
+    print(f"Wrote runtime API contracts to {CONTRACT_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Make backend request/response schemas stricter to catch invalid data early by adding length constraints, enums, and stronger field formats.  
- Ensure the JSON contract the frontend relies on is explicit and guarded against accidental backend changes.  
- Provide a reproducible, testable snapshot of the runtime API surface so CI can detect drift between runtime schemas and the committed contract.  

### Description
- Expanded `backend/app/api/schemas.py` to use constrained types, `Annotated`/`StringConstraints`, `Literal` enums, `datetime`/`UUID` typing, bounded numeric fields, safer list defaults via `Field(default_factory=...)`, and stricter patterns for emails, E.164 phones, OTPs, vehicle IDs and QR tokens.  
- Added contract-oriented tests in `backend/tests/test_frontend_contracts.py` which assert incident list/detail and export responses match the shapes expected by `frontend/lib/api.ts`.  
- Added a runtime contract generator `scripts/generate_runtime_api_contract.py` that emits `contracts/schemas/runtime_api_contracts.json` and a test `backend/tests/test_runtime_contract_snapshot.py` that fails when the snapshot drifts from current backend schemas.  
- Updated contract docs (`contracts/schemas/README.md`) and CI (`.github/workflows/ci.yml`) to validate JSON schemas and to run the runtime contract drift check automatically.  

### Testing
- Ran linting with `ruff` on the changed files which passed.  
- Ran targeted pytest runs for the new contract tests and schema tests with `cd backend && pytest tests/test_request_otp_schema.py tests/test_frontend_contracts.py tests/test_runtime_contract_snapshot.py -v` which passed.  
- Ran the full backend test suite with `cd backend && pytest tests/ -q` which completed successfully (`255 passed, 3 warnings`).  
- Validated committed JSON artifact schemas and runtime snapshot by running `python scripts/validate_schemas.py` and `python scripts/generate_runtime_api_contract.py --check`, both of which reported OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d27b058060832181ea58788b80ce84)