### PR TITLE
[PR #82 Follow-up] Fix contact lead delivery and submission UX

### DIFF
--- a/frontend/app/api/leads/route.ts
+++ b/frontend/app/api/leads/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+
+interface LeadPayload {
+  name: string;
+  email: string;
+  message: string;
+}
+
+function isLeadPayload(payload: unknown): payload is LeadPayload {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+
+  const parsed = payload as Partial<LeadPayload>;
+
+  return (
+    typeof parsed.name === "string" &&
+    parsed.name.trim().length > 0 &&
+    typeof parsed.email === "string" &&
+    parsed.email.trim().length > 0 &&
+    typeof parsed.message === "string" &&
+    parsed.message.trim().length > 0
+  );
+}
+
+export async function POST(request: Request) {
+  const webhookUrl = process.env.MARKETING_LEADS_WEBHOOK_URL;
+
+  if (!webhookUrl) {
+    return NextResponse.json(
+      { detail: "Lead intake unavailable." },
+      { status: 503 }
+    );
+  }
+
+  const payload = await request.json().catch(() => null);
+
+  if (!isLeadPayload(payload)) {
+    return NextResponse.json(
+      { detail: "Invalid lead payload." },
+      { status: 400 }
+    );
+  }
+
+  const webhookResponse = await fetch(webhookUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      ...payload,
+      source: "company-contact",
+      submitted_at_utc: new Date().toISOString(),
+    }),
+    cache: "no-store",
+  });
+
+  if (!webhookResponse.ok) {
+    return NextResponse.json(
+      { detail: "Lead delivery failed." },
+      { status: 502 }
+    );
+  }
+
+  return NextResponse.json({ ok: true }, { status: 202 });
+}

--- a/frontend/components/marketing/LeadForm.tsx
+++ b/frontend/components/marketing/LeadForm.tsx
@@ -3,17 +3,55 @@
 import { FormEvent, useState } from "react";
 import { trackCtaClick } from "@/lib/tracking";
 
-export default function LeadForm() {
-  const [submitted, setSubmitted] = useState(false);
+interface LeadFormState {
+  name: string;
+  email: string;
+  message: string;
+}
 
-  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+const EMPTY_FORM: LeadFormState = {
+  name: "",
+  email: "",
+  message: "",
+};
+
+export default function LeadForm() {
+  const [form, setForm] = useState<LeadFormState>(EMPTY_FORM);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setSubmitted(true);
-    trackCtaClick({
-      event: "lead_form_submit",
-      location: "company-contact",
-      label: "Submit contact form",
-    });
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      const response = await fetch("/api/leads", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(form),
+      });
+
+      if (!response.ok) {
+        throw new Error("We could not send your request. Please try again.");
+      }
+
+      setSubmitted(true);
+      setForm(EMPTY_FORM);
+      trackCtaClick({
+        event: "lead_form_submit",
+        location: "company-contact",
+        label: "Submit contact form",
+      });
+    } catch {
+      setSubmitError("We could not send your request. Please try again.");
+      setSubmitted(false);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -22,7 +60,13 @@ export default function LeadForm() {
         <label className="mb-1 block text-sm font-medium" htmlFor="name">
           Full name
         </label>
-        <input id="name" required className="w-full rounded border border-slate-300 px-3 py-2" />
+        <input
+          id="name"
+          required
+          className="w-full rounded border border-slate-300 px-3 py-2"
+          value={form.name}
+          onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+        />
       </div>
       <div>
         <label className="mb-1 block text-sm font-medium" htmlFor="email">
@@ -33,21 +77,34 @@ export default function LeadForm() {
           type="email"
           required
           className="w-full rounded border border-slate-300 px-3 py-2"
+          value={form.email}
+          onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
         />
       </div>
       <div>
         <label className="mb-1 block text-sm font-medium" htmlFor="message">
           How can we help?
         </label>
-        <textarea id="message" required rows={4} className="w-full rounded border border-slate-300 px-3 py-2" />
+        <textarea
+          id="message"
+          required
+          rows={4}
+          className="w-full rounded border border-slate-300 px-3 py-2"
+          value={form.message}
+          onChange={(event) => setForm((prev) => ({ ...prev, message: event.target.value }))}
+        />
       </div>
       <button
         type="submit"
-        className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+        disabled={isSubmitting}
+        className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-slate-400"
       >
-        Submit contact form
+        {isSubmitting ? "Submitting..." : "Submit contact form"}
       </button>
-      {submitted ? <p className="text-sm text-emerald-700">Thanks, our team will follow up within 1 business day.</p> : null}
+      {submitted ? (
+        <p className="text-sm text-emerald-700">Thanks, our team will follow up within 1 business day.</p>
+      ) : null}
+      {submitError ? <p className="text-sm text-red-700">{submitError}</p> : null}
     </form>
   );
 }


### PR DESCRIPTION
### Motivation
- Prevent silent lead loss by ensuring the contact form only shows success after lead data is actually delivered. 
- Add simple submit UX so users see loading and error states instead of an optimistic success.

### Description
- Updated `frontend/components/marketing/LeadForm.tsx` to use controlled inputs and add `isSubmitting`/`submitError` states, disable the submit button while sending, and only set the success state after a confirmed successful POST. 
- Emit the `lead_form_submit` tracking event only after the backend acknowledges delivery to avoid false-positive conversions. 
- Added a new Next.js route `frontend/app/api/leads/route.ts` that validates incoming payloads, requires `MARKETING_LEADS_WEBHOOK_URL`, forwards lead data (with `source` and `submitted_at_utc`) to the configured webhook, and returns appropriate HTTP errors when intake/delivery fails. 
- Files changed: `frontend/components/marketing/LeadForm.tsx` and `frontend/app/api/leads/route.ts`.

### Testing
- Ran `cd frontend && npm run lint`, which completed successfully with one pre-existing warning in `frontend/app/dashboard/page.tsx`. 
- Ran `cd frontend && npm run build`, which compiled and generated the routes (including `/api/leads`) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d27f9868208321a6182a0dddc65f31)