### PR TITLE
InstructionStep: fetch active instructions, require ack, persist progress

### DIFF
--- a/driver-app/src/api.ts
+++ b/driver-app/src/api.ts
@@ -63,6 +63,24 @@ export type DriverIncidentInitiateResponse = {
   capture_started: boolean;
 };
 
+export type DriverInstructionStepResponse = {
+  step_id: string;
+  step_order: number;
+  title: string;
+  body: string;
+};
+
+export type DriverActiveInstructionsResponse = {
+  instruction_set_id: string;
+  scope: 'default' | 'company' | 'insurer';
+  require_ack?: boolean | null;
+  steps: DriverInstructionStepResponse[];
+};
+
+export type DriverInstructionAckResponse = {
+  acknowledged: boolean;
+};
+
 const request = async <T>(
   path: string,
   init: RequestInit = {},
@@ -149,6 +167,20 @@ export const initiateDriverIncident = (payload: DriverIncidentInitiateRequest) =
     {
       method: 'POST',
       body: JSON.stringify(payload),
+    },
+    true,
+  );
+
+
+export const getDriverActiveInstructions = () =>
+  request<DriverActiveInstructionsResponse>('/driver/instructions/active', {}, true);
+
+export const acknowledgeDriverInstructions = (instructionSetId: string) =>
+  request<DriverInstructionAckResponse>(
+    '/driver/instructions/ack',
+    {
+      method: 'POST',
+      body: JSON.stringify({ instruction_set_id: instructionSetId }),
     },
     true,
   );

--- a/driver-app/src/screens/InstructionStepScreen.tsx
+++ b/driver-app/src/screens/InstructionStepScreen.tsx
@@ -1,26 +1,352 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, Button, Text } from 'react-native-paper';
+import * as SecureStore from 'expo-secure-store';
 
+import {
+  acknowledgeDriverInstructions,
+  DriverInstructionStepResponse,
+  getDriverActiveInstructions,
+} from '../api';
 import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
 import { RootStackParamList } from '../navigation/types';
 import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
-import ProtocolStepScreen from './ProtocolStepScreen';
+import { emitTimelineAndAnalyticsEvent } from '../telemetry/protocolEvents';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'InstructionStep'>;
+
+type StoredInstructionProgress = {
+  instructionSetId: string;
+  viewedStepIds: string[];
+  acknowledgedStepIds: string[];
+  currentStepIndex: number;
+};
+
+type ActiveInstructionSet = {
+  instruction_set_id: string;
+  require_ack: boolean;
+  steps: DriverInstructionStepResponse[];
+};
+
+const INSTRUCTION_PROGRESS_STORAGE_KEY = 'driver_instruction_progress_v1';
+
+function normalizeStepOrder(steps: DriverInstructionStepResponse[]) {
+  return [...steps].sort((left, right) => left.step_order - right.step_order);
+}
 
 export default function InstructionStepScreen({ navigation }: Props) {
   const { completeRoute } = useProtocolFlow();
   useProtocolRouteGuard('InstructionStep', navigation);
 
-  return (
-    <ProtocolStepScreen
-      title="Instruction Step"
-      description="Follow the dispatch instruction and confirm completion."
-      continueLabel="Instruction complete"
-      onContinue={() => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [activeSet, setActiveSet] = useState<ActiveInstructionSet | null>(null);
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [viewedStepIds, setViewedStepIds] = useState<Set<string>>(new Set());
+  const [acknowledgedStepIds, setAcknowledgedStepIds] = useState<Set<string>>(new Set());
+  const [isAcknowledging, setIsAcknowledging] = useState(false);
+
+  const persistProgress = useCallback(
+    async (
+      instructionSetId: string,
+      nextStepIndex: number,
+      nextViewedStepIds: Set<string>,
+      nextAcknowledgedStepIds: Set<string>,
+    ) => {
+      const payload: StoredInstructionProgress = {
+        instructionSetId,
+        currentStepIndex: nextStepIndex,
+        viewedStepIds: Array.from(nextViewedStepIds),
+        acknowledgedStepIds: Array.from(nextAcknowledgedStepIds),
+      };
+      await SecureStore.setItemAsync(
+        INSTRUCTION_PROGRESS_STORAGE_KEY,
+        JSON.stringify(payload),
+      );
+    },
+    [],
+  );
+
+  const markStepViewed = useCallback(
+    async (
+      stepId: string,
+      instructionSetId: string,
+      stepIndex: number,
+      currentAcknowledgedStepIds: Set<string>,
+    ) => {
+      if (viewedStepIds.has(stepId)) {
+        return;
+      }
+
+      const nextViewedStepIds = new Set(viewedStepIds);
+      nextViewedStepIds.add(stepId);
+      setViewedStepIds(nextViewedStepIds);
+      emitTimelineAndAnalyticsEvent('driver_instruction_step_viewed');
+
+      await persistProgress(
+        instructionSetId,
+        stepIndex,
+        nextViewedStepIds,
+        currentAcknowledgedStepIds,
+      );
+    },
+    [persistProgress, viewedStepIds],
+  );
+
+  const loadActiveInstructions = useCallback(async () => {
+    setIsLoading(true);
+    setLoadError(null);
+
+    try {
+      const response = await getDriverActiveInstructions();
+      const normalizedSteps = normalizeStepOrder(response.steps ?? []);
+      const requireAck = Boolean(response.require_ack);
+      const nextActiveSet: ActiveInstructionSet = {
+        instruction_set_id: response.instruction_set_id,
+        require_ack: requireAck,
+        steps: normalizedSteps,
+      };
+
+      const storedRaw = await SecureStore.getItemAsync(
+        INSTRUCTION_PROGRESS_STORAGE_KEY,
+      );
+      let nextStepIndex = 0;
+      let nextViewedStepIds = new Set<string>();
+      let nextAcknowledgedStepIds = new Set<string>();
+
+      if (storedRaw) {
+        try {
+          const stored = JSON.parse(storedRaw) as StoredInstructionProgress;
+          if (stored.instructionSetId === response.instruction_set_id) {
+            nextStepIndex = Math.max(
+              0,
+              Math.min(stored.currentStepIndex ?? 0, normalizedSteps.length - 1),
+            );
+            nextViewedStepIds = new Set(stored.viewedStepIds ?? []);
+            nextAcknowledgedStepIds = new Set(stored.acknowledgedStepIds ?? []);
+          }
+        } catch {
+          // Ignore malformed local progress state and reset to defaults.
+        }
+      }
+
+      if (!normalizedSteps.length) {
         completeRoute('InstructionStep');
-        navigation.navigate('SceneFacts');
-      }}
-      onBack={() => navigation.goBack()}
-    />
+        navigation.replace('SceneFacts');
+        return;
+      }
+
+      setActiveSet(nextActiveSet);
+      setCurrentStepIndex(nextStepIndex);
+      setViewedStepIds(nextViewedStepIds);
+      setAcknowledgedStepIds(nextAcknowledgedStepIds);
+
+      const initialStep = normalizedSteps[nextStepIndex];
+      await markStepViewed(
+        initialStep.step_id,
+        response.instruction_set_id,
+        nextStepIndex,
+        nextAcknowledgedStepIds,
+      );
+    } catch (error) {
+      setLoadError(
+        error instanceof Error ? error.message : 'Failed to load active instructions.',
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [completeRoute, markStepViewed, navigation]);
+
+  useEffect(() => {
+    void loadActiveInstructions();
+  }, [loadActiveInstructions]);
+
+  const currentStep = useMemo(() => {
+    if (!activeSet?.steps.length) {
+      return null;
+    }
+
+    return activeSet.steps[currentStepIndex] ?? null;
+  }, [activeSet, currentStepIndex]);
+
+  const isCurrentStepAcknowledged =
+    currentStep != null && acknowledgedStepIds.has(currentStep.step_id);
+  const shouldDisableNext =
+    Boolean(activeSet?.require_ack) && currentStep != null && !isCurrentStepAcknowledged;
+
+  const handleAcknowledgeStep = useCallback(async () => {
+    if (!activeSet || !currentStep || isCurrentStepAcknowledged) {
+      return;
+    }
+
+    setIsAcknowledging(true);
+    setLoadError(null);
+    try {
+      await acknowledgeDriverInstructions(activeSet.instruction_set_id);
+      const nextAcknowledgedStepIds = new Set(acknowledgedStepIds);
+      nextAcknowledgedStepIds.add(currentStep.step_id);
+      setAcknowledgedStepIds(nextAcknowledgedStepIds);
+      emitTimelineAndAnalyticsEvent('driver_instruction_step_acknowledged');
+      await persistProgress(
+        activeSet.instruction_set_id,
+        currentStepIndex,
+        viewedStepIds,
+        nextAcknowledgedStepIds,
+      );
+    } catch (error) {
+      setLoadError(
+        error instanceof Error ? error.message : 'Unable to acknowledge this step.',
+      );
+    } finally {
+      setIsAcknowledging(false);
+    }
+  }, [
+    activeSet,
+    acknowledgedStepIds,
+    currentStep,
+    currentStepIndex,
+    isCurrentStepAcknowledged,
+    persistProgress,
+    viewedStepIds,
+  ]);
+
+  const handleContinue = useCallback(async () => {
+    if (!activeSet || !currentStep || shouldDisableNext) {
+      return;
+    }
+
+    const isLastStep = currentStepIndex >= activeSet.steps.length - 1;
+    if (isLastStep) {
+      completeRoute('InstructionStep');
+      navigation.navigate('SceneFacts');
+      return;
+    }
+
+    const nextStepIndex = currentStepIndex + 1;
+    const nextStep = activeSet.steps[nextStepIndex];
+    setCurrentStepIndex(nextStepIndex);
+
+    await markStepViewed(
+      nextStep.step_id,
+      activeSet.instruction_set_id,
+      nextStepIndex,
+      acknowledgedStepIds,
+    );
+  }, [
+    acknowledgedStepIds,
+    activeSet,
+    completeRoute,
+    currentStep,
+    currentStepIndex,
+    markStepViewed,
+    navigation,
+    shouldDisableNext,
+  ]);
+
+  if (isLoading) {
+    return (
+      <View style={styles.stateContainer}>
+        <ActivityIndicator animating size="large" />
+        <Text variant="bodyMedium">Loading active instructions…</Text>
+      </View>
+    );
+  }
+
+  if (loadError && !activeSet) {
+    return (
+      <View style={styles.stateContainer}>
+        <Text variant="titleMedium">Unable to load instructions</Text>
+        <Text variant="bodyMedium" style={styles.errorText}>
+          {loadError}
+        </Text>
+        <Button mode="contained" onPress={() => void loadActiveInstructions()}>
+          Retry
+        </Button>
+      </View>
+    );
+  }
+
+  if (!currentStep || !activeSet) {
+    return (
+      <View style={styles.stateContainer}>
+        <Text variant="bodyLarge">No instructions available.</Text>
+        <Button mode="contained" onPress={() => navigation.navigate('SceneFacts')}>
+          Continue
+        </Button>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.content}>
+        <Text variant="headlineSmall">Instruction step</Text>
+        <Text variant="labelLarge" style={styles.metaText}>
+          Step {currentStepIndex + 1} of {activeSet.steps.length}
+        </Text>
+        <Text variant="titleLarge">{currentStep.title}</Text>
+        <Text variant="bodyLarge" style={styles.description}>
+          {currentStep.body}
+        </Text>
+        {loadError ? (
+          <Text variant="bodySmall" style={styles.errorText}>
+            {loadError}
+          </Text>
+        ) : null}
+      </View>
+
+      <View style={styles.actions}>
+        {activeSet.require_ack ? (
+          <Button
+            mode={isCurrentStepAcknowledged ? 'contained-tonal' : 'outlined'}
+            onPress={() => void handleAcknowledgeStep()}
+            disabled={isCurrentStepAcknowledged || isAcknowledging}
+            loading={isAcknowledging}
+          >
+            {isCurrentStepAcknowledged ? 'Acknowledged' : 'Acknowledge step'}
+          </Button>
+        ) : null}
+
+        <Button mode="outlined" onPress={() => navigation.goBack()}>
+          Back
+        </Button>
+        <Button mode="contained" onPress={() => void handleContinue()} disabled={shouldDisableNext}>
+          {currentStepIndex >= activeSet.steps.length - 1 ? 'Continue' : 'Next'}
+        </Button>
+      </View>
+    </ScrollView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    justifyContent: 'space-between',
+    padding: 24,
+    gap: 24,
+  },
+  content: {
+    gap: 12,
+  },
+  description: {
+    color: '#5f6b7a',
+  },
+  metaText: {
+    color: '#5f6b7a',
+  },
+  actions: {
+    gap: 12,
+  },
+  stateContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+    gap: 12,
+  },
+  errorText: {
+    color: '#b3261e',
+    textAlign: 'center',
+  },
+});

--- a/driver-app/src/telemetry/protocolEvents.ts
+++ b/driver-app/src/telemetry/protocolEvents.ts
@@ -3,7 +3,9 @@ export type DriverProtocolEventName =
   | 'driver_safety_gate_viewed'
   | 'driver_safety_gate_acknowledged'
   | 'driver_emergency_call_tapped'
-  | 'driver_safety_call_tapped';
+  | 'driver_safety_call_tapped'
+  | 'driver_instruction_step_viewed'
+  | 'driver_instruction_step_acknowledged';
 
 export function emitTimelineAndAnalyticsEvent(
   eventName: DriverProtocolEventName,


### PR DESCRIPTION
### Motivation
- Provide drivers a step-by-step instruction flow driven by the server `GET /driver/instructions/active` response and require acknowledgement when the instruction set is configured to `require_ack`.
- Ensure progress (viewed and acknowledged steps + current index) is persisted locally so a driver can resume where they left off.
- Surface telemetry for step views and acknowledgements and record acknowledgements remotely via `POST /driver/instructions/ack`.

### Description
- Implemented the interactive instruction flow in `driver-app/src/screens/InstructionStepScreen.tsx` that fetches the active set, renders one step at a time, enforces `require_ack` by disabling Next until the step is acknowledged, and navigates to `SceneFacts` when complete or when no steps exist.
- Persisted resume state to secure local storage using `expo-secure-store` under the key `driver_instruction_progress_v1` storing `instructionSetId`, `currentStepIndex`, `viewedStepIds`, and `acknowledgedStepIds`, and restored this state when loading the active set.
- Wired remote API helpers and types in `driver-app/src/api.ts`: added `DriverInstructionStepResponse`, `DriverActiveInstructionsResponse`, `DriverInstructionAckResponse`, `getDriverActiveInstructions()` and `acknowledgeDriverInstructions()` to call `GET /driver/instructions/active` and `POST /driver/instructions/ack` respectively.
- Added telemetry event names to `driver-app/src/telemetry/protocolEvents.ts` and emit `driver_instruction_step_viewed` when a step is viewed and `driver_instruction_step_acknowledged` when an ack is recorded.
- Misc: steps are normalized/sorted by `step_order`, UI shows step count and handles loading/error states, and acknowledgements are persisted locally and sent to the server when tapped.

### Testing
- Type-check: ran `npx tsc --noEmit` in `driver-app` and it passed.
- Lint: attempted `npm run lint` in `driver-app` but it failed because there is no `lint` script defined in `driver-app/package.json`.
- Tests: attempted `npm test` in `driver-app` but it failed because there is no `test` script defined in `driver-app/package.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2a7fb88448321acddd05663ca1637)