### PR TITLE
Extend export schema and typed export status/progress across backend/frontend

### DIFF
--- a/backend/app/api/routes_exports.py
+++ b/backend/app/api/routes_exports.py
@@ -6,8 +6,8 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from app.api.schemas import DownloadExportResponse
-from app.core.deps import get_current_user
+from app.api.schemas import DownloadExportResponse, ExportSummary
+from app.core.deps import get_current_user, get_current_user_org_ids
 from app.core.logging import set_log_context
 from app.core.metrics import MetricNames, increment, timed
 from app.db.models import User
@@ -15,6 +15,7 @@ from app.db.session import get_db
 from app.db.repo.exports import get_export, list_exports_for_org_ids
 from app.db.repo.events import create_event
 from app.db.repo.incidents import get_incident
+from app.db.repo.users import get_user_org_ids
 from app.domain.system_event_types import SystemEventType
 from app.core.config import settings
 from app.services.vault_s3 import (
@@ -39,7 +40,32 @@ def _get_export_owner_org_id(db: Session, export):
     return incident.org_id
 
 
-@router.get("/")
+def _serialize_export(export):
+    return {
+        "export_id": str(export.export_id),
+        "incident_id": str(export.incident_id),
+        "export_type": export.export_type,
+        "requested_by_user_id": (
+            str(export.requested_by_user_id) if export.requested_by_user_id else None
+        ),
+        "options_json": export.options_json or {},
+        "status": export.status,
+        "progress_stage": export.progress_stage,
+        "error_message": export.error_message,
+        "package_sha256": export.package_sha256,
+        "byte_size": export.byte_size,
+        "artifact_count": export.artifact_count,
+        "timeline_event_count": export.timeline_event_count,
+        "requested_at_utc": export.requested_at_utc,
+        "processing_started_at_utc": export.processing_started_at_utc,
+        "completed_at_utc": export.completed_at_utc,
+        "expires_at_utc": export.expires_at_utc,
+        "created_at_utc": export.created_at_utc,
+        "updated_at_utc": export.updated_at_utc,
+    }
+
+
+@router.get("/", response_model=list[ExportSummary])
 def list_exports_endpoint(
     db: Session = Depends(get_db),
     org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
@@ -50,18 +76,10 @@ def list_exports_endpoint(
         user_id=str(current_user.id), org_id=str(org_ids[0]) if org_ids else None
     )
     exports = list_exports_for_org_ids(db, org_ids)
-    return [
-        {
-            "export_id": str(export.export_id),
-            "incident_id": str(export.incident_id),
-            "status": export.status,
-            "created_at_utc": export.created_at_utc,
-        }
-        for export in exports
-    ]
+    return [_serialize_export(export) for export in exports]
 
 
-@router.get("/{export_id}")
+@router.get("/{export_id}", response_model=ExportSummary)
 def get_export_endpoint(
     export_id: uuid.UUID,
     db: Session = Depends(get_db),
@@ -82,11 +100,7 @@ def get_export_endpoint(
         increment(MetricNames.EXPORT_DOWNLOAD_FAILURES)
         raise HTTPException(status_code=403, detail="Forbidden")
 
-    return {
-        "export_id": str(export.export_id),
-        "incident_id": str(export.incident_id),
-        "status": export.status,
-    }
+    return _serialize_export(export)
 
 
 @router.get("/{export_id}/download", response_model=DownloadExportResponse)
@@ -150,4 +164,5 @@ def download_export_endpoint(
         export_id=export.export_id,
         url=presigned_url,
         status="ready",
+        progress_stage="ready_for_download",
     )

--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -16,7 +16,12 @@ from app.api.schemas import (
     IncidentDetailResponse,
     IncidentListItem,
 )
-from app.core.deps import get_current_user
+from app.core.deps import (
+    enforce_resource_org_ownership,
+    get_current_user,
+    get_current_user_org_ids,
+    get_current_user_primary_org_id,
+)
 from app.core.logging import get_request_id, set_log_context
 from app.core.metrics import MetricNames, increment, timed
 from app.db.models import User
@@ -180,10 +185,29 @@ def get_incident_endpoint(
         export_status=[
             ExportSummary(
                 export_id=e.export_id,
+                incident_id=e.incident_id,
+                export_type=e.export_type,
+                requested_by_user_id=e.requested_by_user_id,
+                options_json=e.options_json or {},
                 status=e.status,
-                created_at_utc=e.created_at_utc.isoformat()
-                if e.created_at_utc
+                progress_stage=e.progress_stage,
+                error_message=e.error_message,
+                package_sha256=e.package_sha256,
+                byte_size=e.byte_size,
+                artifact_count=e.artifact_count,
+                timeline_event_count=e.timeline_event_count,
+                requested_at_utc=e.requested_at_utc.isoformat()
+                if e.requested_at_utc
                 else None,
+                processing_started_at_utc=e.processing_started_at_utc.isoformat()
+                if e.processing_started_at_utc
+                else None,
+                completed_at_utc=e.completed_at_utc.isoformat()
+                if e.completed_at_utc
+                else None,
+                expires_at_utc=e.expires_at_utc.isoformat() if e.expires_at_utc else None,
+                created_at_utc=e.created_at_utc.isoformat() if e.created_at_utc else None,
+                updated_at_utc=e.updated_at_utc.isoformat() if e.updated_at_utc else None,
             )
             for e in exports
         ],
@@ -229,6 +253,9 @@ def request_export_endpoint(
         incident_id=incident_id,
         org_id=incident.org_id,
         status="requested",
+        export_type="court_defense",
+        requested_by_user_id=current_user.id,
+        progress_stage="request_accepted",
     )
 
     create_event(
@@ -243,4 +270,4 @@ def request_export_endpoint(
     logger.info("Queueing export build task", extra={"request_id": get_request_id()})
     build_export.delay(str(incident_id), str(export.export_id))
 
-    return CreateExportResponse(export_id=export.export_id, status=export.status)
+    return CreateExportResponse(export_id=export.export_id, status=export.status, progress_stage=export.progress_stage)

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -2,9 +2,11 @@
 
 import uuid
 from datetime import datetime
-from typing import Annotated, Literal, Optional
+from typing import Annotated, Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+
+from app.domain.exports import EXPORT_PROGRESS_STAGES, EXPORT_STATUSES, EXPORT_TYPES
 
 EmailStrLike = Annotated[
     str,
@@ -51,7 +53,13 @@ InstructionScope = Literal["default", "company", "insurer"]
 IncidentSeverity = Literal["minor", "serious", "critical"]
 IncidentStatus = Literal["open", "evidence_capturing", "closed"]
 ArtifactStatus = Literal["pending", "captured", "unavailable"]
-ExportStatus = Literal["requested", "processing", "ready", "failed"]
+ExportType = Literal["court_defense", "insurer_packet", "internal_review", "compliance_audit"]
+ExportStatus = Literal["requested", "queued", "processing", "ready", "failed", "expired"]
+ExportProgressStage = Literal["request_accepted", "gathering_incident_data", "assembling_documents", "packaging_evidence", "uploading_export", "ready_for_download"]
+
+assert set(EXPORT_TYPES) == {"court_defense", "insurer_packet", "internal_review", "compliance_audit"}
+assert set(EXPORT_STATUSES) == {"requested", "queued", "processing", "ready", "failed", "expired"}
+assert set(EXPORT_PROGRESS_STAGES) == {"request_accepted", "gathering_incident_data", "assembling_documents", "packaging_evidence", "uploading_export", "ready_for_download"}
 VehicleStrategy = Literal["qr", "last_assigned"]
 CaptureState = Literal[
     "failed", "complete", "in_progress", "requested", "lockdown", "closed", "pending"
@@ -151,8 +159,23 @@ class ArtifactSummary(BaseModel):
 
 class ExportSummary(BaseModel):
     export_id: uuid.UUID
+    incident_id: Optional[uuid.UUID] = None
+    export_type: ExportType = "court_defense"
+    requested_by_user_id: Optional[uuid.UUID] = None
+    options_json: dict[str, Any] = Field(default_factory=dict)
     status: ExportStatus
+    progress_stage: ExportProgressStage = "request_accepted"
+    error_message: Optional[str] = None
+    package_sha256: Optional[str] = None
+    byte_size: Optional[int] = None
+    artifact_count: int = Field(default=0, ge=0)
+    timeline_event_count: int = Field(default=0, ge=0)
+    requested_at_utc: Optional[datetime] = None
+    processing_started_at_utc: Optional[datetime] = None
+    completed_at_utc: Optional[datetime] = None
+    expires_at_utc: Optional[datetime] = None
     created_at_utc: Optional[datetime] = None
+    updated_at_utc: Optional[datetime] = None
 
 
 class EventSummary(BaseModel):
@@ -193,12 +216,14 @@ class IncidentDetailResponse(BaseModel):
 class CreateExportResponse(BaseModel):
     export_id: uuid.UUID
     status: ExportStatus
+    progress_stage: ExportProgressStage = "request_accepted"
 
 
 class DownloadExportResponse(BaseModel):
     export_id: uuid.UUID
     url: Annotated[str, StringConstraints(min_length=1, max_length=4096)]
     status: ExportStatus
+    progress_stage: ExportProgressStage = "ready_for_download"
 
 
 # ── Driver ──────────────────────────────────────────────────────────

--- a/backend/app/db/migrations/versions/0009_extend_export_schema.py
+++ b/backend/app/db/migrations/versions/0009_extend_export_schema.py
@@ -1,0 +1,134 @@
+"""extend export schema with typed metadata and progress tracking
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-04-06
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0009"
+down_revision: Union[str, None] = "0008"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE TYPE export_type AS ENUM ('court_defense', 'insurer_packet', 'internal_review', 'compliance_audit')"
+    )
+    op.execute(
+        "CREATE TYPE export_progress_stage AS ENUM ('request_accepted', 'gathering_incident_data', 'assembling_documents', 'packaging_evidence', 'uploading_export', 'ready_for_download')"
+    )
+
+    op.execute("ALTER TYPE export_status ADD VALUE IF NOT EXISTS 'queued'")
+    op.execute("ALTER TYPE export_status ADD VALUE IF NOT EXISTS 'expired'")
+
+    op.add_column(
+        "exports",
+        sa.Column(
+            "export_type",
+            sa.Enum(name="export_type", create_type=False),
+            nullable=False,
+            server_default="court_defense",
+        ),
+    )
+    op.add_column(
+        "exports",
+        sa.Column(
+            "requested_by_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "exports",
+        sa.Column(
+            "options_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "exports",
+        sa.Column(
+            "progress_stage",
+            sa.Enum(name="export_progress_stage", create_type=False),
+            nullable=False,
+            server_default="request_accepted",
+        ),
+    )
+    op.add_column("exports", sa.Column("error_message", sa.Text(), nullable=True))
+    op.add_column("exports", sa.Column("package_sha256", sa.Text(), nullable=True))
+    op.add_column("exports", sa.Column("byte_size", sa.BigInteger(), nullable=True))
+    op.add_column(
+        "exports",
+        sa.Column("artifact_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "exports",
+        sa.Column(
+            "timeline_event_count", sa.Integer(), nullable=False, server_default="0"
+        ),
+    )
+    op.add_column(
+        "exports",
+        sa.Column(
+            "requested_at_utc",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.add_column(
+        "exports",
+        sa.Column("processing_started_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "exports",
+        sa.Column("completed_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "exports",
+        sa.Column("expires_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "exports",
+        sa.Column(
+            "updated_at_utc",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    op.execute("UPDATE exports SET requested_at_utc = created_at_utc WHERE requested_at_utc IS NULL")
+    op.execute("UPDATE exports SET updated_at_utc = created_at_utc WHERE updated_at_utc IS NULL")
+
+
+def downgrade() -> None:
+    op.drop_column("exports", "updated_at_utc")
+    op.drop_column("exports", "expires_at_utc")
+    op.drop_column("exports", "completed_at_utc")
+    op.drop_column("exports", "processing_started_at_utc")
+    op.drop_column("exports", "requested_at_utc")
+    op.drop_column("exports", "timeline_event_count")
+    op.drop_column("exports", "artifact_count")
+    op.drop_column("exports", "byte_size")
+    op.drop_column("exports", "package_sha256")
+    op.drop_column("exports", "error_message")
+    op.drop_column("exports", "progress_stage")
+    op.drop_column("exports", "options_json")
+    op.drop_column("exports", "requested_by_user_id")
+    op.drop_column("exports", "export_type")
+
+    op.execute("DROP TYPE export_progress_stage")
+    op.execute("DROP TYPE export_type")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -17,6 +17,8 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import UUID, JSONB, TIMESTAMP
 from sqlalchemy.orm import declarative_base
 
+from app.domain.exports import EXPORT_PROGRESS_STAGES, EXPORT_STATUSES, EXPORT_TYPES
+
 Base = declarative_base()
 
 
@@ -182,15 +184,44 @@ class Export(Base):
         nullable=False,
         index=True,
     )
+    export_type = Column(
+        Enum(*EXPORT_TYPES, name="export_type"),
+        nullable=False,
+        default="court_defense",
+        server_default="court_defense",
+    )
+    requested_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    options_json = Column(JSONB, nullable=False, default=dict)
     status = Column(
-        Enum("requested", "processing", "ready", "failed", name="export_status"),
+        Enum(*EXPORT_STATUSES, name="export_status"),
         nullable=False,
         default="requested",
+        server_default="requested",
     )
+    progress_stage = Column(
+        Enum(*EXPORT_PROGRESS_STAGES, name="export_progress_stage"),
+        nullable=False,
+        default="request_accepted",
+        server_default="request_accepted",
+    )
+    error_message = Column(Text, nullable=True)
+    package_sha256 = Column(Text, nullable=True)
+    byte_size = Column(BigInteger, nullable=True)
+    artifact_count = Column(Integer, nullable=False, default=0, server_default="0")
+    timeline_event_count = Column(Integer, nullable=False, default=0, server_default="0")
+    requested_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    processing_started_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    completed_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    expires_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
     s3_bucket = Column(Text, nullable=True)
     s3_key = Column(Text, nullable=True)
     created_at_utc = Column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
     )
 
     __table_args__ = (Index("ix_exports_org_incident", "org_id", "incident_id"),)

--- a/backend/app/db/repo/exports.py
+++ b/backend/app/db/repo/exports.py
@@ -1,7 +1,7 @@
 """Repository layer for exports."""
 
 import uuid as _uuid
-from typing import Optional
+from typing import Any, Optional
 
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
@@ -48,6 +48,10 @@ def create_export(
     incident_id: _uuid.UUID,
     org_id: Optional[_uuid.UUID] = None,
     status: str = "requested",
+    export_type: str = "court_defense",
+    requested_by_user_id: Optional[_uuid.UUID] = None,
+    options_json: Optional[dict[str, Any]] = None,
+    progress_stage: str = "request_accepted",
     s3_bucket: Optional[str] = None,
     s3_key: Optional[str] = None,
 ) -> Export:
@@ -55,7 +59,11 @@ def create_export(
     export = Export(
         org_id=org_id,
         incident_id=incident_id,
+        export_type=export_type,
+        requested_by_user_id=requested_by_user_id,
+        options_json=options_json or {},
         status=status,
+        progress_stage=progress_stage,
         s3_bucket=s3_bucket,
         s3_key=s3_key,
     )
@@ -69,6 +77,12 @@ def update_export(
     db: Session,
     export_id: _uuid.UUID,
     status: Optional[str] = None,
+    progress_stage: Optional[str] = None,
+    error_message: Optional[str] = None,
+    package_sha256: Optional[str] = None,
+    byte_size: Optional[int] = None,
+    artifact_count: Optional[int] = None,
+    timeline_event_count: Optional[int] = None,
     s3_bucket: Optional[str] = None,
     s3_key: Optional[str] = None,
 ) -> Optional[Export]:
@@ -81,6 +95,18 @@ def update_export(
     # Only update fields that are provided
     if status is not None:
         export.status = status
+    if progress_stage is not None:
+        export.progress_stage = progress_stage
+    if error_message is not None:
+        export.error_message = error_message
+    if package_sha256 is not None:
+        export.package_sha256 = package_sha256
+    if byte_size is not None:
+        export.byte_size = byte_size
+    if artifact_count is not None:
+        export.artifact_count = artifact_count
+    if timeline_event_count is not None:
+        export.timeline_event_count = timeline_event_count
     if s3_bucket is not None:
         export.s3_bucket = s3_bucket
     if s3_key is not None:

--- a/backend/app/domain/exports.py
+++ b/backend/app/domain/exports.py
@@ -1,0 +1,26 @@
+"""Shared export constants and enum value sets."""
+
+EXPORT_TYPES: tuple[str, ...] = (
+    "court_defense",
+    "insurer_packet",
+    "internal_review",
+    "compliance_audit",
+)
+
+EXPORT_STATUSES: tuple[str, ...] = (
+    "requested",
+    "queued",
+    "processing",
+    "ready",
+    "failed",
+    "expired",
+)
+
+EXPORT_PROGRESS_STAGES: tuple[str, ...] = (
+    "request_accepted",
+    "gathering_incident_data",
+    "assembling_documents",
+    "packaging_evidence",
+    "uploading_export",
+    "ready_for_download",
+)

--- a/backend/tests/test_exports.py
+++ b/backend/tests/test_exports.py
@@ -145,7 +145,7 @@ def test_list_exports_filters_by_org_including_legacy_null_org_exports(
 
     for export in [caller_export, legacy_caller_export]:
         row = by_id[str(export.export_id)]
-        assert set(["export_id", "incident_id", "status", "created_at_utc"]).issubset(
+        assert set(["export_id", "incident_id", "export_type", "status", "progress_stage", "artifact_count", "timeline_event_count", "created_at_utc", "updated_at_utc"]).issubset(
             row.keys()
         )
         assert row["incident_id"] == str(export.incident_id)

--- a/backend/tests/test_frontend_contracts.py
+++ b/backend/tests/test_frontend_contracts.py
@@ -223,7 +223,15 @@ def test_export_response_contract_matches_frontend(
     assert export_resp.status_code == 201
     payload = export_resp.json()
 
-    for field in ("export_id", "status"):
+    for field in ("export_id", "status", "progress_stage"):
         assert field in payload
     _assert_uuid(payload["export_id"])
-    assert payload["status"] in {"requested", "processing", "ready", "failed"}
+    assert payload["status"] in {"requested", "queued", "processing", "ready", "failed", "expired"}
+    assert payload["progress_stage"] in {
+        "request_accepted",
+        "gathering_incident_data",
+        "assembling_documents",
+        "packaging_evidence",
+        "uploading_export",
+        "ready_for_download",
+    }

--- a/backend/tests/test_model_improvements.py
+++ b/backend/tests/test_model_improvements.py
@@ -150,7 +150,7 @@ class TestStatusEnums:
         db.commit()
 
         # Test all valid status values
-        for status in ["requested", "processing", "ready", "failed"]:
+        for status in ["requested", "queued", "processing", "ready", "failed", "expired"]:
             export = Export(
                 incident_id=incident.incident_id,
                 status=status,

--- a/frontend/app/exports/page.tsx
+++ b/frontend/app/exports/page.tsx
@@ -8,6 +8,7 @@ import {
   downloadExport,
   type ExportListItem,
 } from "@/lib/api";
+import { getExportStatusBadgeClass, getExportStatusLabel } from "@/lib/exportStatus";
 
 /**
  * Exports listing page.  Displays all exports available to the current
@@ -139,16 +140,8 @@ export default function ExportsPage() {
                         : "—"}
                     </td>
                     <td className="px-4 py-3">
-                      <span
-                        className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-                          ex.status === "ready"
-                            ? "bg-green-100 text-green-800"
-                            : ex.status === "failed"
-                            ? "bg-red-100 text-red-800"
-                            : "bg-yellow-100 text-yellow-800"
-                        }`}
-                      >
-                        {ex.status}
+                      <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${getExportStatusBadgeClass(ex.status)}`}>
+                        {getExportStatusLabel(ex.status)}
                       </span>
                     </td>
                     <td className="px-4 py-3 text-gray-600 dark:text-gray-400">

--- a/frontend/components/ExportPanel.tsx
+++ b/frontend/components/ExportPanel.tsx
@@ -10,6 +10,7 @@
 "use client";
 
 import { type ExportSummary } from "@/lib/api";
+import { getExportStatusBadgeClass, getExportStatusLabel } from "@/lib/exportStatus";
 
 function formatTime(iso?: string | null): string {
   if (!iso) return "—";
@@ -162,16 +163,8 @@ export default function ExportPanel({
                 </span>
               </div>
               <div className="flex items-center gap-2">
-                <span
-                  className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-                    ex.status === "ready"
-                      ? "bg-green-100 text-green-800"
-                      : ex.status === "failed"
-                      ? "bg-red-100 text-red-800"
-                      : "bg-yellow-100 text-yellow-800"
-                  }`}
-                >
-                  {ex.status}
+                <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${getExportStatusBadgeClass(ex.status)}`}>
+                  {getExportStatusLabel(ex.status)}
                 </span>
                 {ex.status === "ready" && (
                   <button

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -106,6 +106,29 @@ export function getMe() {
 
 /* ── Incidents ─────────────────────────────────────────────────── */
 
+
+export type ExportType =
+  | "court_defense"
+  | "insurer_packet"
+  | "internal_review"
+  | "compliance_audit";
+
+export type ExportStatus =
+  | "requested"
+  | "queued"
+  | "processing"
+  | "ready"
+  | "failed"
+  | "expired";
+
+export type ExportProgressStage =
+  | "request_accepted"
+  | "gathering_incident_data"
+  | "assembling_documents"
+  | "packaging_evidence"
+  | "uploading_export"
+  | "ready_for_download";
+
 export interface Incident {
   incident_id: string;
   status: string;
@@ -146,11 +169,25 @@ export interface ArtifactSummary {
 
 export interface ExportSummary {
   export_id: string;
-  status: string;
+  incident_id?: string | null;
+  export_type: ExportType;
+  requested_by_user_id?: string | null;
+  options_json: Record<string, unknown>;
+  status: ExportStatus;
+  progress_stage: ExportProgressStage;
+  error_message?: string | null;
+  package_sha256?: string | null;
+  byte_size?: number | null;
+  artifact_count: number;
+  timeline_event_count: number;
+  requested_at_utc?: string | null;
+  processing_started_at_utc?: string | null;
+  completed_at_utc?: string | null;
+  expires_at_utc?: string | null;
   created_at_utc?: string | null;
+  updated_at_utc?: string | null;
   generated_by?: string | null;
   generation_duration_seconds?: number | null;
-  artifact_count?: number | null;
   failure_count?: number | null;
   failure_reason?: string | null;
   retry_guidance?: string | null;
@@ -211,14 +248,14 @@ export function getIncident(id: string) {
 }
 
 export function requestExport(incidentId: string) {
-  return request<{ export_id: string; status: string }>(
+  return request<{ export_id: string; status: ExportStatus; progress_stage: ExportProgressStage }>(
     `/incidents/${incidentId}/exports`,
     { method: "POST" }
   );
 }
 
 export function downloadExport(exportId: string) {
-  return request<{ export_id: string; url: string; status: string }>(
+  return request<{ export_id: string; url: string; status: ExportStatus; progress_stage: ExportProgressStage }>(
     `/exports/${exportId}/download`
   );
 }

--- a/frontend/lib/exportStatus.ts
+++ b/frontend/lib/exportStatus.ts
@@ -1,0 +1,20 @@
+import type { ExportStatus } from "@/lib/api";
+
+export const EXPORT_STATUS_LABELS: Record<ExportStatus, string> = {
+  requested: "Requested",
+  queued: "Queued",
+  processing: "Processing",
+  ready: "Ready",
+  failed: "Failed",
+  expired: "Expired",
+};
+
+export function getExportStatusLabel(status: ExportStatus): string {
+  return EXPORT_STATUS_LABELS[status];
+}
+
+export function getExportStatusBadgeClass(status: ExportStatus): string {
+  if (status === "ready") return "bg-green-100 text-green-800";
+  if (status === "failed" || status === "expired") return "bg-red-100 text-red-800";
+  return "bg-yellow-100 text-yellow-800";
+}


### PR DESCRIPTION
### Motivation
- Introduce shared, canonical export enums and progress stages so backend and frontend use the same value set for `export_type`, `export_status`, and progress stages. 
- Extend the `Export` record to store Section 13 metadata (type, requester, options, progress stage, error/package metadata, counts, timestamps) so export generation can be tracked, audited and surfaced to the UI. 
- Keep existing rows and behaviour backward-compatible while exposing richer data to API clients and the UI. 

### Description
- Added `backend/app/domain/exports.py` with `EXPORT_TYPES`, `EXPORT_STATUSES`, and `EXPORT_PROGRESS_STAGES` constants for shared enum values. 
- Extended the SQLAlchemy `Export` model with Section 13 fields (`export_type`, `requested_by_user_id`, `options_json`, `progress_stage`, `error_message`, `package_sha256`, `byte_size`, `artifact_count`, `timeline_event_count`, `requested_at_utc`, `processing_started_at_utc`, `completed_at_utc`, `expires_at_utc`, `updated_at_utc`) and wired server defaults. 
- Added Alembic migration `backend/app/db/migrations/versions/0009_extend_export_schema.py` to create new enum types, add the new columns, add `queued`/`expired` to `export_status`, and backfill `requested_at_utc`/`updated_at_utc` from existing `created_at_utc`. 
- Updated repository helpers (`create_export`, `update_export`) to accept and persist the new fields while preserving backward-compatible defaults. 
- Exposed expanded export fields in Pydantic schemas (`ExportSummary`, `CreateExportResponse`, `DownloadExportResponse`) and updated API endpoints to serialize the new fields for list/detail/download surfaces. 
- Frontend: added strict TypeScript unions and models in `frontend/lib/api.ts` for `ExportType`, `ExportStatus`, `ExportProgressStage` and expanded `ExportSummary`/`ExportListItem` to match backend responses. 
- Frontend: added centralized status label/badge mapping in `frontend/lib/exportStatus.ts` and updated export UI components to use exact labels `Requested`, `Queued`, `Processing`, `Ready`, `Failed` (and `Expired` optionally). 
- Updated backend tests to include the expanded status/stage value-sets and ensure contract compatibility with the frontend DTO shape. 

### Testing
- Ran backend linting with `cd backend && ruff check app tests` and the linter passed. 
- Ran backend unit/contract tests with `cd backend && pytest -q tests/test_exports.py tests/test_frontend_contracts.py tests/test_model_improvements.py` and all selected backend tests passed (`21 passed`, 3 warnings). 
- Ran frontend checks with `cd frontend && npm run lint` (passes but reports one pre-existing ESLint warning in `frontend/components/marketing/Hero.tsx`), and `cd frontend && npm run typecheck && npm test` which succeeded (typecheck and frontend test harness passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d31eeee22483219289a08cb85216df)