### PR TITLE
Add driver incident report endpoints and service with ownership/org validation

### DIFF
--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""API route modules."""

--- a/backend/app/api/routes/routes_driver_report.py
+++ b/backend/app/api/routes/routes_driver_report.py
@@ -1,0 +1,142 @@
+"""Driver report patch/submit routes."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.api.schemas import (
+    DriverIncidentReportNarrativePatchRequest,
+    DriverIncidentReportPartiesPatchRequest,
+    DriverIncidentReportPatchRequest,
+    DriverIncidentReportScenePatchRequest,
+    DriverIncidentReportWriteResponse,
+)
+from app.core.deps import get_current_driver
+from app.db.models import Driver
+from app.db.session import get_db
+from app.services.driver_report_service import (
+    patch_report_sections,
+    submit_driver_report,
+)
+
+router = APIRouter()
+
+
+@router.patch(
+    "/incidents/{incident_id}/scene",
+    response_model=DriverIncidentReportWriteResponse,
+)
+def patch_incident_scene(
+    incident_id: uuid.UUID,
+    body: DriverIncidentReportScenePatchRequest,
+    driver: Driver = Depends(get_current_driver),
+    db: Session = Depends(get_db),
+):
+    updated_sections = patch_report_sections(
+        db,
+        incident_id=incident_id,
+        driver=driver,
+        patch={"scene": body.scene},
+    )
+    return DriverIncidentReportWriteResponse(
+        incident_id=incident_id,
+        updated_sections=updated_sections,
+    )
+
+
+@router.patch(
+    "/incidents/{incident_id}/parties",
+    response_model=DriverIncidentReportWriteResponse,
+)
+def patch_incident_parties(
+    incident_id: uuid.UUID,
+    body: DriverIncidentReportPartiesPatchRequest,
+    driver: Driver = Depends(get_current_driver),
+    db: Session = Depends(get_db),
+):
+    updated_sections = patch_report_sections(
+        db,
+        incident_id=incident_id,
+        driver=driver,
+        patch={"parties": body.parties},
+    )
+    return DriverIncidentReportWriteResponse(
+        incident_id=incident_id,
+        updated_sections=updated_sections,
+    )
+
+
+@router.patch(
+    "/incidents/{incident_id}/narrative",
+    response_model=DriverIncidentReportWriteResponse,
+)
+def patch_incident_narrative(
+    incident_id: uuid.UUID,
+    body: DriverIncidentReportNarrativePatchRequest,
+    driver: Driver = Depends(get_current_driver),
+    db: Session = Depends(get_db),
+):
+    updated_sections = patch_report_sections(
+        db,
+        incident_id=incident_id,
+        driver=driver,
+        patch={"narrative": body.narrative},
+    )
+    return DriverIncidentReportWriteResponse(
+        incident_id=incident_id,
+        updated_sections=updated_sections,
+    )
+
+
+@router.patch(
+    "/incidents/{incident_id}/report",
+    response_model=DriverIncidentReportWriteResponse,
+)
+def patch_incident_report(
+    incident_id: uuid.UUID,
+    body: DriverIncidentReportPatchRequest,
+    driver: Driver = Depends(get_current_driver),
+    db: Session = Depends(get_db),
+):
+    patch: dict = {}
+    if body.scene is not None:
+        patch["scene"] = body.scene
+    if body.parties is not None:
+        patch["parties"] = body.parties
+    if body.narrative is not None:
+        patch["narrative"] = body.narrative
+
+    updated_sections = patch_report_sections(
+        db,
+        incident_id=incident_id,
+        driver=driver,
+        patch=patch,
+    )
+    return DriverIncidentReportWriteResponse(
+        incident_id=incident_id,
+        updated_sections=updated_sections,
+    )
+
+
+@router.post(
+    "/incidents/{incident_id}/submit-driver-report",
+    response_model=DriverIncidentReportWriteResponse,
+)
+def submit_incident_driver_report(
+    incident_id: uuid.UUID,
+    driver: Driver = Depends(get_current_driver),
+    db: Session = Depends(get_db),
+):
+    submit_driver_report(
+        db,
+        incident_id=incident_id,
+        driver=driver,
+    )
+    return DriverIncidentReportWriteResponse(
+        incident_id=incident_id,
+        updated_sections=[],
+        submitted=True,
+    )

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -23,11 +23,28 @@ PhoneE164 = Annotated[
     ),
 ]
 OtpCode = Annotated[str, StringConstraints(pattern=r"^\d{4,8}$")]
-ShortText = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=255)]
-LongText = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=4000)]
-VehicleId = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=64, pattern=r"^[A-Za-z0-9._:-]+$")]
+ShortText = Annotated[
+    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=255)
+]
+LongText = Annotated[
+    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=4000)
+]
+VehicleId = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        min_length=1,
+        max_length=64,
+        pattern=r"^[A-Za-z0-9._:-]+$",
+    ),
+]
 DriverId = VehicleId
-QrToken = Annotated[str, StringConstraints(strip_whitespace=True, min_length=8, max_length=256, pattern=r"^[A-Za-z0-9_-]+$")]
+QrToken = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True, min_length=8, max_length=256, pattern=r"^[A-Za-z0-9_-]+$"
+    ),
+]
 
 UserRole = Literal["admin", "safety_manager"]
 InstructionScope = Literal["default", "company", "insurer"]
@@ -36,7 +53,9 @@ IncidentStatus = Literal["open", "evidence_capturing", "closed"]
 ArtifactStatus = Literal["pending", "captured", "unavailable"]
 ExportStatus = Literal["requested", "processing", "ready", "failed"]
 VehicleStrategy = Literal["qr", "last_assigned"]
-CaptureState = Literal["failed", "complete", "in_progress", "requested", "lockdown", "closed", "pending"]
+CaptureState = Literal[
+    "failed", "complete", "in_progress", "requested", "lockdown", "closed", "pending"
+]
 
 
 # ── Auth ────────────────────────────────────────────────────────────
@@ -244,7 +263,9 @@ class DriverInstructionStepResponse(BaseModel):
 class DriverInstructionSetResponse(DriverInstructionSetRequest):
     instruction_set_id: uuid.UUID
     require_ack: Optional[bool] = None
-    steps: list[DriverInstructionStep | DriverInstructionStepResponse] = Field(default_factory=list)
+    steps: list[DriverInstructionStep | DriverInstructionStepResponse] = Field(
+        default_factory=list
+    )
     model_config = ConfigDict(extra="ignore")
 
 
@@ -280,6 +301,32 @@ class DriverIncidentStatusResponse(BaseModel):
     safety_notified: bool
     capture_state: CaptureState
     last_evidence_update_utc: Optional[datetime] = None
+
+
+class DriverIncidentReportScenePatchRequest(BaseModel):
+    scene: dict = Field(default_factory=dict)
+
+
+class DriverIncidentReportPartiesPatchRequest(BaseModel):
+    parties: list[dict] = Field(default_factory=list)
+
+
+class DriverIncidentReportNarrativePatchRequest(BaseModel):
+    narrative: LongText
+
+
+class DriverIncidentReportPatchRequest(BaseModel):
+    scene: Optional[dict] = None
+    parties: Optional[list[dict]] = None
+    narrative: Optional[LongText] = None
+
+
+class DriverIncidentReportWriteResponse(BaseModel):
+    incident_id: uuid.UUID
+    updated_sections: list[Literal["scene", "parties", "narrative"]] = Field(
+        default_factory=list
+    )
+    submitted: bool = False
 
 
 # ── Admin vehicles / QR ────────────────────────────────────────────

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from app.api.routes_driver_auth import router as driver_auth_router
 from app.api.routes_incidents import router as incidents_router
 from app.api.routes_exports import router as exports_router
 from app.api.routes_driver import router as driver_router
+from app.api.routes.routes_driver_report import router as driver_report_router
 from app.api.routes_admin import router as admin_router
 from app.api.routes_twilio import router as twilio_router
 from app.core.config import settings
@@ -33,6 +34,7 @@ app.include_router(incidents_router, prefix="/incidents", tags=["incidents"])
 app.include_router(exports_router, prefix="/exports", tags=["exports"])
 app.include_router(driver_auth_router, prefix="/driver/auth", tags=["driver-auth"])
 app.include_router(driver_router, prefix="/driver", tags=["driver"])
+app.include_router(driver_report_router, prefix="/driver", tags=["driver-report"])
 app.include_router(admin_router, prefix="/admin", tags=["admin"])
 app.include_router(twilio_router, prefix="/twilio", tags=["twilio"])
 

--- a/backend/app/services/driver_report_service.py
+++ b/backend/app/services/driver_report_service.py
@@ -1,0 +1,101 @@
+"""Service logic for driver incident report write operations."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db.models import Driver, Event, Incident
+from app.domain.system_event_types import SystemEventType
+
+REPORT_SECTIONS = ("scene", "parties", "narrative")
+
+
+def _validate_incident_write_scope(
+    db: Session,
+    incident_id: uuid.UUID,
+    driver: Driver,
+) -> Incident:
+    incident = db.query(Incident).filter(Incident.incident_id == incident_id).first()
+    if incident is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Incident not found"
+        )
+
+    if incident.org_id != driver.org_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
+    if incident.adc_driver_id is not None and incident.adc_driver_id != str(
+        driver.driver_id
+    ):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
+    return incident
+
+
+def patch_report_sections(
+    db: Session,
+    *,
+    incident_id: uuid.UUID,
+    driver: Driver,
+    patch: dict,
+) -> list[str]:
+    incident = _validate_incident_write_scope(db, incident_id, driver)
+    updated_sections: list[str] = []
+
+    for section in REPORT_SECTIONS:
+        if section not in patch:
+            continue
+
+        value = patch[section]
+        payload = {
+            "report_section": section,
+            "report_value": value,
+            "submitted": False,
+        }
+        db.add(
+            Event(
+                org_id=incident.org_id,
+                incident_id=incident.incident_id,
+                event_type=SystemEventType.INCIDENT_UPDATED.value,
+                actor_type="driver_app",
+                actor_id=str(driver.driver_id),
+                payload=payload,
+            )
+        )
+        updated_sections.append(section)
+
+    if not updated_sections:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="At least one report section must be provided",
+        )
+
+    db.commit()
+    return updated_sections
+
+
+def submit_driver_report(
+    db: Session,
+    *,
+    incident_id: uuid.UUID,
+    driver: Driver,
+) -> None:
+    incident = _validate_incident_write_scope(db, incident_id, driver)
+
+    db.add(
+        Event(
+            org_id=incident.org_id,
+            incident_id=incident.incident_id,
+            event_type=SystemEventType.INCIDENT_UPDATED.value,
+            actor_type="driver_app",
+            actor_id=str(driver.driver_id),
+            payload={
+                "driver_report_submitted": True,
+                "submitted": True,
+            },
+        )
+    )
+    db.commit()

--- a/backend/tests/test_driver_report_routes.py
+++ b/backend/tests/test_driver_report_routes.py
@@ -1,0 +1,181 @@
+"""Tests for driver report patch and submit endpoints."""
+
+import uuid
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core.security import create_access_token
+from app.db.models import Base, Driver, Event, Incident, Org
+from app.db.session import get_db
+from app.api.routes.routes_driver_report import router as driver_report_router
+
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine)
+    session = TestSession()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    app = FastAPI()
+    app.include_router(driver_report_router, prefix="/driver")
+
+    def _override():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def seeded_driver_and_incident(db_session):
+    org = Org(name="Report Org")
+    db_session.add(org)
+    db_session.commit()
+    db_session.refresh(org)
+
+    driver = Driver(
+        org_id=org.id,
+        phone_e164="+15550001111",
+        display_name="Driver Report",
+    )
+    db_session.add(driver)
+    db_session.commit()
+    db_session.refresh(driver)
+
+    incident = Incident(
+        org_id=org.id,
+        adc_driver_id=str(driver.driver_id),
+        adc_vehicle_id="veh-1",
+        status="open",
+    )
+    db_session.add(incident)
+    db_session.commit()
+    db_session.refresh(incident)
+
+    return driver, incident
+
+
+def _driver_auth_headers(driver_id: uuid.UUID) -> dict[str, str]:
+    token = create_access_token({"sub": str(driver_id), "scope": "driver"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_patch_scene_creates_incident_updated_event(
+    client, db_session, seeded_driver_and_incident
+):
+    driver, incident = seeded_driver_and_incident
+
+    response = client.patch(
+        f"/driver/incidents/{incident.incident_id}/scene",
+        headers=_driver_auth_headers(driver.driver_id),
+        json={"scene": {"weather": "rain", "road": "wet"}},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["updated_sections"] == ["scene"]
+
+    event = (
+        db_session.query(Event).filter(Event.incident_id == incident.incident_id).one()
+    )
+    assert event.event_type == "incident_updated"
+    assert event.payload["report_section"] == "scene"
+    assert event.payload["report_value"]["weather"] == "rain"
+
+
+def test_patch_report_rejects_driver_not_owner(
+    client, db_session, seeded_driver_and_incident
+):
+    _driver, incident = seeded_driver_and_incident
+
+    other_driver = Driver(
+        org_id=incident.org_id,
+        phone_e164="+15550002222",
+        display_name="Other Driver",
+    )
+    db_session.add(other_driver)
+    db_session.commit()
+    db_session.refresh(other_driver)
+
+    response = client.patch(
+        f"/driver/incidents/{incident.incident_id}/report",
+        headers=_driver_auth_headers(other_driver.driver_id),
+        json={"narrative": "I saw brake lights and slowed down."},
+    )
+
+    assert response.status_code == 403
+
+
+def test_patch_parties_rejects_cross_org_write(
+    client, db_session, seeded_driver_and_incident
+):
+    _driver, incident = seeded_driver_and_incident
+
+    other_org = Org(name="Other Org")
+    db_session.add(other_org)
+    db_session.commit()
+    db_session.refresh(other_org)
+
+    cross_org_driver = Driver(
+        org_id=other_org.id,
+        phone_e164="+15550003333",
+        display_name="Cross Org Driver",
+    )
+    db_session.add(cross_org_driver)
+    db_session.commit()
+    db_session.refresh(cross_org_driver)
+
+    response = client.patch(
+        f"/driver/incidents/{incident.incident_id}/parties",
+        headers=_driver_auth_headers(cross_org_driver.driver_id),
+        json={"parties": [{"name": "Witness A"}]},
+    )
+
+    assert response.status_code == 403
+
+
+def test_submit_driver_report_writes_submission_event(
+    client, db_session, seeded_driver_and_incident
+):
+    driver, incident = seeded_driver_and_incident
+
+    response = client.post(
+        f"/driver/incidents/{incident.incident_id}/submit-driver-report",
+        headers=_driver_auth_headers(driver.driver_id),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["submitted"] is True
+
+    submission_event = (
+        db_session.query(Event)
+        .filter(
+            Event.incident_id == incident.incident_id,
+            Event.payload.isnot(None),
+        )
+        .order_by(Event.created_at_utc.desc())
+        .first()
+    )
+    assert submission_event is not None
+    assert submission_event.payload["driver_report_submitted"] is True


### PR DESCRIPTION
### Motivation
- Provide driver-facing endpoints to allow patching report sections (`scene`, `parties`, `narrative`) and submitting a driver report while ensuring every write enforces incident ownership and organization scoping.

### Description
- Add a new router `backend/app/api/routes/routes_driver_report.py` exposing `PATCH /driver/incidents/{incident_id}/scene`, `PATCH /driver/incidents/{incident_id}/parties`, `PATCH /driver/incidents/{incident_id}/narrative`, `PATCH /driver/incidents/{incident_id}/report`, and `POST /driver/incidents/{incident_id}/submit-driver-report`.
- Implement shared service logic in `backend/app/services/driver_report_service.py` that validates incident existence, org membership, and driver ownership before recording `incident_updated` events and a submission event.
- Extend `backend/app/api/schemas.py` with request and response models for section patches, consolidated patch requests, and a write response model.
- Register the new router in `backend/app/main.py` and add focused tests in `backend/tests/test_driver_report_routes.py` covering successful writes and ownership/org-scope enforcement.

### Testing
- Ran `ruff` checks against the changed files (`app/api/schemas.py`, `app/services/driver_report_service.py`, `app/api/routes/routes_driver_report.py`, `app/main.py`, tests) and they passed.
- Ran the new test module with `pytest tests/test_driver_report_routes.py -v` and all tests passed (`4 passed`).
- A full-repo lint/test run earlier surfaced unrelated pre-existing errors outside this change set (e.g. undefined names in other modules), which are not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3121bbd6883218b94aea38f03998d)