### PR TITLE
Follow-up: tolerate partial incident fetch failures in dashboard/timeline polling

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -32,12 +32,28 @@ export default function DashboardPage() {
     const loadDashboard = async () => {
       try {
         const incidents = await listIncidents();
-        const details = await Promise.all(
+        const detailResults = await Promise.allSettled(
           incidents.map((incident) => getIncident(incident.incident_id))
         );
+        const details = detailResults
+          .filter(
+            (result): result is PromiseFulfilledResult<IncidentDetail> =>
+              result.status === "fulfilled"
+          )
+          .map((result) => result.value);
+        const failedCount = detailResults.length - details.length;
+
         if (!cancelled) {
-          setIncidentDetails(details);
-          setError("");
+          if (details.length > 0 || incidents.length === 0) {
+            setIncidentDetails(details);
+          }
+          if (failedCount > 0) {
+            setError(
+              `Loaded ${details.length} of ${detailResults.length} incidents. ${failedCount} failed to refresh.`
+            );
+          } else {
+            setError("");
+          }
         }
       } catch (err) {
         if (!cancelled) {

--- a/frontend/app/timeline/page.tsx
+++ b/frontend/app/timeline/page.tsx
@@ -41,9 +41,16 @@ export default function TimelinePage() {
     const refresh = async () => {
       try {
         const incidents = await listIncidents();
-        const details = await Promise.all(
+        const detailResults = await Promise.allSettled(
           incidents.map((incident) => getIncident(incident.incident_id))
         );
+        const details = detailResults
+          .filter(
+            (result): result is PromiseFulfilledResult<Awaited<ReturnType<typeof getIncident>>> =>
+              result.status === "fulfilled"
+          )
+          .map((result) => result.value);
+        const failedCount = detailResults.length - details.length;
 
         const allEvents = details
           .flatMap((incident) =>
@@ -60,8 +67,16 @@ export default function TimelinePage() {
           .slice(0, MAX_EVENTS);
 
         if (!cancelled) {
-          setEvents(allEvents);
-          setError("");
+          if (details.length > 0 || incidents.length === 0) {
+            setEvents(allEvents);
+          }
+          if (failedCount > 0) {
+            setError(
+              `Loaded ${details.length} of ${detailResults.length} incidents. ${failedCount} failed to refresh.`
+            );
+          } else {
+            setError("");
+          }
         }
       } catch (err) {
         if (!cancelled) {


### PR DESCRIPTION
### Motivation
- Make the dashboard and cross-incident Timeline polling resilient to transient per-incident failures so one failed `getIncident` call does not block all updates. 
- Prevent transient backend hiccups from blanking KPIs or stalling the timeline for all users by preserving previously loaded data when a poll cycle fails.

### Description
- Replaced `Promise.all` with `Promise.allSettled` when fetching incident details in `frontend/app/dashboard/page.tsx` and `frontend/app/timeline/page.tsx`. 
- Filtered `PromiseFulfilledResult` entries and built KPI/timeline state only from successful detail responses while computing a `failedCount` for diagnostics. 
- Added partial-refresh messaging (`Loaded X of Y incidents. N failed to refresh.`) to surface partial failures to users and cleared the message only when all detail requests succeed. 
- Kept prior dashboard/timeline state when an entire poll cycle returns no successful detail responses (except when there are zero incidents), avoiding unnecessary blanking.

### Testing
- Ran linter with `cd frontend && npm run lint` and it completed successfully. 
- Ran TypeScript checks with `cd frontend && npx tsc --noEmit` and the type check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d27f80d374832181ddfb70fe653b47)