### PR TITLE
Harden driver incident ownership and server-side timestamps

### DIFF
--- a/backend/app/api/routes_driver.py
+++ b/backend/app/api/routes_driver.py
@@ -42,8 +42,8 @@ from app.db.models import (
     Org,
     OtpChallenge,
     VehicleQrToken,
+    Incident,
 )
-from app.db.repo.incidents import get_incident
 from app.db.session import get_db
 from app.domain.system_event_types import SystemEventType
 from app.services.incident_workflow_service import (
@@ -404,6 +404,26 @@ def _evidence_capture_state(events: list, incident_status: str) -> str:
     return "pending"
 
 
+def _get_driver_incident(
+    db: Session,
+    *,
+    incident_id: uuid.UUID,
+    driver: Driver,
+) -> Incident:
+    incident = (
+        db.query(Incident)
+        .filter(
+            Incident.incident_id == incident_id,
+            Incident.org_id == driver.org_id,
+            Incident.adc_driver_id == str(driver.driver_id),
+        )
+        .first()
+    )
+    if incident is None:
+        raise HTTPException(status_code=404, detail="Incident not found")
+    return incident
+
+
 @router.post("/incidents/initiate", response_model=DriverIncidentInitiateResponse)
 def initiate_incident(
     body: DriverIncidentInitiateRequest,
@@ -519,6 +539,7 @@ def acknowledge_instructions(
     active_incident_id = (
         active_incident.incident_id if active_incident is not None else None
     )
+    acknowledged_at_utc = datetime.now(timezone.utc)
 
     event = Event(
         org_id=driver.org_id,
@@ -526,7 +547,11 @@ def acknowledge_instructions(
         event_type=SystemEventType.DRIVER_INSTRUCTION_STEP_ACKNOWLEDGED.value,
         actor_type="driver_app",
         actor_id=str(driver.driver_id),
-        payload={"instruction_set_id": str(instruction_set.instruction_set_id)},
+        occurred_at_utc=acknowledged_at_utc,
+        payload={
+            "instruction_set_id": str(instruction_set.instruction_set_id),
+            "acknowledged_at_utc": acknowledged_at_utc.isoformat(),
+        },
     )
     db.add(event)
     db.commit()
@@ -545,9 +570,11 @@ def write_driver_timeline_event(
     db: Session = Depends(get_db),
 ):
     """Persist driver app timeline events with actor identity and audit timestamps."""
-    incident = get_incident(db, incident_id, org_ids=[driver.org_id])
-    if incident is None:
-        raise HTTPException(status_code=404, detail="Incident not found")
+    incident = _get_driver_incident(
+        db,
+        incident_id=incident_id,
+        driver=driver,
+    )
 
     event_kwargs = {
         "org_id": incident.org_id,
@@ -557,9 +584,6 @@ def write_driver_timeline_event(
         "actor_id": str(driver.driver_id),
         "payload": body.payload or {},
     }
-    if body.occurred_at_utc is not None:
-        event_kwargs["occurred_at_utc"] = body.occurred_at_utc
-
     event = Event(
         **event_kwargs,
     )
@@ -578,9 +602,11 @@ def driver_incident_status(
     db: Session = Depends(get_db),
 ):
     """Return status and evidence capture state for an incident."""
-    incident = get_incident(db, incident_id, org_ids=[driver.org_id])
-    if incident is None:
-        raise HTTPException(status_code=404, detail="Incident not found")
+    incident = _get_driver_incident(
+        db,
+        incident_id=incident_id,
+        driver=driver,
+    )
 
     summary = incident_status_summary(db, incident_id=incident_id)
     events = summary["events"]

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -355,7 +355,6 @@ class DriverInstructionAckResponse(BaseModel):
 
 class DriverTimelineEventWriteRequest(BaseModel):
     event_name: DriverTimelineEventName
-    occurred_at_utc: Optional[datetime] = None
     payload: dict = Field(default_factory=dict)
 
 

--- a/backend/app/db/migrations/versions/0008_add_artifact_uploaded_at.py
+++ b/backend/app/db/migrations/versions/0008_add_artifact_uploaded_at.py
@@ -1,0 +1,29 @@
+"""add uploaded timestamp to artifacts
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-04-06
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0008"
+down_revision: Union[str, None] = "0007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "artifacts",
+        sa.Column("uploaded_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("artifacts", "uploaded_at_utc")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -154,6 +154,7 @@ class Artifact(Base):
     s3_key = Column(Text, nullable=True)
     sha256 = Column(Text, nullable=True)
     byte_size = Column(BigInteger, nullable=True)
+    uploaded_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
     unavailable_reason_code = Column(Text, nullable=True)
     unavailable_reason_detail = Column(Text, nullable=True)
     created_at_utc = Column(

--- a/backend/app/services/artifact_upload_service.py
+++ b/backend/app/services/artifact_upload_service.py
@@ -34,20 +34,20 @@ def _validate_incident_driver_ownership(
     incident_id: uuid.UUID,
     driver: Driver,
 ) -> Incident:
-    incident = db.query(Incident).filter(Incident.incident_id == incident_id).first()
+    incident = (
+        db.query(Incident)
+        .filter(
+            Incident.incident_id == incident_id,
+            Incident.org_id == driver.org_id,
+            Incident.adc_driver_id == str(driver.driver_id),
+        )
+        .first()
+    )
     if incident is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Incident not found",
         )
-
-    if incident.org_id != driver.org_id:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
-
-    if incident.adc_driver_id is not None and incident.adc_driver_id != str(
-        driver.driver_id
-    ):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
 
     return incident
 
@@ -100,6 +100,7 @@ def issue_driver_artifact_upload_url(
         incident_id=incident.incident_id,
         artifact_type=normalized_artifact_type,
         status="pending",
+        capture_window_end_utc=datetime.now(timezone.utc),
     )
     ext = _file_extension(file_name)
     artifact.s3_bucket = settings.S3_ARTIFACTS_BUCKET
@@ -135,13 +136,18 @@ def complete_driver_artifact_upload(
     byte_size: int,
     sha256: str | None,
 ) -> Artifact:
-    _validate_incident_driver_ownership(db, incident_id=incident_id, driver=driver)
+    incident = _validate_incident_driver_ownership(
+        db,
+        incident_id=incident_id,
+        driver=driver,
+    )
 
     artifact = (
         db.query(Artifact)
         .filter(
             Artifact.artifact_id == artifact_id,
             Artifact.incident_id == incident_id,
+            Artifact.org_id == incident.org_id,
         )
         .first()
     )
@@ -154,7 +160,7 @@ def complete_driver_artifact_upload(
     artifact.status = "captured"
     artifact.byte_size = byte_size
     artifact.sha256 = sha256
-    artifact.capture_window_end_utc = datetime.now(timezone.utc)
+    artifact.uploaded_at_utc = datetime.now(timezone.utc)
     db.commit()
     db.refresh(artifact)
     return artifact

--- a/backend/app/services/driver_report_service.py
+++ b/backend/app/services/driver_report_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timezone
 
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
@@ -23,19 +24,19 @@ def _validate_incident_write_scope(
     incident_id: uuid.UUID,
     driver: Driver,
 ) -> Incident:
-    incident = db.query(Incident).filter(Incident.incident_id == incident_id).first()
+    incident = (
+        db.query(Incident)
+        .filter(
+            Incident.incident_id == incident_id,
+            Incident.org_id == driver.org_id,
+            Incident.adc_driver_id == str(driver.driver_id),
+        )
+        .first()
+    )
     if incident is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Incident not found"
         )
-
-    if incident.org_id != driver.org_id:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
-
-    if incident.adc_driver_id is not None and incident.adc_driver_id != str(
-        driver.driver_id
-    ):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
 
     return incident
 
@@ -89,6 +90,7 @@ def submit_driver_report(
     driver: Driver,
 ) -> None:
     incident = _validate_incident_write_scope(db, incident_id, driver)
+    submitted_at_utc = datetime.now(timezone.utc)
 
     db.add(
         Event(
@@ -97,9 +99,11 @@ def submit_driver_report(
             event_type=SystemEventType.DRIVER_REPORT_SUBMITTED.value,
             actor_type="driver_app",
             actor_id=str(driver.driver_id),
+            occurred_at_utc=submitted_at_utc,
             payload={
                 "driver_report_submitted": True,
                 "submitted": True,
+                "submitted_at_utc": submitted_at_utc.isoformat(),
             },
         )
     )

--- a/backend/tests/test_driver_admin_endpoints.py
+++ b/backend/tests/test_driver_admin_endpoints.py
@@ -618,6 +618,8 @@ class TestDriverInstructionAck:
         assert events[0].payload["instruction_set_id"] == str(
             instruction_set.instruction_set_id
         )
+        assert events[0].payload["acknowledged_at_utc"] is not None
+        assert events[0].occurred_at_utc is not None
 
 
 class TestDriverTimelineEvents:
@@ -656,6 +658,37 @@ class TestDriverTimelineEvents:
         assert event.actor_id == str(test_driver.driver_id)
         assert event.occurred_at_utc is not None
         assert event.payload["source"] == "driver-app"
+
+    def test_timeline_event_rejects_incident_owned_by_other_driver(
+        self, client, db_session, test_org, driver_headers
+    ):
+        other_driver = Driver(
+            org_id=test_org.id,
+            phone_e164="+15550009999",
+            display_name="Different Driver",
+        )
+        db_session.add(other_driver)
+        db_session.commit()
+        db_session.refresh(other_driver)
+
+        incident = Incident(
+            org_id=test_org.id,
+            adc_vehicle_id="veh-888",
+            adc_driver_id=str(other_driver.driver_id),
+            status="open",
+        )
+        db_session.add(incident)
+        db_session.commit()
+
+        resp = client.post(
+            f"/driver/incidents/{incident.incident_id}/timeline-events",
+            json={
+                "event_name": "driver_safety_gate_viewed",
+                "payload": {"source": "driver-app"},
+            },
+            headers=driver_headers,
+        )
+        assert resp.status_code == 404
 
 
 class TestDriverActiveIncidentAndStatus:
@@ -738,6 +771,37 @@ class TestDriverActiveIncidentAndStatus:
         assert data["protocol_started_at_utc"] is not None
         assert data["evidence_requested_at_utc"] is not None
         assert data["last_evidence_update_utc"] is not None
+
+    def test_status_rejects_incident_owned_by_other_driver(
+        self,
+        client,
+        db_session,
+        test_org,
+        driver_headers,
+    ):
+        other_driver = Driver(
+            org_id=test_org.id,
+            phone_e164="+15550008888",
+            display_name="Other Driver",
+        )
+        db_session.add(other_driver)
+        db_session.commit()
+        db_session.refresh(other_driver)
+
+        incident = Incident(
+            org_id=test_org.id,
+            adc_vehicle_id="veh-100",
+            adc_driver_id=str(other_driver.driver_id),
+            status="open",
+        )
+        db_session.add(incident)
+        db_session.commit()
+
+        resp = client.get(
+            f"/driver/incidents/{incident.incident_id}/status",
+            headers=driver_headers,
+        )
+        assert resp.status_code == 404
 
 
 

--- a/backend/tests/test_driver_artifact_routes.py
+++ b/backend/tests/test_driver_artifact_routes.py
@@ -112,6 +112,8 @@ def test_issue_upload_url_creates_pending_artifact(
     artifact = db_session.query(Artifact).filter(Artifact.incident_id == incident.incident_id).one()
     assert artifact.status == "pending"
     assert artifact.artifact_type == "driver_document"
+    assert artifact.capture_window_end_utc is not None
+    assert artifact.uploaded_at_utc is None
 
 
 def test_issue_upload_url_rejects_disallowed_content_type(client, seeded_driver_and_incident):
@@ -161,6 +163,8 @@ def test_complete_upload_marks_artifact_captured(client, db_session, seeded_driv
     db_session.refresh(artifact)
     assert artifact.status == "captured"
     assert artifact.byte_size == 2048
+    assert artifact.capture_window_end_utc is None
+    assert artifact.uploaded_at_utc is not None
 
 
 def test_list_artifacts_enforces_driver_ownership(client, db_session, seeded_driver_and_incident):
@@ -185,4 +189,43 @@ def test_list_artifacts_enforces_driver_ownership(client, db_session, seeded_dri
         headers=_driver_auth_headers(other_driver.driver_id),
     )
 
-    assert response.status_code == 403
+    assert response.status_code == 404
+
+
+def test_complete_rejects_cross_incident_artifact_id(
+    client,
+    db_session,
+    seeded_driver_and_incident,
+):
+    driver, incident = seeded_driver_and_incident
+    other_incident = Incident(
+        org_id=incident.org_id,
+        adc_driver_id=str(driver.driver_id),
+        adc_vehicle_id="veh-other",
+        status="open",
+    )
+    db_session.add(other_incident)
+    db_session.commit()
+    db_session.refresh(other_incident)
+
+    foreign_artifact = Artifact(
+        org_id=incident.org_id,
+        incident_id=other_incident.incident_id,
+        artifact_type="driver_photo",
+        status="pending",
+    )
+    db_session.add(foreign_artifact)
+    db_session.commit()
+    db_session.refresh(foreign_artifact)
+
+    response = client.post(
+        f"/driver/incidents/{incident.incident_id}/artifacts/complete",
+        headers=_driver_auth_headers(driver.driver_id),
+        json={
+            "artifact_id": str(foreign_artifact.artifact_id),
+            "byte_size": 2048,
+            "sha256": "b" * 64,
+        },
+    )
+
+    assert response.status_code == 404

--- a/backend/tests/test_driver_report_routes.py
+++ b/backend/tests/test_driver_report_routes.py
@@ -124,7 +124,7 @@ def test_patch_report_rejects_driver_not_owner(
         json={"narrative": "I saw brake lights and slowed down."},
     )
 
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
 def test_patch_parties_rejects_cross_org_write(
@@ -152,7 +152,7 @@ def test_patch_parties_rejects_cross_org_write(
         json={"parties": [{"name": "Witness A"}]},
     )
 
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
 def test_submit_driver_report_writes_submission_event(
@@ -180,3 +180,5 @@ def test_submit_driver_report_writes_submission_event(
     assert submission_event is not None
     assert submission_event.event_type == "driver_report_submitted"
     assert submission_event.payload["driver_report_submitted"] is True
+    assert submission_event.payload["submitted_at_utc"] is not None
+    assert submission_event.occurred_at_utc is not None


### PR DESCRIPTION
### Motivation
- Prevent unauthorized cross-org and cross-driver reads/writes on driver incident endpoints by ensuring incidents belong to the authenticated driver and org. 
- Ensure auditability by making instruction acknowledgements and driver report submissions use server-side timestamps instead of trusting client-supplied values. 
- Track artifact lifecycle more explicitly by separating capture and upload timestamps so capture issuance and upload completion are recorded independently.

### Description
- Add `uploaded_at_utc` to the `Artifact` model and supply Alembic migration `0008_add_artifact_uploaded_at.py` to add the column. 
- Tighten incident ownership checks by requiring `(incident_id, org_id, adc_driver_id)` to match the authenticated driver in `artifact_upload_service` and `driver_report_service`, and add `_get_driver_incident` helper in the driver routes to enforce the same for timeline writes and status reads. 
- Remove client-controlled `occurred_at_utc` from the driver timeline write request schema so timeline events are timestamped server-side. 
- Record server timestamps for instruction acknowledgements and driver report submissions by setting `occurred_at_utc` and including ISO8601 timestamp values in event payloads for `acknowledged_at_utc` and `submitted_at_utc`. 
- Separate artifact capture vs upload times by setting `capture_window_end_utc` when issuing an upload URL and setting `uploaded_at_utc` when the artifact is completed, and scope artifact completion lookups to the incident + org to prevent cross-incident mutation. 
- Update and add tests to assert ownership restrictions, cross-incident protection, and server-generated timestamps for ack/submission/upload lifecycle fields.

### Testing
- Ran `ruff` lint checks on the modified modules (passed). 
- Ran `pytest -q backend/tests/test_driver_artifact_routes.py backend/tests/test_driver_report_routes.py` and all tests passed (`9 passed`). 
- Ran `pytest -q backend/tests/test_driver_artifact_routes.py backend/tests/test_driver_report_routes.py backend/tests/test_driver_admin_endpoints.py` which failed during collection due to a pre-existing `NameError: get_current_user_org_ids` in `backend/app/api/routes_incidents.py` that is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d31c73d4648321a7d0f5fb7551be67)