### PR TITLE
Add protocol state machine guards and persistence utilities

### DIFF
--- a/driver-app/src/store/protocolStore.ts
+++ b/driver-app/src/store/protocolStore.ts
@@ -1,0 +1,225 @@
+import {
+  DriverProtocolState,
+  INITIAL_PROTOCOL_CONTEXT,
+  INITIAL_PROTOCOL_SNAPSHOT,
+  hasMinimumSubmissionValidations,
+  IncidentDraftStatus,
+  PROTOCOL_PERSISTENCE_VERSION,
+  ProtocolContext,
+  ProtocolSnapshot,
+  UploadState,
+} from '../types/protocol';
+
+const TRANSITION_MAP: Readonly<Record<DriverProtocolState, DriverProtocolState[]>> = {
+  unauthenticated: ['authenticated'],
+  authenticated: ['incident_confirmed'],
+  incident_confirmed: ['incident_initiated'],
+  incident_initiated: ['evidence_collecting', 'submitted'],
+  evidence_collecting: ['submitted'],
+  submitted: [],
+};
+
+const DEFAULT_DRAFT_STATUS_BY_STATE: Readonly<
+  Record<DriverProtocolState, IncidentDraftStatus>
+> = {
+  unauthenticated: 'idle',
+  authenticated: 'idle',
+  incident_confirmed: 'idle',
+  incident_initiated: 'drafting',
+  evidence_collecting: 'drafting',
+  submitted: 'submitted',
+};
+
+const DEFAULT_UPLOAD_STATE_BY_STATE: Readonly<Record<DriverProtocolState, UploadState>> = {
+  unauthenticated: 'idle',
+  authenticated: 'idle',
+  incident_confirmed: 'idle',
+  incident_initiated: 'idle',
+  evidence_collecting: 'uploading',
+  submitted: 'uploaded',
+};
+
+type TransitionGuard = (snapshot: ProtocolSnapshot) => boolean;
+
+const TRANSITION_GUARDS: Partial<Record<DriverProtocolState, TransitionGuard>> = {
+  incident_confirmed: (snapshot) => snapshot.context.isAuthenticated,
+  incident_initiated: (snapshot) =>
+    snapshot.context.vehicleResolved && snapshot.context.safetyAcknowledged,
+  submitted: (snapshot) =>
+    hasMinimumSubmissionValidations(snapshot.context.submissionValidations),
+};
+
+function isTransitionListed(from: DriverProtocolState, to: DriverProtocolState): boolean {
+  return TRANSITION_MAP[from].includes(to);
+}
+
+export function canTransition(
+  snapshot: ProtocolSnapshot,
+  toState: DriverProtocolState,
+): boolean {
+  if (!isTransitionListed(snapshot.state, toState)) {
+    return false;
+  }
+
+  const guard = TRANSITION_GUARDS[toState];
+  return guard ? guard(snapshot) : true;
+}
+
+export function getAllowedTransitions(
+  snapshot: ProtocolSnapshot,
+): DriverProtocolState[] {
+  return TRANSITION_MAP[snapshot.state].filter((nextState) =>
+    canTransition(snapshot, nextState),
+  );
+}
+
+export function createProtocolSnapshot(
+  initial?: Partial<ProtocolSnapshot>,
+): ProtocolSnapshot {
+  const context: ProtocolContext = {
+    ...INITIAL_PROTOCOL_CONTEXT,
+    ...(initial?.context ?? {}),
+    submissionValidations: {
+      ...INITIAL_PROTOCOL_CONTEXT.submissionValidations,
+      ...(initial?.context?.submissionValidations ?? {}),
+    },
+  };
+
+  return {
+    ...INITIAL_PROTOCOL_SNAPSHOT,
+    ...initial,
+    context,
+    version: PROTOCOL_PERSISTENCE_VERSION,
+    updatedAt: initial?.updatedAt ?? new Date().toISOString(),
+  };
+}
+
+export function transitionProtocol(
+  snapshot: ProtocolSnapshot,
+  toState: DriverProtocolState,
+  contextPatch?: Partial<ProtocolContext>,
+): ProtocolSnapshot {
+  const candidate = createProtocolSnapshot({
+    ...snapshot,
+    context: {
+      ...snapshot.context,
+      ...(contextPatch ?? {}),
+      submissionValidations: {
+        ...snapshot.context.submissionValidations,
+        ...(contextPatch?.submissionValidations ?? {}),
+      },
+    },
+  });
+
+  if (!canTransition(candidate, toState)) {
+    throw new Error(
+      `Invalid protocol transition: ${candidate.state} -> ${toState}`,
+    );
+  }
+
+  return createProtocolSnapshot({
+    ...candidate,
+    state: toState,
+    incidentDraftStatus: DEFAULT_DRAFT_STATUS_BY_STATE[toState],
+    uploadState: DEFAULT_UPLOAD_STATE_BY_STATE[toState],
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+export function serializeProtocolSnapshot(snapshot: ProtocolSnapshot): string {
+  return JSON.stringify(createProtocolSnapshot(snapshot));
+}
+
+function isDriverProtocolState(value: unknown): value is DriverProtocolState {
+  return (
+    typeof value === 'string' &&
+    [
+      'unauthenticated',
+      'authenticated',
+      'incident_confirmed',
+      'incident_initiated',
+      'evidence_collecting',
+      'submitted',
+    ].includes(value)
+  );
+}
+
+function isIncidentDraftStatus(value: unknown): value is IncidentDraftStatus {
+  return (
+    typeof value === 'string' &&
+    ['idle', 'drafting', 'ready_for_submission', 'submitted'].includes(value)
+  );
+}
+
+function isUploadState(value: unknown): value is UploadState {
+  return (
+    typeof value === 'string' &&
+    ['idle', 'uploading', 'uploaded', 'failed'].includes(value)
+  );
+}
+
+export function deserializeProtocolSnapshot(payload: string): ProtocolSnapshot {
+  try {
+    const parsed = JSON.parse(payload) as Partial<ProtocolSnapshot>;
+    const candidate = createProtocolSnapshot(parsed);
+
+    if (!isDriverProtocolState(parsed.state)) {
+      return createProtocolSnapshot();
+    }
+
+    if (parsed.incidentDraftStatus && !isIncidentDraftStatus(parsed.incidentDraftStatus)) {
+      return createProtocolSnapshot();
+    }
+
+    if (parsed.uploadState && !isUploadState(parsed.uploadState)) {
+      return createProtocolSnapshot();
+    }
+
+    if (parsed.version !== PROTOCOL_PERSISTENCE_VERSION) {
+      return reconcilePersistedSnapshot(candidate);
+    }
+
+    return reconcilePersistedSnapshot(candidate);
+  } catch {
+    return createProtocolSnapshot();
+  }
+}
+
+export function reconcilePersistedSnapshot(
+  snapshot: ProtocolSnapshot,
+): ProtocolSnapshot {
+  let reconciled = createProtocolSnapshot(snapshot);
+
+  const progressionOrder: DriverProtocolState[] = [
+    'authenticated',
+    'incident_confirmed',
+    'incident_initiated',
+    'evidence_collecting',
+    'submitted',
+  ];
+
+  for (const state of progressionOrder) {
+    if (reconciled.state === state) {
+      const fallback = progressionOrder[progressionOrder.indexOf(state) - 1];
+      if (!fallback) {
+        return createProtocolSnapshot({
+          ...reconciled,
+          state: 'unauthenticated',
+          incidentDraftStatus: 'idle',
+          uploadState: 'idle',
+        });
+      }
+
+      if (!canTransition({ ...reconciled, state: fallback }, state)) {
+        return createProtocolSnapshot({
+          ...reconciled,
+          state: fallback,
+          incidentDraftStatus: DEFAULT_DRAFT_STATUS_BY_STATE[fallback],
+          uploadState: DEFAULT_UPLOAD_STATE_BY_STATE[fallback],
+        });
+      }
+    }
+  }
+
+  return reconciled;
+}

--- a/driver-app/src/types/protocol.ts
+++ b/driver-app/src/types/protocol.ts
@@ -1,0 +1,73 @@
+export type DriverProtocolState =
+  | 'unauthenticated'
+  | 'authenticated'
+  | 'incident_confirmed'
+  | 'incident_initiated'
+  | 'evidence_collecting'
+  | 'submitted';
+
+export type IncidentDraftStatus =
+  | 'idle'
+  | 'drafting'
+  | 'ready_for_submission'
+  | 'submitted';
+
+export type UploadState =
+  | 'idle'
+  | 'uploading'
+  | 'uploaded'
+  | 'failed';
+
+export type SubmissionValidations = {
+  hasIncidentType: boolean;
+  hasDescription: boolean;
+  hasMedia: boolean;
+};
+
+export type ProtocolContext = {
+  isAuthenticated: boolean;
+  vehicleResolved: boolean;
+  safetyAcknowledged: boolean;
+  submissionValidations: SubmissionValidations;
+};
+
+export type ProtocolSnapshot = {
+  state: DriverProtocolState;
+  incidentDraftStatus: IncidentDraftStatus;
+  uploadState: UploadState;
+  context: ProtocolContext;
+  updatedAt: string;
+  version: 1;
+};
+
+export const PROTOCOL_PERSISTENCE_VERSION = 1 as const;
+
+export const INITIAL_PROTOCOL_CONTEXT: ProtocolContext = {
+  isAuthenticated: false,
+  vehicleResolved: false,
+  safetyAcknowledged: false,
+  submissionValidations: {
+    hasIncidentType: false,
+    hasDescription: false,
+    hasMedia: false,
+  },
+};
+
+export const INITIAL_PROTOCOL_SNAPSHOT: ProtocolSnapshot = {
+  state: 'unauthenticated',
+  incidentDraftStatus: 'idle',
+  uploadState: 'idle',
+  context: INITIAL_PROTOCOL_CONTEXT,
+  updatedAt: new Date(0).toISOString(),
+  version: PROTOCOL_PERSISTENCE_VERSION,
+};
+
+export const MINIMUM_SUBMISSION_VALIDATION_KEYS: ReadonlyArray<
+  keyof SubmissionValidations
+> = ['hasIncidentType', 'hasDescription', 'hasMedia'];
+
+export function hasMinimumSubmissionValidations(
+  validations: SubmissionValidations,
+): boolean {
+  return MINIMUM_SUBMISSION_VALIDATION_KEYS.every((key) => validations[key]);
+}


### PR DESCRIPTION
### Motivation
- Enforce a strict protocol state machine so UI screens cannot mutate driver protocol state arbitrarily.  
- Provide explicit guards for required transitions to prevent invalid flows (authentication, vehicle/safety, submission validation).  
- Support local persistence and safe resume by serializing snapshots and reconciling persisted state against current rules and versions.  

### Description
- Add shared types and defaults in `driver-app/src/types/protocol.ts`, including `DriverProtocolState`, `IncidentDraftStatus`, `UploadState`, `ProtocolContext`, `ProtocolSnapshot`, and `hasMinimumSubmissionValidations`.  
- Implement a transition map and guarded state machine in `driver-app/src/store/protocolStore.ts` with helper APIs `canTransition`, `getAllowedTransitions`, and `transitionProtocol`.  
- Add explicit transition guards: `incident_confirmed` requires `isAuthenticated`, `incident_initiated` requires `vehicleResolved && safetyAcknowledged`, and `submitted` requires minimum submission validations.  
- Add persistence helpers `serializeProtocolSnapshot`, `deserializeProtocolSnapshot`, and `reconcilePersistedSnapshot` with runtime validation and versioned fallback behavior, plus default mappings for draft/upload states.  

### Testing
- Ran the project validation commands: `cd driver-app && npm run lint --if-present && npm test --if-present && npx tsc --noEmit`.  
- All automated checks completed successfully (TypeScript compilation and test/lint commands exited without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d28a57d7e08321ba5e98c9c9957a9a)