### PR TITLE
Add protocol-level analytics and correlation IDs for driver workflow events

### DIFF
--- a/driver-app/src/navigation/ProtocolFlowContext.tsx
+++ b/driver-app/src/navigation/ProtocolFlowContext.tsx
@@ -9,6 +9,7 @@ import {
 } from '../types/protocol';
 import { ProtocolRouteName } from './protocolFlow';
 import { persistProtocolResumeState } from '../store/protocolResumeStore';
+import { createWorkflowCorrelationId } from '../telemetry/correlation';
 
 type ProtocolFlowContextValue = {
   completedRoutes: Set<ProtocolRouteName>;
@@ -60,6 +61,7 @@ export function ProtocolFlowProvider({ children }: { children: ReactNode }) {
         setProtocolContext({
           ...INITIAL_PROTOCOL_CONTEXT,
           isAuthenticated: true,
+          workflowCorrelationId: createWorkflowCorrelationId(),
         });
       },
       restoreProtocol: (routes) => {
@@ -69,6 +71,8 @@ export function ProtocolFlowProvider({ children }: { children: ReactNode }) {
           ...previous,
           ...INITIAL_PROTOCOL_CONTEXT,
           isAuthenticated: true,
+          workflowCorrelationId:
+            previous.workflowCorrelationId ?? createWorkflowCorrelationId(),
         }));
       },
       completeRoute: (routeName) => {
@@ -139,6 +143,7 @@ export function ProtocolFlowProvider({ children }: { children: ReactNode }) {
         setProtocolContext({
           ...INITIAL_PROTOCOL_CONTEXT,
           isAuthenticated: true,
+          workflowCorrelationId: null,
         });
       },
     }),

--- a/driver-app/src/screens/DriverHomeScreen.tsx
+++ b/driver-app/src/screens/DriverHomeScreen.tsx
@@ -17,6 +17,7 @@ import {
   clearProtocolLocalDraftsAndResumeState,
   resolveProtocolResumeState,
 } from '../store/protocolResumeStore';
+import { emitProtocolAnalyticsEvent } from '../telemetry/protocolEvents';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'DriverHome'>;
 
@@ -66,6 +67,7 @@ export default function DriverHomeScreen({ navigation }: Props) {
 
   const startNewIncidentProtocol = useCallback(() => {
     startProtocol();
+    emitProtocolAnalyticsEvent('protocol_start_tapped');
     navigation.navigate('IncidentConfirm');
   }, [navigation, startProtocol]);
 
@@ -79,9 +81,21 @@ export default function DriverHomeScreen({ navigation }: Props) {
 
   const resumeSavedProtocol = useCallback(() => {
     const nextRoute = getNextActionRoute();
+    emitProtocolAnalyticsEvent('protocol_resumed', {
+      incidentId: activeIncident?.incident_id ?? null,
+      payload: {
+        resume_route: nextRoute,
+      },
+    });
     restoreProtocol(resumeCompletedRoutes);
     navigation.navigate(nextRoute);
-  }, [getNextActionRoute, navigation, restoreProtocol, resumeCompletedRoutes]);
+  }, [
+    activeIncident?.incident_id,
+    getNextActionRoute,
+    navigation,
+    restoreProtocol,
+    resumeCompletedRoutes,
+  ]);
 
   const discardSavedProtocol = useCallback(async () => {
     await clearProtocolLocalDraftsAndResumeState();

--- a/driver-app/src/screens/IncidentStartLoadingScreen.tsx
+++ b/driver-app/src/screens/IncidentStartLoadingScreen.tsx
@@ -11,6 +11,7 @@ import {
 import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
 import { RootStackParamList } from '../navigation/types';
 import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import { emitProtocolAnalyticsEvent } from '../telemetry/protocolEvents';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'IncidentStartLoading'>;
 
@@ -112,10 +113,22 @@ export default function IncidentStartLoadingScreen({ navigation }: Props) {
       return;
     }
 
+    emitProtocolAnalyticsEvent('incident_initiated', {
+      workflowCorrelationId: protocolContext.workflowCorrelationId,
+      payload: {
+        vehicle_resolution_method: protocolContext.vehicleResolutionMethod,
+      },
+    });
     transitionWorkflow('incident_initiated');
     completeRoute('IncidentStartLoading');
     navigation.replace('InstructionStep');
-  }, [completeRoute, navigation, transitionWorkflow]);
+  }, [
+    completeRoute,
+    navigation,
+    protocolContext.vehicleResolutionMethod,
+    protocolContext.workflowCorrelationId,
+    transitionWorkflow,
+  ]);
 
   const beginIncidentInitiation = useCallback(async () => {
     if (!isMountedRef.current) {

--- a/driver-app/src/screens/InstructionStepScreen.tsx
+++ b/driver-app/src/screens/InstructionStepScreen.tsx
@@ -12,7 +12,10 @@ import {
 import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
 import { RootStackParamList } from '../navigation/types';
 import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
-import { emitTimelineAndAnalyticsEvent } from '../telemetry/protocolEvents';
+import {
+  emitProtocolAnalyticsEvent,
+  emitTimelineAndAnalyticsEvent,
+} from '../telemetry/protocolEvents';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'InstructionStep'>;
 
@@ -36,7 +39,7 @@ function normalizeStepOrder(steps: DriverInstructionStepResponse[]) {
 }
 
 export default function InstructionStepScreen({ navigation }: Props) {
-  const { completeRoute } = useProtocolFlow();
+  const { completeRoute, protocolContext } = useProtocolFlow();
   useProtocolRouteGuard('InstructionStep', navigation);
 
   const [isLoading, setIsLoading] = useState(true);
@@ -184,6 +187,13 @@ export default function InstructionStepScreen({ navigation }: Props) {
     setLoadError(null);
     try {
       await acknowledgeDriverInstructions(activeSet.instruction_set_id);
+      emitProtocolAnalyticsEvent('instruction_acknowledged', {
+        workflowCorrelationId: protocolContext.workflowCorrelationId,
+        payload: {
+          instruction_set_id: activeSet.instruction_set_id,
+          instruction_step_id: currentStep.step_id,
+        },
+      });
       const nextAcknowledgedStepIds = new Set(acknowledgedStepIds);
       nextAcknowledgedStepIds.add(currentStep.step_id);
       setAcknowledgedStepIds(nextAcknowledgedStepIds);
@@ -207,6 +217,7 @@ export default function InstructionStepScreen({ navigation }: Props) {
     currentStepIndex,
     isCurrentStepAcknowledged,
     persistProgress,
+    protocolContext.workflowCorrelationId,
     viewedStepIds,
   ]);
 

--- a/driver-app/src/screens/MediaCaptureScreen.tsx
+++ b/driver-app/src/screens/MediaCaptureScreen.tsx
@@ -8,6 +8,7 @@ import { getDriverActiveIncident } from '../api';
 import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
 import { RootStackParamList } from '../navigation/types';
 import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import { emitProtocolAnalyticsEvent } from '../telemetry/protocolEvents';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'MediaCapture'>;
 
@@ -124,7 +125,7 @@ function mergePromptStatuses(
 }
 
 export default function MediaCaptureScreen({ navigation }: Props) {
-  const { completeRoute } = useProtocolFlow();
+  const { completeRoute, protocolContext } = useProtocolFlow();
   useProtocolRouteGuard('MediaCapture', navigation);
 
   const [incidentId, setIncidentId] = useState<string | null>(null);
@@ -194,6 +195,17 @@ export default function MediaCaptureScreen({ navigation }: Props) {
       setErrorText(null);
 
       try {
+        if (source != null) {
+          emitProtocolAnalyticsEvent('artifact_capture_started', {
+            incidentId,
+            workflowCorrelationId: protocolContext.workflowCorrelationId,
+            payload: {
+              prompt_type: promptType,
+              capture_source: source,
+            },
+          });
+        }
+
         const gps = source ? await getOptionalGps() : null;
         const nextQueue =
           source == null
@@ -227,7 +239,7 @@ export default function MediaCaptureScreen({ navigation }: Props) {
         setIsSaving(false);
       }
     },
-    [incidentId, persistDraft, prompts, queue],
+    [incidentId, persistDraft, prompts, protocolContext.workflowCorrelationId, queue],
   );
 
   const handleContinue = useCallback(async () => {

--- a/driver-app/src/screens/NarrativeScreen.tsx
+++ b/driver-app/src/screens/NarrativeScreen.tsx
@@ -12,6 +12,7 @@ import {
 import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
 import { RootStackParamList } from '../navigation/types';
 import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import { emitProtocolAnalyticsEvent } from '../telemetry/protocolEvents';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Narrative'>;
 
@@ -42,7 +43,7 @@ function buildNarrativePayload(draft: NarrativeDraft): DriverNarrativePayload {
 }
 
 export default function NarrativeScreen({ navigation }: Props) {
-  const { completeRoute } = useProtocolFlow();
+  const { completeRoute, protocolContext } = useProtocolFlow();
   useProtocolRouteGuard('Narrative', navigation);
 
   const [incidentId, setIncidentId] = useState<string | null>(null);
@@ -146,12 +147,23 @@ export default function NarrativeScreen({ navigation }: Props) {
 
       await persistDraft(nextDraft, incidentId);
       setDraft(nextDraft);
+      emitProtocolAnalyticsEvent('narrative_saved', {
+        incidentId,
+        workflowCorrelationId: protocolContext.workflowCorrelationId,
+      });
       completeRoute('Narrative');
       navigation.navigate('ReviewSubmit');
     } finally {
       setIsSaving(false);
     }
-  }, [completeRoute, draft.narrativeText, incidentId, navigation, persistDraft]);
+  }, [
+    completeRoute,
+    draft.narrativeText,
+    incidentId,
+    navigation,
+    persistDraft,
+    protocolContext.workflowCorrelationId,
+  ]);
 
   if (isInitializing) {
     return (

--- a/driver-app/src/screens/ReviewSubmitScreen.tsx
+++ b/driver-app/src/screens/ReviewSubmitScreen.tsx
@@ -13,6 +13,7 @@ import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
 import { PROTOCOL_ROUTE_ORDER, ProtocolRouteName } from '../navigation/protocolFlow';
 import { RootStackParamList } from '../navigation/types';
 import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import { emitProtocolAnalyticsEvent } from '../telemetry/protocolEvents';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'ReviewSubmit'>;
 
@@ -70,7 +71,7 @@ function describeUploadStatus(incidentStatus: DriverIncidentStatusResponse | nul
 }
 
 export default function ReviewSubmitScreen({ navigation }: Props) {
-  const { completeRoute, completedRoutes } = useProtocolFlow();
+  const { completeRoute, completedRoutes, protocolContext } = useProtocolFlow();
   useProtocolRouteGuard('ReviewSubmit', navigation);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -154,6 +155,10 @@ export default function ReviewSubmitScreen({ navigation }: Props) {
       }
 
       await submitDriverIncidentReport(incidentId);
+      emitProtocolAnalyticsEvent('driver_report_submitted', {
+        incidentId,
+        workflowCorrelationId: protocolContext.workflowCorrelationId,
+      });
       completeRoute('ReviewSubmit');
       navigation.navigate('IncidentStatus');
     } catch (error) {
@@ -161,7 +166,12 @@ export default function ReviewSubmitScreen({ navigation }: Props) {
     } finally {
       setIsSubmitting(false);
     }
-  }, [completeRoute, minimumSubmissionReady, navigation]);
+  }, [
+    completeRoute,
+    minimumSubmissionReady,
+    navigation,
+    protocolContext.workflowCorrelationId,
+  ]);
 
   return (
     <ScrollView contentContainerStyle={styles.container}>

--- a/driver-app/src/screens/SafetyGateScreen.tsx
+++ b/driver-app/src/screens/SafetyGateScreen.tsx
@@ -6,7 +6,10 @@ import { Button, Text } from 'react-native-paper';
 import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
 import { RootStackParamList } from '../navigation/types';
 import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
-import { emitTimelineAndAnalyticsEvent } from '../telemetry/protocolEvents';
+import {
+  emitProtocolAnalyticsEvent,
+  emitTimelineAndAnalyticsEvent,
+} from '../telemetry/protocolEvents';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'SafetyGate'>;
 
@@ -20,6 +23,7 @@ export default function SafetyGateScreen({ navigation }: Props) {
     acknowledgeSafetyGate,
     recordEmergencyCallTap,
     recordSafetyManagerCallTap,
+    protocolContext,
   } = useProtocolFlow();
 
   useProtocolRouteGuard('SafetyGate', navigation);
@@ -69,6 +73,9 @@ export default function SafetyGateScreen({ navigation }: Props) {
         mode="contained"
         onPress={() => {
           acknowledgeSafetyGate();
+          emitProtocolAnalyticsEvent('safety_gate_acknowledged', {
+            workflowCorrelationId: protocolContext.workflowCorrelationId,
+          });
           emitTimelineAndAnalyticsEvent('driver_safety_gate_acknowledged');
           completeRoute('SafetyGate');
           navigation.navigate('IncidentStartLoading');

--- a/driver-app/src/screens/SceneFactsScreen.tsx
+++ b/driver-app/src/screens/SceneFactsScreen.tsx
@@ -12,6 +12,7 @@ import {
 import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
 import { RootStackParamList } from '../navigation/types';
 import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import { emitProtocolAnalyticsEvent } from '../telemetry/protocolEvents';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'SceneFacts'>;
 
@@ -134,7 +135,7 @@ function YesNoQuestion({
 }
 
 export default function SceneFactsScreen({ navigation }: Props) {
-  const { completeRoute } = useProtocolFlow();
+  const { completeRoute, protocolContext } = useProtocolFlow();
   useProtocolRouteGuard('SceneFacts', navigation);
 
   const [stepIndex, setStepIndex] = useState(0);
@@ -244,12 +245,25 @@ export default function SceneFactsScreen({ navigation }: Props) {
 
     try {
       await persistDraft(draft, incidentId);
+      emitProtocolAnalyticsEvent('scene_saved', {
+        incidentId,
+        workflowCorrelationId: protocolContext.workflowCorrelationId,
+      });
       completeRoute('SceneFacts');
       navigation.navigate('ThirdPartyInfo');
     } finally {
       setIsSaving(false);
     }
-  }, [completeRoute, draft, handleStepChange, incidentId, navigation, persistDraft, stepIndex]);
+  }, [
+    completeRoute,
+    draft,
+    handleStepChange,
+    incidentId,
+    navigation,
+    persistDraft,
+    protocolContext.workflowCorrelationId,
+    stepIndex,
+  ]);
 
   const handleBack = useCallback(async () => {
     if (stepIndex > 0) {

--- a/driver-app/src/screens/ThirdPartyInfoScreen.tsx
+++ b/driver-app/src/screens/ThirdPartyInfoScreen.tsx
@@ -13,6 +13,7 @@ import {
 import { MediaPromptType, RootStackParamList } from '../navigation/types';
 import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
 import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
+import { emitProtocolAnalyticsEvent } from '../telemetry/protocolEvents';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'ThirdPartyInfo'>;
 
@@ -86,7 +87,7 @@ function hasPartyData(item: ThirdPartyDraftItem): boolean {
 }
 
 export default function ThirdPartyInfoScreen({ navigation }: Props) {
-  const { completeRoute } = useProtocolFlow();
+  const { completeRoute, protocolContext } = useProtocolFlow();
   useProtocolRouteGuard('ThirdPartyInfo', navigation);
 
   const [incidentId, setIncidentId] = useState<string | null>(null);
@@ -225,12 +226,28 @@ export default function ThirdPartyInfoScreen({ navigation }: Props) {
       };
       await persistDraft(nextDraft, incidentId);
       setDraft(nextDraft);
+      emitProtocolAnalyticsEvent('party_info_saved', {
+        incidentId,
+        workflowCorrelationId: protocolContext.workflowCorrelationId,
+        payload: {
+          completion_state: nextDraft.completionState,
+          entered_party_count: nonEmptyPartyCount,
+        },
+      });
       completeRoute('ThirdPartyInfo');
       navigation.navigate('MediaCapture', { destinationPromptType: 'general_scene' });
     } finally {
       setIsSaving(false);
     }
-  }, [completeRoute, draft, incidentId, navigation, persistDraft]);
+  }, [
+    completeRoute,
+    draft,
+    incidentId,
+    navigation,
+    nonEmptyPartyCount,
+    persistDraft,
+    protocolContext.workflowCorrelationId,
+  ]);
 
   const handleSkip = useCallback(async () => {
     setErrorText(null);
@@ -244,12 +261,28 @@ export default function ThirdPartyInfoScreen({ navigation }: Props) {
 
       await persistDraft(nextDraft, incidentId);
       setDraft(nextDraft);
+      emitProtocolAnalyticsEvent('party_info_saved', {
+        incidentId,
+        workflowCorrelationId: protocolContext.workflowCorrelationId,
+        payload: {
+          completion_state: nextDraft.completionState,
+          entered_party_count: nonEmptyPartyCount,
+        },
+      });
       completeRoute('ThirdPartyInfo');
       navigation.navigate('MediaCapture', { destinationPromptType: 'general_scene' });
     } finally {
       setIsSaving(false);
     }
-  }, [completeRoute, draft, incidentId, navigation, persistDraft]);
+  }, [
+    completeRoute,
+    draft,
+    incidentId,
+    navigation,
+    nonEmptyPartyCount,
+    persistDraft,
+    protocolContext.workflowCorrelationId,
+  ]);
 
   const handleTakePhotoInstead = useCallback(
     async (promptType: MediaPromptType) => {
@@ -261,13 +294,30 @@ export default function ThirdPartyInfoScreen({ navigation }: Props) {
           completionState: draft.completionState,
         };
         await persistDraft(nextDraft, incidentId);
+        emitProtocolAnalyticsEvent('party_info_saved', {
+          incidentId,
+          workflowCorrelationId: protocolContext.workflowCorrelationId,
+          payload: {
+            completion_state: nextDraft.completionState,
+            entered_party_count: nonEmptyPartyCount,
+            transitioned_to_media_prompt: promptType,
+          },
+        });
         completeRoute('ThirdPartyInfo');
         navigation.navigate('MediaCapture', { destinationPromptType: promptType });
       } finally {
         setIsSaving(false);
       }
     },
-    [completeRoute, draft, incidentId, navigation, persistDraft],
+    [
+      completeRoute,
+      draft,
+      incidentId,
+      navigation,
+      nonEmptyPartyCount,
+      persistDraft,
+      protocolContext.workflowCorrelationId,
+    ],
   );
 
   if (isInitializing) {

--- a/driver-app/src/screens/VehicleConfirmScreen.tsx
+++ b/driver-app/src/screens/VehicleConfirmScreen.tsx
@@ -9,6 +9,7 @@ import { useProtocolFlow } from '../navigation/ProtocolFlowContext';
 import { RootStackParamList } from '../navigation/types';
 import { useProtocolRouteGuard } from '../navigation/useProtocolRouteGuard';
 import { resolveVehicleQr } from '../services/incidents';
+import { emitProtocolAnalyticsEvent } from '../telemetry/protocolEvents';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'VehicleConfirm'>;
 
@@ -81,6 +82,12 @@ export default function VehicleConfirmScreen({ navigation }: Props) {
     setIsResolvingQr(true);
     setQrStatus('idle');
     setQrMessage(null);
+    emitProtocolAnalyticsEvent('qr_scan_started', {
+      workflowCorrelationId: protocolContext.workflowCorrelationId,
+      payload: {
+        source: 'vehicle_confirm_screen',
+      },
+    });
     try {
       const response = await resolveVehicleQr(token);
       resolveVehicle({
@@ -88,10 +95,23 @@ export default function VehicleConfirmScreen({ navigation }: Props) {
         method: 'qr_scan',
         qrToken: token,
       });
+      emitProtocolAnalyticsEvent('qr_scan_success', {
+        workflowCorrelationId: protocolContext.workflowCorrelationId,
+        payload: {
+          vehicle_id: response.adc_vehicle_id,
+        },
+      });
       setQrStatus('idle');
       setQrMessage(`QR resolved ${response.display_label}.`);
     } catch (error) {
       const isInvalid = error instanceof ApiRequestError && error.status === 400;
+      emitProtocolAnalyticsEvent('qr_scan_failed', {
+        workflowCorrelationId: protocolContext.workflowCorrelationId,
+        payload: {
+          reason: error instanceof Error ? error.message : 'Unable to resolve vehicle QR token.',
+          invalid_token: isInvalid,
+        },
+      });
       setQrStatus(isInvalid ? 'invalid' : 'failed');
       setQrMessage(
         error instanceof Error ? error.message : 'Unable to resolve vehicle QR token.',
@@ -107,6 +127,13 @@ export default function VehicleConfirmScreen({ navigation }: Props) {
     }
 
     completeRoute('VehicleConfirm');
+    emitProtocolAnalyticsEvent('vehicle_confirmed', {
+      workflowCorrelationId: protocolContext.workflowCorrelationId,
+      payload: {
+        vehicle_resolution_method: protocolContext.vehicleResolutionMethod,
+        vehicle_id: protocolContext.vehicleId,
+      },
+    });
     navigation.navigate('SafetyGate');
   };
 

--- a/driver-app/src/services/uploads.ts
+++ b/driver-app/src/services/uploads.ts
@@ -16,6 +16,7 @@ import {
   UploadQueueItem,
 } from '../store/uploadQueueStore';
 import {
+  emitProtocolAnalyticsEvent,
   emitTimelineAndAnalyticsEvent,
   emitUploadAnalyticsEvent,
 } from '../telemetry/protocolEvents';
@@ -169,6 +170,13 @@ async function processUploadItem(item: UploadQueueItem): Promise<void> {
       incident_id: item.incidentId,
       artifact_type: item.artifactType,
     });
+    emitProtocolAnalyticsEvent('artifact_upload_success', {
+      incidentId: item.incidentId,
+      payload: {
+        queue_item_id: item.id,
+        artifact_type: item.artifactType,
+      },
+    });
   } catch (error) {
     const errorMessage = getErrorMessage(error);
     const nextAttempt = item.attempts + 1;
@@ -204,6 +212,15 @@ async function processUploadItem(item: UploadQueueItem): Promise<void> {
       artifact_type: item.artifactType,
       attempt: nextAttempt,
       reason: errorMessage,
+    });
+    emitProtocolAnalyticsEvent('artifact_upload_failed', {
+      incidentId: item.incidentId,
+      payload: {
+        queue_item_id: item.id,
+        artifact_type: item.artifactType,
+        attempt: nextAttempt,
+        reason: errorMessage,
+      },
     });
   }
 }

--- a/driver-app/src/telemetry/correlation.ts
+++ b/driver-app/src/telemetry/correlation.ts
@@ -1,0 +1,7 @@
+export function createWorkflowCorrelationId(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+
+  return `wf-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+}

--- a/driver-app/src/telemetry/protocolEvents.ts
+++ b/driver-app/src/telemetry/protocolEvents.ts
@@ -25,6 +25,24 @@ export type DriverUploadAnalyticsEventName =
   | 'driver_upload_succeeded'
   | 'driver_upload_failed';
 
+export type ProtocolAnalyticsEventName =
+  | 'protocol_start_tapped'
+  | 'vehicle_confirmed'
+  | 'qr_scan_started'
+  | 'qr_scan_success'
+  | 'qr_scan_failed'
+  | 'safety_gate_acknowledged'
+  | 'incident_initiated'
+  | 'instruction_acknowledged'
+  | 'scene_saved'
+  | 'party_info_saved'
+  | 'artifact_capture_started'
+  | 'artifact_upload_success'
+  | 'artifact_upload_failed'
+  | 'narrative_saved'
+  | 'driver_report_submitted'
+  | 'protocol_resumed';
+
 const PERSISTED_TIMELINE_EVENT_NAMES: Set<DriverTimelineEventName> = new Set([
   'driver_protocol_launch_confirmed',
   'driver_safety_gate_viewed',
@@ -45,31 +63,50 @@ function isPersistedTimelineEventName(
   return PERSISTED_TIMELINE_EVENT_NAMES.has(eventName as DriverTimelineEventName);
 }
 
+async function resolveIncidentCorrelationId(explicitIncidentId?: string | null) {
+  const trimmedIncidentId = explicitIncidentId?.trim();
+  return trimmedIncidentId || (await getDriverActiveIncident())?.incident_id?.trim() || null;
+}
+
+function createCorrelatedPayload(
+  payload: Record<string, unknown> | undefined,
+  correlations: {
+    incidentCorrelationId: string | null;
+    workflowCorrelationId?: string | null;
+  },
+): Record<string, unknown> {
+  return {
+    ...(payload ?? {}),
+    incident_correlation_id: correlations.incidentCorrelationId,
+    workflow_correlation_id: correlations.workflowCorrelationId ?? null,
+  };
+}
+
 export function emitTimelineAndAnalyticsEvent(
   eventName: DriverProtocolEventName,
   options?: {
     incidentId?: string | null;
+    workflowCorrelationId?: string | null;
     payload?: Record<string, unknown>;
   },
 ): void {
   console.info('[driver-protocol-event]', eventName);
-  if (!isPersistedTimelineEventName(eventName)) {
-    return;
-  }
-
   void (async () => {
     try {
-      const explicitIncidentId = options?.incidentId?.trim();
-      const resolvedIncidentId =
-        explicitIncidentId || (await getDriverActiveIncident())?.incident_id?.trim();
-      if (!resolvedIncidentId) {
+      const resolvedIncidentId = await resolveIncidentCorrelationId(options?.incidentId);
+      const correlatedPayload = createCorrelatedPayload(options?.payload, {
+        incidentCorrelationId: resolvedIncidentId,
+        workflowCorrelationId: options?.workflowCorrelationId,
+      });
+
+      if (!isPersistedTimelineEventName(eventName) || !resolvedIncidentId) {
         return;
       }
 
       await postDriverTimelineEvent(resolvedIncidentId, {
         event_name: eventName,
         occurred_at_utc: new Date().toISOString(),
-        payload: options?.payload ?? {},
+        payload: correlatedPayload,
       });
     } catch {
       // Non-blocking telemetry write.
@@ -82,4 +119,26 @@ export function emitUploadAnalyticsEvent(
   payload: Record<string, unknown>,
 ): void {
   console.info('[driver-upload-analytics-event]', eventName, payload);
+}
+
+export function emitProtocolAnalyticsEvent(
+  eventName: ProtocolAnalyticsEventName,
+  options?: {
+    incidentId?: string | null;
+    workflowCorrelationId?: string | null;
+    payload?: Record<string, unknown>;
+  },
+): void {
+  void (async () => {
+    try {
+      const resolvedIncidentId = await resolveIncidentCorrelationId(options?.incidentId);
+      const correlatedPayload = createCorrelatedPayload(options?.payload, {
+        incidentCorrelationId: resolvedIncidentId,
+        workflowCorrelationId: options?.workflowCorrelationId,
+      });
+      console.info('[driver-protocol-analytics-event]', eventName, correlatedPayload);
+    } catch {
+      // Non-blocking analytics emission.
+    }
+  })();
 }

--- a/driver-app/src/types/protocol.ts
+++ b/driver-app/src/types/protocol.ts
@@ -28,6 +28,7 @@ export type VehicleResolutionMethod = 'assigned_vehicle' | 'qr_scan';
 
 export type ProtocolContext = {
   isAuthenticated: boolean;
+  workflowCorrelationId: string | null;
   vehicleResolved: boolean;
   vehicleResolutionMethod: VehicleResolutionMethod | null;
   vehicleId: string | null;
@@ -53,6 +54,7 @@ export const PROTOCOL_PERSISTENCE_VERSION = 1 as const;
 
 export const INITIAL_PROTOCOL_CONTEXT: ProtocolContext = {
   isAuthenticated: false,
+  workflowCorrelationId: null,
   vehicleResolved: false,
   vehicleResolutionMethod: null,
   vehicleId: null,


### PR DESCRIPTION
### Motivation

- Provide structured analytics at key driver workflow action points to enable funnel and drop-off analysis across the incident protocol.  
- Ensure analytics and persisted timeline events carry incident and workflow correlation IDs so events can be correlated to a single protocol run.  

### Description

- Added a workflow correlation ID generator (`driver-app/src/telemetry/correlation.ts`) and extended `ProtocolContext` with `workflowCorrelationId` to bind analytics to a protocol run.  
- Wired correlation ID lifecycle into `ProtocolFlowContext` so a correlation id is created on protocol start/restore and cleared on reset.  
- Introduced a protocol analytics emitter and correlation helpers in `driver-app/src/telemetry/protocolEvents.ts`, and updated timeline event emission to include `incident_correlation_id` and `workflow_correlation_id` in persisted payloads.  
- Instrumented the requested touch points to emit protocol analytics (examples): `protocol_start_tapped`, `protocol_resumed`, `vehicle_confirmed`, `qr_scan_started`, `qr_scan_success`, `qr_scan_failed`, `safety_gate_acknowledged`, `incident_initiated`, `instruction_acknowledged`, `scene_saved`, `party_info_saved`, `artifact_capture_started`, `artifact_upload_success`, `artifact_upload_failed`, `narrative_saved`, and `driver_report_submitted` across relevant screens and upload flow.  
- Key modified files: `driver-app/src/telemetry/protocolEvents.ts`, `driver-app/src/telemetry/correlation.ts`, `driver-app/src/navigation/ProtocolFlowContext.tsx`, `driver-app/src/types/protocol.ts`, and multiple screens/services (Home, VehicleConfirm, SafetyGate, IncidentStartLoading, InstructionStep, SceneFacts, ThirdPartyInfo, MediaCapture, Narrative, ReviewSubmit, uploads).  

### Testing

- Ran TypeScript check: `cd driver-app && npx tsc --noEmit` — succeeded.  
- Ran a targeted backend unit test: `cd backend && pytest tests/test_driver_protocol_models.py -q` — succeeded (5 tests passed).  
- Ran repo lint target: `make lint` — failed due to pre-existing backend undefined-name issues in route modules unrelated to this driver-app change (lint failures are not caused by the telemetry changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d318634d8c83219f894039ed44e55c)