### PR TITLE
Vehicle resolution flow: assigned vehicle + QR integration

### DIFF
--- a/driver-app/src/navigation/ProtocolFlowContext.tsx
+++ b/driver-app/src/navigation/ProtocolFlowContext.tsx
@@ -1,15 +1,26 @@
 import { ReactNode, createContext, useContext, useMemo, useState } from 'react';
 
+import { INITIAL_PROTOCOL_CONTEXT } from '../types/protocol';
 import { transitionProtocol } from '../store/protocolStore';
-import { DriverProtocolState } from '../types/protocol';
+import {
+  DriverProtocolState,
+  ProtocolContext,
+  VehicleResolutionMethod,
+} from '../types/protocol';
 import { ProtocolRouteName } from './protocolFlow';
 
 type ProtocolFlowContextValue = {
   completedRoutes: Set<ProtocolRouteName>;
   workflowState: DriverProtocolState;
+  protocolContext: ProtocolContext;
   startProtocol: () => void;
   completeRoute: (routeName: ProtocolRouteName) => void;
   transitionWorkflow: (toState: DriverProtocolState) => void;
+  resolveVehicle: (payload: {
+    vehicleId: string;
+    method: VehicleResolutionMethod;
+    qrToken?: string | null;
+  }) => void;
   resetProtocol: () => void;
 };
 
@@ -23,14 +34,21 @@ export function ProtocolFlowProvider({ children }: { children: ReactNode }) {
   );
   const [workflowState, setWorkflowState] =
     useState<DriverProtocolState>('authenticated');
+  const [protocolContext, setProtocolContext] =
+    useState<ProtocolContext>(INITIAL_PROTOCOL_CONTEXT);
 
   const value = useMemo<ProtocolFlowContextValue>(
     () => ({
       completedRoutes,
       workflowState,
+      protocolContext,
       startProtocol: () => {
         setCompletedRoutes(new Set());
         setWorkflowState('authenticated');
+        setProtocolContext({
+          ...INITIAL_PROTOCOL_CONTEXT,
+          isAuthenticated: true,
+        });
       },
       completeRoute: (routeName) => {
         setCompletedRoutes((previous) => {
@@ -48,27 +66,31 @@ export function ProtocolFlowProvider({ children }: { children: ReactNode }) {
               uploadState: 'idle',
               updatedAt: new Date().toISOString(),
               version: 1,
-              context: {
-                isAuthenticated: true,
-                vehicleResolved: false,
-                safetyAcknowledged: false,
-                submissionValidations: {
-                  hasIncidentType: false,
-                  hasDescription: false,
-                  hasMedia: false,
-                },
-              },
+              context: protocolContext,
             },
             toState,
           ).state,
         );
       },
+      resolveVehicle: ({ vehicleId, method, qrToken }) => {
+        setProtocolContext((previous) => ({
+          ...previous,
+          vehicleResolved: true,
+          vehicleResolutionMethod: method,
+          vehicleId,
+          qrToken: qrToken ?? null,
+        }));
+      },
       resetProtocol: () => {
         setCompletedRoutes(new Set());
         setWorkflowState('authenticated');
+        setProtocolContext({
+          ...INITIAL_PROTOCOL_CONTEXT,
+          isAuthenticated: true,
+        });
       },
     }),
-    [completedRoutes, workflowState],
+    [completedRoutes, protocolContext, workflowState],
   );
 
   return (

--- a/driver-app/src/screens/QrScanScreen.tsx
+++ b/driver-app/src/screens/QrScanScreen.tsx
@@ -5,7 +5,7 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useFocusEffect } from '@react-navigation/native';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 
-import { resolveQr } from '../api';
+import { resolveVehicleQr } from '../services/incidents';
 import { RootStackParamList } from '../navigation/types';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'QrScan'>;
@@ -54,7 +54,7 @@ export default function QrScanScreen({ navigation }: Props) {
     }
 
     try {
-      const response = await resolveQr(qrToken);
+      const response = await resolveVehicleQr(qrToken);
       setStatusMessage(`Resolved vehicle ${response.display_label}.`);
       timeoutRef.current = setTimeout(
         () => navigation.goBack(),

--- a/driver-app/src/screens/VehicleConfirmScreen.tsx
+++ b/driver-app/src/screens/VehicleConfirmScreen.tsx
@@ -1,26 +1,222 @@
+import { useCallback, useMemo, useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { Button, HelperText, Surface, Text, TextInput } from 'react-native-paper';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useFocusEffect } from '@react-navigation/native';
 
+import { ApiRequestError, DriverMeResponse, getDriverMe } from '../api';
 import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
 import { RootStackParamList } from '../navigation/types';
 import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
-import ProtocolStepScreen from './ProtocolStepScreen';
+import { resolveVehicleQr } from '../services/incidents';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'VehicleConfirm'>;
 
+type QrResolutionStatus = 'idle' | 'invalid' | 'failed';
+
 export default function VehicleConfirmScreen({ navigation }: Props) {
-  const { completeRoute } = useProtocolFlow();
+  const { completeRoute, protocolContext, resolveVehicle } = useProtocolFlow();
   useProtocolRouteGuard('VehicleConfirm', navigation);
 
+  const [driver, setDriver] = useState<DriverMeResponse | null>(null);
+  const [isLoadingDriver, setIsLoadingDriver] = useState(false);
+  const [isResolvingQr, setIsResolvingQr] = useState(false);
+  const [qrTokenInput, setQrTokenInput] = useState('');
+  const [qrStatus, setQrStatus] = useState<QrResolutionStatus>('idle');
+  const [qrMessage, setQrMessage] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const assignedVehicle = driver?.vehicle;
+
+  useFocusEffect(
+    useCallback(() => {
+      setIsLoadingDriver(true);
+      setLoadError(null);
+      getDriverMe()
+        .then((response) => setDriver(response))
+        .catch((error) =>
+          setLoadError(
+            error instanceof Error ? error.message : 'Unable to load assigned vehicle.',
+          ),
+        )
+        .finally(() => setIsLoadingDriver(false));
+    }, []),
+  );
+
+  const isVehicleResolved = protocolContext.vehicleResolved;
+  const resolutionSummary = useMemo(() => {
+    if (!isVehicleResolved || !protocolContext.vehicleId) {
+      return null;
+    }
+
+    if (protocolContext.vehicleResolutionMethod === 'assigned_vehicle') {
+      return `Using assigned vehicle ${protocolContext.vehicleId}.`;
+    }
+
+    return `QR resolved vehicle ${protocolContext.vehicleId}.`;
+  }, [isVehicleResolved, protocolContext.vehicleId, protocolContext.vehicleResolutionMethod]);
+
+  const handleAcceptAssignedVehicle = () => {
+    if (!assignedVehicle) {
+      return;
+    }
+
+    resolveVehicle({
+      vehicleId: assignedVehicle.adc_vehicle_id,
+      method: 'assigned_vehicle',
+      qrToken: null,
+    });
+    setQrStatus('idle');
+    setQrMessage(null);
+  };
+
+  const handleResolveQr = async () => {
+    const token = qrTokenInput.trim();
+    if (!token) {
+      setQrStatus('invalid');
+      setQrMessage('Enter a QR token before resolving.');
+      return;
+    }
+
+    setIsResolvingQr(true);
+    setQrStatus('idle');
+    setQrMessage(null);
+    try {
+      const response = await resolveVehicleQr(token);
+      resolveVehicle({
+        vehicleId: response.adc_vehicle_id,
+        method: 'qr_scan',
+        qrToken: token,
+      });
+      setQrStatus('idle');
+      setQrMessage(`QR resolved ${response.display_label}.`);
+    } catch (error) {
+      const isInvalid = error instanceof ApiRequestError && error.status === 400;
+      setQrStatus(isInvalid ? 'invalid' : 'failed');
+      setQrMessage(
+        error instanceof Error ? error.message : 'Unable to resolve vehicle QR token.',
+      );
+    } finally {
+      setIsResolvingQr(false);
+    }
+  };
+
+  const handleContinue = () => {
+    if (!protocolContext.vehicleResolved) {
+      return;
+    }
+
+    completeRoute('VehicleConfirm');
+    navigation.navigate('SafetyGate');
+  };
+
   return (
-    <ProtocolStepScreen
-      title="Confirm Vehicle"
-      description="Confirm you are reporting for the correct vehicle before continuing."
-      continueLabel="Vehicle confirmed"
-      onContinue={() => {
-        completeRoute('VehicleConfirm');
-        navigation.navigate('SafetyGate');
-      }}
-      onBack={() => navigation.goBack()}
-    />
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.content}>
+        <Text variant="headlineMedium">Confirm Vehicle</Text>
+        <Text variant="bodyLarge" style={styles.description}>
+          Resolve your reporting vehicle using your assigned vehicle or by scanning a QR token.
+        </Text>
+
+        <Surface style={styles.section}>
+          <Text variant="titleMedium">Assigned vehicle</Text>
+          <Text style={styles.sectionDescription}>
+            {assignedVehicle
+              ? `${assignedVehicle.display_label} (${assignedVehicle.adc_vehicle_id})`
+              : 'No assigned vehicle found for this driver.'}
+          </Text>
+          {loadError ? <HelperText type="error">{loadError}</HelperText> : null}
+          <Button
+            mode="contained-tonal"
+            onPress={handleAcceptAssignedVehicle}
+            disabled={!assignedVehicle || isLoadingDriver}
+            loading={isLoadingDriver}
+          >
+            Accept assigned vehicle
+          </Button>
+        </Surface>
+
+        <Surface style={styles.section}>
+          <Text variant="titleMedium">QR scan (primary/fallback)</Text>
+          <Text style={styles.sectionDescription}>
+            Use this when no assigned vehicle is shown, or to override with the physical vehicle QR.
+          </Text>
+          <TextInput
+            mode="outlined"
+            label="QR token"
+            value={qrTokenInput}
+            onChangeText={(value) => {
+              setQrTokenInput(value);
+              if (qrStatus !== 'idle') {
+                setQrStatus('idle');
+                setQrMessage(null);
+              }
+            }}
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+          {qrMessage ? (
+            <HelperText type={qrStatus === 'failed' || qrStatus === 'invalid' ? 'error' : 'info'}>
+              {qrMessage}
+            </HelperText>
+          ) : null}
+          {qrStatus === 'invalid' ? (
+            <Button
+              mode="text"
+              onPress={() => {
+                setQrStatus('idle');
+                setQrMessage(null);
+                setQrTokenInput('');
+              }}
+            >
+              Retry QR resolution
+            </Button>
+          ) : null}
+          <Button mode="contained" onPress={handleResolveQr} loading={isResolvingQr}>
+            Resolve QR vehicle
+          </Button>
+        </Surface>
+
+        {resolutionSummary ? <Text style={styles.successText}>{resolutionSummary}</Text> : null}
+      </View>
+
+      <View style={styles.actions}>
+        <Button mode="outlined" onPress={() => navigation.goBack()}>
+          Back
+        </Button>
+        <Button mode="contained" onPress={handleContinue} disabled={!isVehicleResolved}>
+          Vehicle confirmed
+        </Button>
+      </View>
+    </ScrollView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    justifyContent: 'space-between',
+    padding: 24,
+    gap: 24,
+  },
+  content: {
+    gap: 16,
+  },
+  description: {
+    color: '#5f6b7a',
+  },
+  section: {
+    borderRadius: 12,
+    padding: 16,
+    gap: 8,
+  },
+  sectionDescription: {
+    color: '#5f6b7a',
+  },
+  successText: {
+    color: '#1f7a36',
+  },
+  actions: {
+    gap: 12,
+  },
+});

--- a/driver-app/src/services/incidents.ts
+++ b/driver-app/src/services/incidents.ts
@@ -1,0 +1,55 @@
+import { ApiRequestError } from '../api';
+import { getStoredToken } from '../auth';
+
+const API_BASE_URL = (process.env.EXPO_PUBLIC_API_BASE_URL ?? 'http://localhost:8000').replace(
+  /\/$/,
+  '',
+);
+
+type ApiError = {
+  detail?: string;
+};
+
+export type ResolveVehicleQrResponse = {
+  adc_vehicle_id: string;
+  display_label: string;
+};
+
+export async function resolveVehicleQr(
+  qrToken: string,
+): Promise<ResolveVehicleQrResponse> {
+  const token = await getStoredToken();
+  const headers = new Headers({
+    'Content-Type': 'application/json',
+  });
+
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  const response = await fetch(`${API_BASE_URL}/driver/resolve-vehicle-qr`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ qr_token: qrToken }),
+  });
+
+  const text = await response.text();
+  let data: ResolveVehicleQrResponse | ApiError = {};
+  if (text) {
+    try {
+      data = JSON.parse(text) as ResolveVehicleQrResponse | ApiError;
+    } catch {
+      data = { detail: text };
+    }
+  }
+
+  if (!response.ok) {
+    const apiDetail = (data as ApiError).detail;
+    throw new ApiRequestError(
+      typeof apiDetail === 'string' ? apiDetail : response.statusText || 'Request failed',
+      response.status,
+    );
+  }
+
+  return data as ResolveVehicleQrResponse;
+}

--- a/driver-app/src/types/protocol.ts
+++ b/driver-app/src/types/protocol.ts
@@ -24,9 +24,14 @@ export type SubmissionValidations = {
   hasMedia: boolean;
 };
 
+export type VehicleResolutionMethod = 'assigned_vehicle' | 'qr_scan';
+
 export type ProtocolContext = {
   isAuthenticated: boolean;
   vehicleResolved: boolean;
+  vehicleResolutionMethod: VehicleResolutionMethod | null;
+  vehicleId: string | null;
+  qrToken: string | null;
   safetyAcknowledged: boolean;
   submissionValidations: SubmissionValidations;
 };
@@ -45,6 +50,9 @@ export const PROTOCOL_PERSISTENCE_VERSION = 1 as const;
 export const INITIAL_PROTOCOL_CONTEXT: ProtocolContext = {
   isAuthenticated: false,
   vehicleResolved: false,
+  vehicleResolutionMethod: null,
+  vehicleId: null,
+  qrToken: null,
   safetyAcknowledged: false,
   submissionValidations: {
     hasIncidentType: false,


### PR DESCRIPTION
### Motivation
- Drivers need a way to confirm the reporting vehicle either by accepting their assigned vehicle or by resolving a vehicle from a QR token so the protocol can proceed with a resolved vehicle.
- The app must persist vehicle resolution metadata in the protocol context so downstream steps can depend on the resolved vehicle.
- QR scanning and manual token entry should share the same server integration and surface invalid/failed QR states to the user.

### Description
- Implemented a richer `VehicleConfirmScreen` flow that supports accepting the assigned vehicle and resolving a vehicle via QR token, blocks the Continue button until a vehicle is resolved, and shows an invalid-QR retry state (`driver-app/src/screens/VehicleConfirmScreen.tsx`).
- Added a new incidents service function `resolveVehicleQr` that integrates with `POST /driver/resolve-vehicle-qr` and raises `ApiRequestError` on API errors (`driver-app/src/services/incidents.ts`).
- Persisted vehicle resolution metadata in protocol context by adding `vehicleResolutionMethod`, `vehicleId`, and `qrToken` to `ProtocolContext` and exposing `resolveVehicle` in the protocol flow provider (`driver-app/src/types/protocol.ts`, `driver-app/src/navigation/ProtocolFlowContext.tsx`).
- Updated `QrScanScreen` to reuse the new `resolveVehicleQr` service so camera-based scans resolve via the same endpoint (`driver-app/src/screens/QrScanScreen.tsx`).

### Testing
- Ran TypeScript compile check with `cd driver-app && npx tsc --noEmit`, which succeeded.
- Executed `cd driver-app && npm run lint`, which failed because the `lint` script is not defined in `driver-app/package.json`.
- Executed `cd driver-app && npm run test`, which failed because the `test` script is not defined in `driver-app/package.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2a3bdde0c83219e812a5b8e5851c9)