### PR TITLE
Add guarded incident protocol stack routes

### DIFF
--- a/driver-app/App.tsx
+++ b/driver-app/App.tsx
@@ -6,11 +6,23 @@ import { ActivityIndicator, PaperProvider } from 'react-native-paper';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { getStoredToken } from './src/auth';
+import { ProtocolFlowProvider } from './src/navigation/ProtocolFlowContext';
 import { RootStackParamList } from './src/navigation/types';
 import DriverHomeScreen from './src/screens/DriverHomeScreen';
+import IncidentConfirmScreen from './src/screens/IncidentConfirmScreen';
+import IncidentStartLoadingScreen from './src/screens/IncidentStartLoadingScreen';
+import IncidentStatusScreen from './src/screens/IncidentStatusScreen';
+import InstructionStepScreen from './src/screens/InstructionStepScreen';
+import MediaCaptureScreen from './src/screens/MediaCaptureScreen';
+import NarrativeScreen from './src/screens/NarrativeScreen';
 import OtpEntryScreen from './src/screens/OtpEntryScreen';
 import PhoneEntryScreen from './src/screens/PhoneEntryScreen';
 import QrScanScreen from './src/screens/QrScanScreen';
+import ReviewSubmitScreen from './src/screens/ReviewSubmitScreen';
+import SafetyGateScreen from './src/screens/SafetyGateScreen';
+import SceneFactsScreen from './src/screens/SceneFactsScreen';
+import ThirdPartyInfoScreen from './src/screens/ThirdPartyInfoScreen';
+import VehicleConfirmScreen from './src/screens/VehicleConfirmScreen';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -39,30 +51,87 @@ export default function App() {
   return (
     <PaperProvider>
       <SafeAreaProvider>
-        <NavigationContainer>
-          <Stack.Navigator initialRouteName={initialRoute}>
-            <Stack.Screen
-              name="PhoneEntry"
-              component={PhoneEntryScreen}
-              options={{ title: 'Driver Sign In' }}
-            />
-            <Stack.Screen
-              name="OtpEntry"
-              component={OtpEntryScreen}
-              options={{ title: 'Verify OTP' }}
-            />
-            <Stack.Screen
-              name="DriverHome"
-              component={DriverHomeScreen}
-              options={{ title: 'Driver Home' }}
-            />
-            <Stack.Screen
-              name="QrScan"
-              component={QrScanScreen}
-              options={{ title: 'Scan QR' }}
-            />
-          </Stack.Navigator>
-        </NavigationContainer>
+        <ProtocolFlowProvider>
+          <NavigationContainer>
+            <Stack.Navigator initialRouteName={initialRoute}>
+              <Stack.Screen
+                name="PhoneEntry"
+                component={PhoneEntryScreen}
+                options={{ title: 'Driver Sign In' }}
+              />
+              <Stack.Screen
+                name="OtpEntry"
+                component={OtpEntryScreen}
+                options={{ title: 'Verify OTP' }}
+              />
+              <Stack.Screen
+                name="DriverHome"
+                component={DriverHomeScreen}
+                options={{ title: 'Driver Home' }}
+              />
+              <Stack.Screen
+                name="IncidentConfirm"
+                component={IncidentConfirmScreen}
+                options={{ title: 'Incident Confirmation' }}
+              />
+              <Stack.Screen
+                name="VehicleConfirm"
+                component={VehicleConfirmScreen}
+                options={{ title: 'Vehicle Confirmation' }}
+              />
+              <Stack.Screen
+                name="SafetyGate"
+                component={SafetyGateScreen}
+                options={{ title: 'Safety Gate' }}
+              />
+              <Stack.Screen
+                name="IncidentStartLoading"
+                component={IncidentStartLoadingScreen}
+                options={{ title: 'Loading Incident' }}
+              />
+              <Stack.Screen
+                name="InstructionStep"
+                component={InstructionStepScreen}
+                options={{ title: 'Instruction Step' }}
+              />
+              <Stack.Screen
+                name="SceneFacts"
+                component={SceneFactsScreen}
+                options={{ title: 'Scene Facts' }}
+              />
+              <Stack.Screen
+                name="ThirdPartyInfo"
+                component={ThirdPartyInfoScreen}
+                options={{ title: 'Third Party Info' }}
+              />
+              <Stack.Screen
+                name="MediaCapture"
+                component={MediaCaptureScreen}
+                options={{ title: 'Media Capture' }}
+              />
+              <Stack.Screen
+                name="Narrative"
+                component={NarrativeScreen}
+                options={{ title: 'Narrative' }}
+              />
+              <Stack.Screen
+                name="ReviewSubmit"
+                component={ReviewSubmitScreen}
+                options={{ title: 'Review & Submit' }}
+              />
+              <Stack.Screen
+                name="IncidentStatus"
+                component={IncidentStatusScreen}
+                options={{ title: 'Incident Status' }}
+              />
+              <Stack.Screen
+                name="QrScan"
+                component={QrScanScreen}
+                options={{ title: 'Scan QR' }}
+              />
+            </Stack.Navigator>
+          </NavigationContainer>
+        </ProtocolFlowProvider>
       </SafeAreaProvider>
     </PaperProvider>
   );

--- a/driver-app/src/navigation/ProtocolFlowContext.tsx
+++ b/driver-app/src/navigation/ProtocolFlowContext.tsx
@@ -1,0 +1,55 @@
+import { ReactNode, createContext, useContext, useMemo, useState } from 'react';
+
+import { ProtocolRouteName } from './protocolFlow';
+
+type ProtocolFlowContextValue = {
+  completedRoutes: Set<ProtocolRouteName>;
+  startProtocol: () => void;
+  completeRoute: (routeName: ProtocolRouteName) => void;
+  resetProtocol: () => void;
+};
+
+const ProtocolFlowContext = createContext<ProtocolFlowContextValue | undefined>(
+  undefined,
+);
+
+export function ProtocolFlowProvider({ children }: { children: ReactNode }) {
+  const [completedRoutes, setCompletedRoutes] = useState<Set<ProtocolRouteName>>(
+    new Set(),
+  );
+
+  const value = useMemo<ProtocolFlowContextValue>(
+    () => ({
+      completedRoutes,
+      startProtocol: () => {
+        setCompletedRoutes(new Set());
+      },
+      completeRoute: (routeName) => {
+        setCompletedRoutes((previous) => {
+          const updated = new Set(previous);
+          updated.add(routeName);
+          return updated;
+        });
+      },
+      resetProtocol: () => {
+        setCompletedRoutes(new Set());
+      },
+    }),
+    [completedRoutes],
+  );
+
+  return (
+    <ProtocolFlowContext.Provider value={value}>
+      {children}
+    </ProtocolFlowContext.Provider>
+  );
+}
+
+export function useProtocolFlow() {
+  const context = useContext(ProtocolFlowContext);
+  if (!context) {
+    throw new Error('useProtocolFlow must be used within ProtocolFlowProvider.');
+  }
+
+  return context;
+}

--- a/driver-app/src/navigation/protocolFlow.ts
+++ b/driver-app/src/navigation/protocolFlow.ts
@@ -1,0 +1,40 @@
+export const PROTOCOL_ROUTE_ORDER = [
+  'IncidentConfirm',
+  'VehicleConfirm',
+  'SafetyGate',
+  'IncidentStartLoading',
+  'InstructionStep',
+  'SceneFacts',
+  'ThirdPartyInfo',
+  'MediaCapture',
+  'Narrative',
+  'ReviewSubmit',
+  'IncidentStatus',
+] as const;
+
+export type ProtocolRouteName = (typeof PROTOCOL_ROUTE_ORDER)[number];
+
+export const getProtocolPrerequisites = (
+  routeName: ProtocolRouteName,
+): ProtocolRouteName[] => {
+  const routeIndex = PROTOCOL_ROUTE_ORDER.indexOf(routeName);
+  return routeIndex <= 0 ? [] : [...PROTOCOL_ROUTE_ORDER.slice(0, routeIndex)];
+};
+
+export const getFirstIncompleteRoute = (
+  completedRoutes: Set<ProtocolRouteName>,
+): ProtocolRouteName => {
+  return (
+    PROTOCOL_ROUTE_ORDER.find((routeName) => !completedRoutes.has(routeName)) ??
+    PROTOCOL_ROUTE_ORDER[PROTOCOL_ROUTE_ORDER.length - 1]
+  );
+};
+
+export const canAccessProtocolRoute = (
+  routeName: ProtocolRouteName,
+  completedRoutes: Set<ProtocolRouteName>,
+): boolean => {
+  return getProtocolPrerequisites(routeName).every((route) =>
+    completedRoutes.has(route),
+  );
+};

--- a/driver-app/src/navigation/types.ts
+++ b/driver-app/src/navigation/types.ts
@@ -3,4 +3,15 @@ export type RootStackParamList = {
   OtpEntry: { phoneE164: string };
   DriverHome: undefined;
   QrScan: undefined;
+  IncidentConfirm: undefined;
+  VehicleConfirm: undefined;
+  SafetyGate: undefined;
+  IncidentStartLoading: undefined;
+  InstructionStep: undefined;
+  SceneFacts: undefined;
+  ThirdPartyInfo: undefined;
+  MediaCapture: undefined;
+  Narrative: undefined;
+  ReviewSubmit: undefined;
+  IncidentStatus: undefined;
 };

--- a/driver-app/src/navigation/useProtocolRouteGuard.ts
+++ b/driver-app/src/navigation/useProtocolRouteGuard.ts
@@ -1,0 +1,33 @@
+import { useCallback } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
+
+import {
+  canAccessProtocolRoute,
+  getFirstIncompleteRoute,
+  ProtocolRouteName,
+} from './protocolFlow';
+import { useProtocolFlow } from './ProtocolFlowContext';
+
+type ProtocolGuardNavigation = {
+  replace: (routeName: ProtocolRouteName) => void;
+};
+
+export function useProtocolRouteGuard(
+  routeName: ProtocolRouteName,
+  navigation: ProtocolGuardNavigation,
+) {
+  const { completedRoutes } = useProtocolFlow();
+
+  useFocusEffect(
+    useCallback(() => {
+      if (canAccessProtocolRoute(routeName, completedRoutes)) {
+        return;
+      }
+
+      const firstIncompleteRoute = getFirstIncompleteRoute(completedRoutes);
+      if (firstIncompleteRoute !== routeName) {
+        navigation.replace(firstIncompleteRoute);
+      }
+    }, [completedRoutes, navigation, routeName]),
+  );
+}

--- a/driver-app/src/screens/DriverHomeScreen.tsx
+++ b/driver-app/src/screens/DriverHomeScreen.tsx
@@ -1,16 +1,18 @@
 import { useCallback, useState } from 'react';
-import { Alert, ScrollView, StyleSheet, View } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { Button, Card, HelperText, Text } from 'react-native-paper';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useFocusEffect } from '@react-navigation/native';
 
 import { DriverMeResponse, getDriverMe } from '../api';
 import { RootStackParamList } from '../navigation/types';
+import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'DriverHome'>;
 
 export default function DriverHomeScreen({ navigation }: Props) {
   const [driver, setDriver] = useState<DriverMeResponse | null>(null);
+  const { startProtocol } = useProtocolFlow();
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -52,7 +54,10 @@ export default function DriverHomeScreen({ navigation }: Props) {
       {error ? <HelperText type="error">{error}</HelperText> : null}
       <Button
         mode="contained"
-        onPress={() => Alert.alert('Incident Protocol', 'Starting soon.')}
+        onPress={() => {
+          startProtocol();
+          navigation.navigate('IncidentConfirm');
+        }}
         loading={isLoading}
         disabled={isLoading}
         style={styles.button}

--- a/driver-app/src/screens/IncidentConfirmScreen.tsx
+++ b/driver-app/src/screens/IncidentConfirmScreen.tsx
@@ -1,0 +1,27 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
+import { RootStackParamList } from '../navigation/types';
+import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import ProtocolStepScreen from './ProtocolStepScreen';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'IncidentConfirm'>;
+
+export default function IncidentConfirmScreen({ navigation }: Props) {
+  const { completeRoute } = useProtocolFlow();
+  useProtocolRouteGuard('IncidentConfirm', navigation);
+
+  return (
+    <ProtocolStepScreen
+      title="Confirm Incident"
+      description="Verify this incident is valid and should enter the protocol workflow."
+      continueLabel="Confirm incident"
+      onContinue={() => {
+        completeRoute('IncidentConfirm');
+        navigation.navigate('VehicleConfirm');
+      }}
+      backLabel="Back to home"
+      onBack={() => navigation.navigate('DriverHome')}
+    />
+  );
+}

--- a/driver-app/src/screens/IncidentStartLoadingScreen.tsx
+++ b/driver-app/src/screens/IncidentStartLoadingScreen.tsx
@@ -1,0 +1,26 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
+import { RootStackParamList } from '../navigation/types';
+import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import ProtocolStepScreen from './ProtocolStepScreen';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'IncidentStartLoading'>;
+
+export default function IncidentStartLoadingScreen({ navigation }: Props) {
+  const { completeRoute } = useProtocolFlow();
+  useProtocolRouteGuard('IncidentStartLoading', navigation);
+
+  return (
+    <ProtocolStepScreen
+      title="Start Incident Loading"
+      description="Prepare protocol instructions and wait for loading to complete."
+      continueLabel="Continue"
+      onContinue={() => {
+        completeRoute('IncidentStartLoading');
+        navigation.navigate('InstructionStep');
+      }}
+      onBack={() => navigation.goBack()}
+    />
+  );
+}

--- a/driver-app/src/screens/IncidentStatusScreen.tsx
+++ b/driver-app/src/screens/IncidentStatusScreen.tsx
@@ -1,0 +1,27 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
+import { RootStackParamList } from '../navigation/types';
+import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import ProtocolStepScreen from './ProtocolStepScreen';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'IncidentStatus'>;
+
+export default function IncidentStatusScreen({ navigation }: Props) {
+  const { completeRoute, resetProtocol } = useProtocolFlow();
+  useProtocolRouteGuard('IncidentStatus', navigation);
+
+  return (
+    <ProtocolStepScreen
+      title="Incident Status"
+      description="Your incident has been submitted. Return to home for the next task."
+      continueLabel="Return to home"
+      onContinue={() => {
+        completeRoute('IncidentStatus');
+        resetProtocol();
+        navigation.reset({ index: 0, routes: [{ name: 'DriverHome' }] });
+      }}
+      onBack={() => navigation.goBack()}
+    />
+  );
+}

--- a/driver-app/src/screens/InstructionStepScreen.tsx
+++ b/driver-app/src/screens/InstructionStepScreen.tsx
@@ -1,0 +1,26 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
+import { RootStackParamList } from '../navigation/types';
+import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import ProtocolStepScreen from './ProtocolStepScreen';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'InstructionStep'>;
+
+export default function InstructionStepScreen({ navigation }: Props) {
+  const { completeRoute } = useProtocolFlow();
+  useProtocolRouteGuard('InstructionStep', navigation);
+
+  return (
+    <ProtocolStepScreen
+      title="Instruction Step"
+      description="Follow the dispatch instruction and confirm completion."
+      continueLabel="Instruction complete"
+      onContinue={() => {
+        completeRoute('InstructionStep');
+        navigation.navigate('SceneFacts');
+      }}
+      onBack={() => navigation.goBack()}
+    />
+  );
+}

--- a/driver-app/src/screens/MediaCaptureScreen.tsx
+++ b/driver-app/src/screens/MediaCaptureScreen.tsx
@@ -1,0 +1,26 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
+import { RootStackParamList } from '../navigation/types';
+import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import ProtocolStepScreen from './ProtocolStepScreen';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'MediaCapture'>;
+
+export default function MediaCaptureScreen({ navigation }: Props) {
+  const { completeRoute } = useProtocolFlow();
+  useProtocolRouteGuard('MediaCapture', navigation);
+
+  return (
+    <ProtocolStepScreen
+      title="Media Capture"
+      description="Capture photos and videos before writing the incident narrative."
+      continueLabel="Media captured"
+      onContinue={() => {
+        completeRoute('MediaCapture');
+        navigation.navigate('Narrative');
+      }}
+      onBack={() => navigation.goBack()}
+    />
+  );
+}

--- a/driver-app/src/screens/NarrativeScreen.tsx
+++ b/driver-app/src/screens/NarrativeScreen.tsx
@@ -1,0 +1,26 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
+import { RootStackParamList } from '../navigation/types';
+import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import ProtocolStepScreen from './ProtocolStepScreen';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Narrative'>;
+
+export default function NarrativeScreen({ navigation }: Props) {
+  const { completeRoute } = useProtocolFlow();
+  useProtocolRouteGuard('Narrative', navigation);
+
+  return (
+    <ProtocolStepScreen
+      title="Narrative"
+      description="Provide your narrative summary before final review and submission."
+      continueLabel="Narrative complete"
+      onContinue={() => {
+        completeRoute('Narrative');
+        navigation.navigate('ReviewSubmit');
+      }}
+      onBack={() => navigation.goBack()}
+    />
+  );
+}

--- a/driver-app/src/screens/ProtocolStepScreen.tsx
+++ b/driver-app/src/screens/ProtocolStepScreen.tsx
@@ -1,0 +1,60 @@
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { Button, Text } from 'react-native-paper';
+
+type ProtocolStepScreenProps = {
+  title: string;
+  description: string;
+  continueLabel: string;
+  onContinue: () => void;
+  backLabel?: string;
+  onBack?: () => void;
+};
+
+export default function ProtocolStepScreen({
+  title,
+  description,
+  continueLabel,
+  onContinue,
+  backLabel,
+  onBack,
+}: ProtocolStepScreenProps) {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.content}>
+        <Text variant="headlineMedium">{title}</Text>
+        <Text variant="bodyLarge" style={styles.description}>
+          {description}
+        </Text>
+      </View>
+
+      <View style={styles.actions}>
+        {onBack ? (
+          <Button mode="outlined" onPress={onBack}>
+            {backLabel ?? 'Back'}
+          </Button>
+        ) : null}
+        <Button mode="contained" onPress={onContinue}>
+          {continueLabel}
+        </Button>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    justifyContent: 'space-between',
+    padding: 24,
+    gap: 24,
+  },
+  content: {
+    gap: 12,
+  },
+  description: {
+    color: '#5f6b7a',
+  },
+  actions: {
+    gap: 12,
+  },
+});

--- a/driver-app/src/screens/ReviewSubmitScreen.tsx
+++ b/driver-app/src/screens/ReviewSubmitScreen.tsx
@@ -1,0 +1,26 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
+import { RootStackParamList } from '../navigation/types';
+import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import ProtocolStepScreen from './ProtocolStepScreen';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ReviewSubmit'>;
+
+export default function ReviewSubmitScreen({ navigation }: Props) {
+  const { completeRoute } = useProtocolFlow();
+  useProtocolRouteGuard('ReviewSubmit', navigation);
+
+  return (
+    <ProtocolStepScreen
+      title="Review & Submit"
+      description="Review all protocol details and submit the incident packet."
+      continueLabel="Submit incident"
+      onContinue={() => {
+        completeRoute('ReviewSubmit');
+        navigation.navigate('IncidentStatus');
+      }}
+      onBack={() => navigation.goBack()}
+    />
+  );
+}

--- a/driver-app/src/screens/SafetyGateScreen.tsx
+++ b/driver-app/src/screens/SafetyGateScreen.tsx
@@ -1,0 +1,26 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
+import { RootStackParamList } from '../navigation/types';
+import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import ProtocolStepScreen from './ProtocolStepScreen';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'SafetyGate'>;
+
+export default function SafetyGateScreen({ navigation }: Props) {
+  const { completeRoute } = useProtocolFlow();
+  useProtocolRouteGuard('SafetyGate', navigation);
+
+  return (
+    <ProtocolStepScreen
+      title="Safety Gate"
+      description="Complete the immediate safety checklist before loading incident steps."
+      continueLabel="Safety check complete"
+      onContinue={() => {
+        completeRoute('SafetyGate');
+        navigation.navigate('IncidentStartLoading');
+      }}
+      onBack={() => navigation.goBack()}
+    />
+  );
+}

--- a/driver-app/src/screens/SceneFactsScreen.tsx
+++ b/driver-app/src/screens/SceneFactsScreen.tsx
@@ -1,0 +1,26 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
+import { RootStackParamList } from '../navigation/types';
+import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import ProtocolStepScreen from './ProtocolStepScreen';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'SceneFacts'>;
+
+export default function SceneFactsScreen({ navigation }: Props) {
+  const { completeRoute } = useProtocolFlow();
+  useProtocolRouteGuard('SceneFacts', navigation);
+
+  return (
+    <ProtocolStepScreen
+      title="Scene Facts"
+      description="Capture key facts from the scene before collecting third-party details."
+      continueLabel="Facts recorded"
+      onContinue={() => {
+        completeRoute('SceneFacts');
+        navigation.navigate('ThirdPartyInfo');
+      }}
+      onBack={() => navigation.goBack()}
+    />
+  );
+}

--- a/driver-app/src/screens/ThirdPartyInfoScreen.tsx
+++ b/driver-app/src/screens/ThirdPartyInfoScreen.tsx
@@ -1,0 +1,26 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
+import { RootStackParamList } from '../navigation/types';
+import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import ProtocolStepScreen from './ProtocolStepScreen';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ThirdPartyInfo'>;
+
+export default function ThirdPartyInfoScreen({ navigation }: Props) {
+  const { completeRoute } = useProtocolFlow();
+  useProtocolRouteGuard('ThirdPartyInfo', navigation);
+
+  return (
+    <ProtocolStepScreen
+      title="Third Party Info"
+      description="Collect details for involved third parties before media capture."
+      continueLabel="Third-party info saved"
+      onContinue={() => {
+        completeRoute('ThirdPartyInfo');
+        navigation.navigate('MediaCapture');
+      }}
+      onBack={() => navigation.goBack()}
+    />
+  );
+}

--- a/driver-app/src/screens/VehicleConfirmScreen.tsx
+++ b/driver-app/src/screens/VehicleConfirmScreen.tsx
@@ -1,0 +1,26 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
+import { RootStackParamList } from '../navigation/types';
+import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import ProtocolStepScreen from './ProtocolStepScreen';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'VehicleConfirm'>;
+
+export default function VehicleConfirmScreen({ navigation }: Props) {
+  const { completeRoute } = useProtocolFlow();
+  useProtocolRouteGuard('VehicleConfirm', navigation);
+
+  return (
+    <ProtocolStepScreen
+      title="Confirm Vehicle"
+      description="Confirm you are reporting for the correct vehicle before continuing."
+      continueLabel="Vehicle confirmed"
+      onContinue={() => {
+        completeRoute('VehicleConfirm');
+        navigation.navigate('SafetyGate');
+      }}
+      onBack={() => navigation.goBack()}
+    />
+  );
+}


### PR DESCRIPTION
### Motivation
- Introduce the end-to-end incident protocol flow (from `IncidentConfirm` through `IncidentStatus`) and ensure users can only progress when prerequisites are satisfied.
- Provide a shared, lightweight scaffold for protocol steps and a centralized way to track completion state so navigation guards can redirect users to the correct step.

### Description
- Add route ordering and helpers in `src/navigation/protocolFlow.ts` and a `ProtocolFlowProvider` with `useProtocolFlow` state in `src/navigation/ProtocolFlowContext.tsx` to track completed steps.
- Implement a route-guard hook `useProtocolRouteGuard` in `src/navigation/useProtocolRouteGuard.ts` that redirects to the earliest incomplete protocol route when prerequisites are not met.
- Register the full protocol stack and wrap the app with `ProtocolFlowProvider` in `App.tsx`, and extend `src/navigation/types.ts` with the new route names.
- Add a shared `ProtocolStepScreen` scaffold and concrete screens for each protocol stage under `src/screens/*`, and update `DriverHomeScreen` to call `startProtocol()` and navigate into the flow.

### Testing
- Ran TypeScript check with `npx tsc --noEmit`, which succeeded.
- Attempted `npm run -s test`, which failed because no `test` script is defined in `driver-app/package.json`.
- Attempted linting with `npx expo lint`, which failed in this environment due to network fetch/auto-config issues during Expo's ESLint setup.
- `npm run -s lint` also did not run because no `lint` script is defined in `driver-app/package.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d28c0f36488321ade908a63f99d1f6)