### PR TITLE
Add release readiness checklist with go/no-go owners

### DIFF
--- a/docs/release-readiness-checklist.md
+++ b/docs/release-readiness-checklist.md
@@ -1,0 +1,53 @@
+# Release Readiness Checklist
+
+Use this checklist as the final go/no-go gate before a production release.
+
+## Required release gates
+
+- [ ] **All required endpoints deployed**
+  - [ ] Backend deployment includes every endpoint required by the release scope.
+  - [ ] Endpoint health checks pass in the target environment.
+  - [ ] API contract/version verification is complete.
+- [ ] **Critical screens implemented and navigable**
+  - [ ] All release-critical screens are present in the mobile and web builds.
+  - [ ] Navigation paths between critical screens are functional end-to-end.
+  - [ ] Blocking UX regressions are resolved or explicitly accepted.
+- [ ] **Audit events present**
+  - [ ] Required audit events are emitted for all critical user and system actions.
+  - [ ] Audit events are queryable in the logging/warehouse destination.
+  - [ ] Event payloads include required correlation identifiers.
+- [ ] **Analytics events firing**
+  - [ ] Release analytics events fire for primary user journeys.
+  - [ ] Event properties and naming conform to tracking spec.
+  - [ ] Events are visible in the analytics destination.
+- [ ] **Security checks passing**
+  - [ ] Authentication and authorization checks pass.
+  - [ ] Secrets/config checks are complete for target environment.
+  - [ ] Vulnerability and dependency checks pass at required severity threshold.
+- [ ] **Draft persistence and resume verified**
+  - [ ] In-progress drafts persist across app restart/session loss.
+  - [ ] Resume flow restores users to the correct step/state.
+  - [ ] Edge cases (offline/interrupted session) are validated.
+- [ ] **Upload retry reliability verified**
+  - [ ] Failed uploads are queued and retried automatically.
+  - [ ] Retry/backoff behavior matches expected policy.
+  - [ ] Upload eventually succeeds (or fails with actionable surfaced error) under flaky network simulation.
+
+## Go/No-Go owner sign-off
+
+Mark one status per owner and include links to evidence.
+
+| Area | Owner | Status (Go / No-Go) | Evidence / Notes |
+| --- | --- | --- | --- |
+| Mobile |  |  |  |
+| Backend |  |  |  |
+| QA |  |  |  |
+| Product |  |  |  |
+
+## Final release decision
+
+- Release date:
+- Release coordinator:
+- Final decision: **Go / No-Go**
+- Decision timestamp:
+- Risks accepted (if any):


### PR DESCRIPTION
### Motivation
- Provide a single, repeatable final go/no-go checklist for production releases that captures endpoint deployment, critical UI navigation, audit/analytics, security, draft resume behavior, and upload retry reliability, and assigns explicit go/no-go ownership for mobile, backend, QA, and product.

### Description
- Add `docs/release-readiness-checklist.md` which enumerates required release gates (endpoints, critical screens, audit events, analytics, security checks, draft persistence/resume, and upload retry reliability) and includes a go/no-go owner sign-off table for Mobile, Backend, QA, and Product plus a final release decision block.

### Testing
- Ran `make lint` and `make test`; both ran but failed due to pre-existing backend issues (undefined names in backend route modules causing lint errors and pytest collection `NameError`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d31dbd50588321b67af180585b4e6d)