### PR TITLE
Make Safety Gate non-skippable and add safety gate event tracking

### DIFF
--- a/driver-app/App.tsx
+++ b/driver-app/App.tsx
@@ -82,7 +82,11 @@ export default function App() {
               <Stack.Screen
                 name="SafetyGate"
                 component={SafetyGateScreen}
-                options={{ title: 'Safety Gate' }}
+                options={{
+                  title: 'Safety Gate',
+                  headerBackVisible: false,
+                  gestureEnabled: false,
+                }}
               />
               <Stack.Screen
                 name="IncidentStartLoading"

--- a/driver-app/src/navigation/ProtocolFlowContext.tsx
+++ b/driver-app/src/navigation/ProtocolFlowContext.tsx
@@ -21,6 +21,10 @@ type ProtocolFlowContextValue = {
     method: VehicleResolutionMethod;
     qrToken?: string | null;
   }) => void;
+  markSafetyGateViewed: () => void;
+  acknowledgeSafetyGate: () => void;
+  recordEmergencyCallTap: () => void;
+  recordSafetyManagerCallTap: () => void;
   resetProtocol: () => void;
 };
 
@@ -79,6 +83,37 @@ export function ProtocolFlowProvider({ children }: { children: ReactNode }) {
           vehicleResolutionMethod: method,
           vehicleId,
           qrToken: qrToken ?? null,
+        }));
+      },
+      markSafetyGateViewed: () => {
+        setProtocolContext((previous) => ({
+          ...previous,
+          safetyGateViewedAt: previous.safetyGateViewedAt ?? new Date().toISOString(),
+        }));
+      },
+      acknowledgeSafetyGate: () => {
+        setProtocolContext((previous) => ({
+          ...previous,
+          safetyAcknowledged: true,
+          safetyGateAcknowledgedAt: new Date().toISOString(),
+        }));
+      },
+      recordEmergencyCallTap: () => {
+        setProtocolContext((previous) => ({
+          ...previous,
+          emergencyCallTapTimestamps: [
+            ...previous.emergencyCallTapTimestamps,
+            new Date().toISOString(),
+          ],
+        }));
+      },
+      recordSafetyManagerCallTap: () => {
+        setProtocolContext((previous) => ({
+          ...previous,
+          safetyManagerCallTapTimestamps: [
+            ...previous.safetyManagerCallTapTimestamps,
+            new Date().toISOString(),
+          ],
         }));
       },
       resetProtocol: () => {

--- a/driver-app/src/screens/SafetyGateScreen.tsx
+++ b/driver-app/src/screens/SafetyGateScreen.tsx
@@ -1,26 +1,100 @@
+import { useEffect } from 'react';
+import { Linking, ScrollView, StyleSheet, View } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { Button, Text } from 'react-native-paper';
 
 import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
 import { RootStackParamList } from '../navigation/types';
 import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
-import ProtocolStepScreen from './ProtocolStepScreen';
+import { emitTimelineAndAnalyticsEvent } from '../telemetry/protocolEvents';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'SafetyGate'>;
 
+const EMERGENCY_NUMBER = '911';
+const SAFETY_MANAGER_NUMBER = '+18005551212';
+
 export default function SafetyGateScreen({ navigation }: Props) {
-  const { completeRoute } = useProtocolFlow();
+  const {
+    completeRoute,
+    markSafetyGateViewed,
+    acknowledgeSafetyGate,
+    recordEmergencyCallTap,
+    recordSafetyManagerCallTap,
+  } = useProtocolFlow();
+
   useProtocolRouteGuard('SafetyGate', navigation);
 
+  useEffect(() => {
+    markSafetyGateViewed();
+    emitTimelineAndAnalyticsEvent('driver_safety_gate_viewed');
+  }, [markSafetyGateViewed]);
+
+  const callNumber = async (number: string) => {
+    await Linking.openURL(`tel:${number}`);
+  };
+
   return (
-    <ProtocolStepScreen
-      title="Safety Gate"
-      description="Complete the immediate safety checklist before loading incident steps."
-      continueLabel="Safety check complete"
-      onContinue={() => {
-        completeRoute('SafetyGate');
-        navigation.navigate('IncidentStartLoading');
-      }}
-      onBack={() => navigation.goBack()}
-    />
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.content}>
+        <Text variant="headlineMedium">Safety Gate</Text>
+        <Text variant="bodyLarge" style={styles.description}>
+          Confirm scene safety first. You must acknowledge this step before
+          proceeding to incident capture.
+        </Text>
+        <View style={styles.callActions}>
+          <Button
+            mode="outlined"
+            onPress={() => {
+              recordEmergencyCallTap();
+              emitTimelineAndAnalyticsEvent('driver_emergency_call_tapped');
+              void callNumber(EMERGENCY_NUMBER);
+            }}
+          >
+            Call 911
+          </Button>
+          <Button
+            mode="outlined"
+            onPress={() => {
+              recordSafetyManagerCallTap();
+              emitTimelineAndAnalyticsEvent('driver_safety_call_tapped');
+              void callNumber(SAFETY_MANAGER_NUMBER);
+            }}
+          >
+            Call Safety Manager
+          </Button>
+        </View>
+      </View>
+
+      <Button
+        mode="contained"
+        onPress={() => {
+          acknowledgeSafetyGate();
+          emitTimelineAndAnalyticsEvent('driver_safety_gate_acknowledged');
+          completeRoute('SafetyGate');
+          navigation.navigate('IncidentStartLoading');
+        }}
+      >
+        Safety check complete
+      </Button>
+    </ScrollView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    justifyContent: 'space-between',
+    padding: 24,
+    gap: 24,
+  },
+  content: {
+    gap: 12,
+  },
+  description: {
+    color: '#5f6b7a',
+  },
+  callActions: {
+    marginTop: 8,
+    gap: 12,
+  },
+});

--- a/driver-app/src/telemetry/protocolEvents.ts
+++ b/driver-app/src/telemetry/protocolEvents.ts
@@ -1,4 +1,9 @@
-export type DriverProtocolEventName = 'driver_protocol_launch_confirmed';
+export type DriverProtocolEventName =
+  | 'driver_protocol_launch_confirmed'
+  | 'driver_safety_gate_viewed'
+  | 'driver_safety_gate_acknowledged'
+  | 'driver_emergency_call_tapped'
+  | 'driver_safety_call_tapped';
 
 export function emitTimelineAndAnalyticsEvent(
   eventName: DriverProtocolEventName,

--- a/driver-app/src/types/protocol.ts
+++ b/driver-app/src/types/protocol.ts
@@ -33,6 +33,10 @@ export type ProtocolContext = {
   vehicleId: string | null;
   qrToken: string | null;
   safetyAcknowledged: boolean;
+  safetyGateViewedAt: string | null;
+  safetyGateAcknowledgedAt: string | null;
+  emergencyCallTapTimestamps: string[];
+  safetyManagerCallTapTimestamps: string[];
   submissionValidations: SubmissionValidations;
 };
 
@@ -54,6 +58,10 @@ export const INITIAL_PROTOCOL_CONTEXT: ProtocolContext = {
   vehicleId: null,
   qrToken: null,
   safetyAcknowledged: false,
+  safetyGateViewedAt: null,
+  safetyGateAcknowledgedAt: null,
+  emergencyCallTapTimestamps: [],
+  safetyManagerCallTapTimestamps: [],
   submissionValidations: {
     hasIncidentType: false,
     hasDescription: false,


### PR DESCRIPTION
### Motivation
- Ensure the Safety Gate step is mandatory in the protocol flow and capture driver interactions for telemetry and auditing. 
- Persist timestamps and call-action taps so the protocol snapshot reflects when the gate was viewed/acknowledged and when emergency/support calls were attempted.

### Description
- Rebuilt `SafetyGateScreen` as a dedicated UI (removed the in-screen back action) that records view/acknowledge actions and emits telemetry on load and acknowledgement, and emits tap events for call actions. 
- Added protocol-context fields `safetyGateViewedAt`, `safetyGateAcknowledgedAt`, `emergencyCallTapTimestamps`, and `safetyManagerCallTapTimestamps` with defaults in `INITIAL_PROTOCOL_CONTEXT`. 
- Extended `ProtocolFlowContext` with methods `markSafetyGateViewed`, `acknowledgeSafetyGate`, `recordEmergencyCallTap`, and `recordSafetyManagerCallTap` to persist timestamps into the protocol context. 
- Added telemetry event names to `emitTimelineAndAnalyticsEvent` to support `driver_safety_gate_viewed`, `driver_safety_gate_acknowledged`, `driver_emergency_call_tapped`, and `driver_safety_call_tapped`, and disabled header/gesture back on the Safety Gate stack screen in `App.tsx` to make it non-skippable.

### Testing
- Ran `npx tsc --noEmit` in `driver-app` which passed. 
- Attempted `npm run lint` in `driver-app` but it failed because a `lint` script is not defined in `package.json`. 
- Attempted `npm test` in `driver-app` but it failed because a `test` script is not defined in `package.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2a4cec24483219d5e9f858b626e14)