### PR TITLE
Driver home: fetch active incident and add resume/start decision flow

### DIFF
--- a/driver-app/src/api.ts
+++ b/driver-app/src/api.ts
@@ -7,6 +7,16 @@ type ApiError = {
   detail?: string;
 };
 
+export class ApiRequestError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'ApiRequestError';
+    this.status = status;
+  }
+}
+
 export type DriverMeResponse = {
   driver_id: string;
   org_id: string;
@@ -25,6 +35,14 @@ export type ResolveQrResponse = {
 
 export type VerifyOtpResponse = {
   access_token: string;
+};
+
+export type DriverActiveIncidentResponse = {
+  incident_id: string;
+  status: string;
+  created_at?: string;
+  updated_at?: string;
+  adc_vehicle_id?: string | null;
 };
 
 const request = async <T>(
@@ -57,11 +75,12 @@ const request = async <T>(
   }
 
   if (!response.ok) {
+    const apiDetail = (data as ApiError).detail;
     const errorMessage =
-      typeof (data as ApiError).detail === 'string'
-        ? (data as ApiError).detail
-        : response.statusText;
-    throw new Error(errorMessage);
+      typeof apiDetail === 'string'
+        ? apiDetail
+        : response.statusText || 'Request failed';
+    throw new ApiRequestError(errorMessage, response.status);
   }
 
   return data as T;
@@ -80,6 +99,21 @@ export const verifyOtp = (phoneE164: string, otpCode: string) =>
   });
 
 export const getDriverMe = () => request<DriverMeResponse>('/driver/me', {}, true);
+
+export const getDriverActiveIncident = async () => {
+  try {
+    return await request<DriverActiveIncidentResponse>(
+      '/driver/incidents/active',
+      {},
+      true,
+    );
+  } catch (error) {
+    if (error instanceof ApiRequestError && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+};
 
 export const resolveQr = (qrToken: string) =>
   request<ResolveQrResponse>(

--- a/driver-app/src/screens/DriverHomeScreen.tsx
+++ b/driver-app/src/screens/DriverHomeScreen.tsx
@@ -1,10 +1,15 @@
 import { useCallback, useState } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { Alert, ScrollView, StyleSheet, View } from 'react-native';
 import { Button, Card, HelperText, Text } from 'react-native-paper';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useFocusEffect } from '@react-navigation/native';
 
-import { DriverMeResponse, getDriverMe } from '../api';
+import {
+  DriverActiveIncidentResponse,
+  DriverMeResponse,
+  getDriverActiveIncident,
+  getDriverMe,
+} from '../api';
 import { RootStackParamList } from '../navigation/types';
 import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
 
@@ -12,18 +17,24 @@ type Props = NativeStackScreenProps<RootStackParamList, 'DriverHome'>;
 
 export default function DriverHomeScreen({ navigation }: Props) {
   const [driver, setDriver] = useState<DriverMeResponse | null>(null);
+  const [activeIncident, setActiveIncident] =
+    useState<DriverActiveIncidentResponse | null>(null);
   const { startProtocol } = useProtocolFlow();
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
-  const loadDriver = useCallback(async () => {
+  const loadHomeData = useCallback(async () => {
     setIsLoading(true);
     setError(null);
     try {
-      const response = await getDriverMe();
-      setDriver(response);
+      const [driverResponse, activeIncidentResponse] = await Promise.all([
+        getDriverMe(),
+        getDriverActiveIncident(),
+      ]);
+      setDriver(driverResponse);
+      setActiveIncident(activeIncidentResponse);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unable to load profile.');
+      setError(err instanceof Error ? err.message : 'Unable to load home data.');
     } finally {
       setIsLoading(false);
     }
@@ -31,11 +42,40 @@ export default function DriverHomeScreen({ navigation }: Props) {
 
   useFocusEffect(
     useCallback(() => {
-      loadDriver();
-    }, [loadDriver]),
+      loadHomeData();
+    }, [loadHomeData]),
   );
 
   const vehicleLabel = driver?.vehicle?.display_label ?? 'Unassigned';
+  const canResumeIncident = activeIncident?.incident_id != null;
+  const startNewIncidentProtocol = () => {
+    startProtocol();
+    navigation.navigate('IncidentConfirm');
+  };
+
+  const handleStartIncidentProtocol = () => {
+    if (!canResumeIncident) {
+      startNewIncidentProtocol();
+      return;
+    }
+
+    Alert.alert(
+      'Active incident in progress',
+      'You have an active incident. Resume it to avoid duplicate submissions, or continue to start a new incident protocol.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Resume incident',
+          onPress: () => navigation.navigate('IncidentStatus'),
+        },
+        {
+          text: 'Start new',
+          style: 'destructive',
+          onPress: startNewIncidentProtocol,
+        },
+      ],
+    );
+  };
 
   return (
     <ScrollView contentContainerStyle={styles.container}>
@@ -54,10 +94,7 @@ export default function DriverHomeScreen({ navigation }: Props) {
       {error ? <HelperText type="error">{error}</HelperText> : null}
       <Button
         mode="contained"
-        onPress={() => {
-          startProtocol();
-          navigation.navigate('IncidentConfirm');
-        }}
+        onPress={handleStartIncidentProtocol}
         loading={isLoading}
         disabled={isLoading}
         style={styles.button}
@@ -69,8 +106,25 @@ export default function DriverHomeScreen({ navigation }: Props) {
         onPress={() => navigation.navigate('QrScan')}
         style={styles.button}
       >
-        Scan QR override
+        Scan Vehicle QR
       </Button>
+      {canResumeIncident ? (
+        <Card style={styles.card}>
+          <Card.Title title="Resume Incident" />
+          <Card.Content style={styles.resumeContent}>
+            <Text variant="bodyMedium">
+              Incident #{activeIncident?.incident_id} is currently {activeIncident?.status}.
+            </Text>
+            <Button
+              mode="contained-tonal"
+              style={styles.resumeButton}
+              onPress={() => navigation.navigate('IncidentStatus')}
+            >
+              Resume Incident
+            </Button>
+          </Card.Content>
+        </Card>
+      ) : null}
     </ScrollView>
   );
 }
@@ -92,5 +146,11 @@ const styles = StyleSheet.create({
   },
   button: {
     marginTop: 8,
+  },
+  resumeContent: {
+    gap: 12,
+  },
+  resumeButton: {
+    alignSelf: 'flex-start',
   },
 });


### PR DESCRIPTION
### Motivation
- Surface driver identity and assigned vehicle info while also detecting any in-progress incident to prevent duplicate submissions.
- Provide a clear decision path for drivers to either resume an active incident or intentionally start a new protocol.
- Make the API layer handle `404` from the active-incident endpoint as “no active incident” so the UI can treat that case explicitly.

### Description
- UI: Update `DriverHomeScreen` to load both `GET /driver/me` and `GET /driver/incidents/active` on focus and render driver identity and current vehicle summary.
- UI: Add a conditional "Resume Incident" card when an active incident exists and change the QR action label to `Scan Vehicle QR`.
- UI: Add start decision prompt using `Alert.alert` so when an active incident exists the driver can `Resume incident` (navigates to `IncidentStatus`) or `Start new` (starts protocol and navigates to `IncidentConfirm`).
- API: Add `ApiRequestError` class, `DriverActiveIncidentResponse` type, and `getDriverActiveIncident()` in `driver-app/src/api.ts`, with `404` mapped to `null` to indicate no active incident.

### Testing
- Ran TypeScript compile check: `cd driver-app && npx tsc --noEmit` and it completed successfully.
- Attempted lint: `cd driver-app && npm run lint` but it failed because there is no `lint` script defined in `driver-app/package.json`.
- Attempted tests: `cd driver-app && npm test` but it failed because there is no `test` script defined in `driver-app/package.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2a0a055e88321b2f8aeab28560ea9)