### PR TITLE
Add POST /exports endpoint with enqueueing, validation, and audit events

### DIFF
--- a/backend/app/api/routes_exports.py
+++ b/backend/app/api/routes_exports.py
@@ -6,18 +6,29 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from app.api.schemas import DownloadExportResponse, ExportSummary
-from app.core.deps import get_current_user, get_current_user_org_ids
+from app.api.schemas import (
+    CreateExportEnqueueResponse,
+    CreateExportRequest,
+    DownloadExportResponse,
+    ExportSummary,
+)
+from app.core.deps import (
+    enforce_resource_org_ownership,
+    get_current_user,
+    get_current_user_org_ids,
+    require_user_role,
+)
 from app.core.logging import set_log_context
 from app.core.metrics import MetricNames, increment, timed
 from app.db.models import User
 from app.db.session import get_db
-from app.db.repo.exports import get_export, list_exports_for_org_ids
+from app.db.repo.exports import create_export, get_export, list_exports_for_org_ids, update_export
 from app.db.repo.events import create_event
 from app.db.repo.incidents import get_incident
 from app.db.repo.users import get_user_org_ids
 from app.domain.system_event_types import SystemEventType
 from app.core.config import settings
+from app.tasks.export_tasks import build_export
 from app.services.vault_s3 import (
     S3PresignConfigurationError,
     S3PresignGenerationError,
@@ -27,6 +38,85 @@ from app.services.vault_s3 import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+@router.post("/", response_model=CreateExportEnqueueResponse, status_code=201)
+def create_export_endpoint(
+    body: CreateExportRequest,
+    db: Session = Depends(get_db),
+    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
+    current_user: User = Depends(require_user_role("admin", "safety_manager")),
+):
+    increment(MetricNames.EXPORT_REQUEST_ATTEMPTS)
+
+    org_ids = get_user_org_ids(db, current_user.id)
+    incident = get_incident(db, body.incident_id)
+    if incident is None:
+        increment(MetricNames.EXPORT_REQUEST_FAILURES)
+        raise HTTPException(status_code=404, detail="Incident not found")
+    enforce_resource_org_ownership(incident.org_id, org_ids)
+
+    set_log_context(
+        user_id=str(current_user.id),
+        org_id=str(incident.org_id) if incident.org_id else None,
+    )
+
+    export = create_export(
+        db,
+        incident_id=body.incident_id,
+        org_id=incident.org_id,
+        status="requested",
+        export_type=body.export_type,
+        requested_by_user_id=current_user.id,
+        options_json=body.options_json,
+        progress_stage="request_accepted",
+    )
+
+    create_event(
+        db,
+        incident_id=body.incident_id,
+        event_type=SystemEventType.EXPORT_REQUESTED,
+        actor_type="user",
+        actor_id=str(current_user.id),
+        payload={"export_id": str(export.export_id), "export_type": body.export_type},
+    )
+
+    try:
+        task_result = build_export.delay(
+            str(body.incident_id),
+            str(export.export_id),
+            {"attempt_number": 1, "trigger": "api"},
+        )
+    except Exception as exc:
+        increment(MetricNames.EXPORT_REQUEST_FAILURES)
+        logger.exception("Failed to enqueue export task")
+        raise HTTPException(
+            status_code=502,
+            detail="Unable to enqueue export generation",
+        ) from exc
+
+    export = update_export(db, export.export_id, status="queued") or export
+    task_id = getattr(task_result, "id", None)
+    create_event(
+        db,
+        incident_id=body.incident_id,
+        event_type=SystemEventType.EXPORT_QUEUED,
+        actor_type="system",
+        actor_id="api",
+        payload={
+            "export_id": str(export.export_id),
+            "task_id": str(task_id) if isinstance(task_id, (str, uuid.UUID)) else None,
+            "attempt_number": 1,
+        },
+    )
+
+    return CreateExportEnqueueResponse(
+        export_id=export.export_id,
+        incident_id=export.incident_id,
+        export_type=export.export_type,
+        status=export.status,
+        created_at_utc=export.created_at_utc,
+    )
 
 
 def _get_export_owner_org_id(db: Session, export):

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Annotated, Any, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
 
 from app.domain.exports import EXPORT_PROGRESS_STAGES, EXPORT_STATUSES, EXPORT_TYPES
 
@@ -217,6 +217,46 @@ class CreateExportResponse(BaseModel):
     export_id: uuid.UUID
     status: ExportStatus
     progress_stage: ExportProgressStage = "request_accepted"
+
+
+class CreateExportRequest(BaseModel):
+    incident_id: uuid.UUID
+    export_type: ExportType = "court_defense"
+    options_json: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_options_for_export_type(self):
+        options = dict(self.options_json or {})
+
+        if self.export_type == "court_defense":
+            profile = options.get("profile", "mvp_default")
+            if profile != "mvp_default":
+                raise ValueError(
+                    "options_json.profile must be 'mvp_default' for court_defense exports"
+                )
+
+            unknown_keys = set(options.keys()) - {"profile"}
+            if unknown_keys:
+                raise ValueError(
+                    "options_json contains unsupported fields for court_defense exports"
+                )
+
+            self.options_json = {"profile": "mvp_default"}
+            return self
+
+        if options:
+            raise ValueError(
+                f"options_json is not supported for export_type '{self.export_type}'"
+            )
+        return self
+
+
+class CreateExportEnqueueResponse(BaseModel):
+    export_id: uuid.UUID
+    incident_id: uuid.UUID
+    export_type: ExportType
+    status: ExportStatus
+    created_at_utc: datetime
 
 
 class DownloadExportResponse(BaseModel):

--- a/backend/app/domain/system_event_types.py
+++ b/backend/app/domain/system_event_types.py
@@ -30,6 +30,7 @@ class SystemEventType(str, Enum):
 
     # ── Exports ─────────────────────────────────────────────────────
     EXPORT_REQUESTED = "export_requested"
+    EXPORT_QUEUED = "export_queued"
     EXPORT_GENERATED = "export_generated"
     EXPORT_FAILED = "export_failed"
     EXPORT_DOWNLOADED = "export_downloaded"

--- a/backend/app/tasks/export_tasks.py
+++ b/backend/app/tasks/export_tasks.py
@@ -119,7 +119,12 @@ def _safe_artifact_type(artifact_type):
     soft_time_limit=300,
     time_limit=360,
 )
-def build_export(self, incident_id: str, export_id: str):
+def build_export(
+    self,
+    incident_id: str,
+    export_id: str,
+    attempt_context: dict | None = None,
+):
     """Generate an export package for an incident.
 
     Steps:
@@ -134,6 +139,10 @@ def build_export(self, incident_id: str, export_id: str):
     9. Emit EXPORT_GENERATED
     """
     increment("exports.build.attempts")
+    logger.info(
+        "Starting export build task",
+        extra={"incident_id": incident_id, "export_id": export_id, "attempt_context": attempt_context or {}},
+    )
     from app.core.config import settings
     from app.db.repo.artifacts import get_artifacts_by_incident
     from app.db.repo.events import get_events_by_incident

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -398,11 +398,11 @@ class TestListIncidents:
         assert "created_at_utc" in inc
 
 
-# ── POST /incidents/{incident_id}/exports ───────────────────────────
+# ── POST /exports ────────────────────────────────────────────────────
 
 
 class TestRequestExport:
-    @patch("app.api.routes_incidents.build_export")
+    @patch("app.api.routes_exports.build_export")
     @patch("app.api.routes_incidents.capture_telematics_bundle")
     @patch("app.api.routes_incidents.capture_dashcam")
     def test_request_export_returns_201(
@@ -424,13 +424,20 @@ class TestRequestExport:
         )
         incident_id = create_resp.json()["incident_id"]
 
-        resp = client.post(f"/incidents/{incident_id}/exports", headers=auth_headers)
+        resp = client.post(
+            "/exports/",
+            json={"incident_id": incident_id, "export_type": "court_defense"},
+            headers=auth_headers,
+        )
         assert resp.status_code == 201
         data = resp.json()
         assert "export_id" in data
-        assert data["status"] == "requested"
+        assert data["status"] == "queued"
+        assert data["incident_id"] == incident_id
+        assert data["export_type"] == "court_defense"
+        assert data["created_at_utc"] is not None
 
-    @patch("app.api.routes_incidents.build_export")
+    @patch("app.api.routes_exports.build_export")
     @patch("app.api.routes_incidents.capture_telematics_bundle")
     @patch("app.api.routes_incidents.capture_dashcam")
     def test_request_export_enqueues_task(
@@ -452,13 +459,25 @@ class TestRequestExport:
         )
         incident_id = create_resp.json()["incident_id"]
 
-        resp = client.post(f"/incidents/{incident_id}/exports", headers=auth_headers)
+        resp = client.post(
+            "/exports/",
+            json={"incident_id": incident_id, "export_type": "court_defense"},
+            headers=auth_headers,
+        )
         export_id = resp.json()["export_id"]
-        mock_gen.delay.assert_called_once_with(incident_id, export_id)
+        mock_gen.delay.assert_called_once_with(
+            incident_id,
+            export_id,
+            {"attempt_number": 1, "trigger": "api"},
+        )
 
     def test_request_export_incident_not_found(self, client, auth_headers):
         fake_id = str(uuid.uuid4())
-        resp = client.post(f"/incidents/{fake_id}/exports", headers=auth_headers)
+        resp = client.post(
+            "/exports/",
+            json={"incident_id": fake_id, "export_type": "court_defense"},
+            headers=auth_headers,
+        )
         assert resp.status_code == 404
 
     def test_request_export_forbidden_for_other_org_incident(
@@ -473,8 +492,49 @@ class TestRequestExport:
         db_session.commit()
         db_session.refresh(inc)
 
-        resp = client.post(f"/incidents/{inc.incident_id}/exports", headers=auth_headers)
+        resp = client.post(
+            "/exports/",
+            json={
+                "incident_id": str(inc.incident_id),
+                "export_type": "court_defense",
+            },
+            headers=auth_headers,
+        )
         assert resp.status_code == 403
+
+    def test_request_export_invalid_type(self, client, db_session, test_org, auth_headers):
+        incident = Incident(status="open", org_id=test_org.id)
+        db_session.add(incident)
+        db_session.commit()
+        db_session.refresh(incident)
+        incident_id = str(incident.incident_id)
+
+        resp = client.post(
+            "/exports/",
+            json={"incident_id": incident_id, "export_type": "invalid_type"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422
+
+    def test_request_export_invalid_options_for_court_defense(
+        self, client, db_session, test_org, auth_headers
+    ):
+        incident = Incident(status="open", org_id=test_org.id)
+        db_session.add(incident)
+        db_session.commit()
+        db_session.refresh(incident)
+        incident_id = str(incident.incident_id)
+
+        resp = client.post(
+            "/exports/",
+            json={
+                "incident_id": incident_id,
+                "export_type": "court_defense",
+                "options_json": {"profile": "advanced"},
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422
 
 
 # ── GET /exports/{export_id}/download ───────────────────────────────

--- a/backend/tests/test_frontend_contracts.py
+++ b/backend/tests/test_frontend_contracts.py
@@ -193,7 +193,7 @@ def test_incident_detail_contract_matches_frontend(
     assert isinstance(detail["timeline"], list)
 
 
-@patch("app.api.routes_incidents.build_export")
+@patch("app.api.routes_exports.build_export")
 @patch("app.api.routes_incidents.capture_telematics_bundle")
 @patch("app.api.routes_incidents.capture_dashcam")
 def test_export_response_contract_matches_frontend(
@@ -219,19 +219,18 @@ def test_export_response_contract_matches_frontend(
     )
     incident_id = create_resp.json()["incident_id"]
 
-    export_resp = client.post(f"/incidents/{incident_id}/exports", headers=auth_headers)
+    export_resp = client.post(
+        "/exports/",
+        json={"incident_id": incident_id, "export_type": "court_defense"},
+        headers=auth_headers,
+    )
     assert export_resp.status_code == 201
     payload = export_resp.json()
 
-    for field in ("export_id", "status", "progress_stage"):
+    for field in ("export_id", "incident_id", "export_type", "status", "created_at_utc"):
         assert field in payload
     _assert_uuid(payload["export_id"])
+    _assert_uuid(payload["incident_id"])
+    assert payload["export_type"] == "court_defense"
     assert payload["status"] in {"requested", "queued", "processing", "ready", "failed", "expired"}
-    assert payload["progress_stage"] in {
-        "request_accepted",
-        "gathering_incident_data",
-        "assembling_documents",
-        "packaging_evidence",
-        "uploading_export",
-        "ready_for_download",
-    }
+    assert isinstance(payload["created_at_utc"], str)

--- a/backend/tests/test_system_event_types.py
+++ b/backend/tests/test_system_event_types.py
@@ -7,8 +7,8 @@ class TestSystemEventType:
     """Validate the SystemEventType contract."""
 
     def test_total_count(self):
-        """There must be exactly 23 system event types."""
-        assert len(SystemEventType) == 23
+        """There must be exactly 35 system event types."""
+        assert len(SystemEventType) == 35
 
     def test_is_str_enum(self):
         """Every member must be usable as a plain string."""
@@ -74,6 +74,9 @@ class TestSystemEventType:
     def test_export_generated(self):
         assert SystemEventType.EXPORT_GENERATED == "export_generated"
 
+    def test_export_queued(self):
+        assert SystemEventType.EXPORT_QUEUED == "export_queued"
+
     def test_export_failed(self):
         assert SystemEventType.EXPORT_FAILED == "export_failed"
 
@@ -137,6 +140,7 @@ class TestSystemEventType:
         """All export types must be present."""
         expected = {
             "export_requested",
+            "export_queued",
             "export_generated",
             "export_failed",
             "export_downloaded",

--- a/contracts/schemas/runtime_api_contracts.json
+++ b/contracts/schemas/runtime_api_contracts.json
@@ -49,12 +49,27 @@
           "title": "Export Id",
           "type": "string"
         },
+        "progress_stage": {
+          "default": "request_accepted",
+          "enum": [
+            "request_accepted",
+            "gathering_incident_data",
+            "assembling_documents",
+            "packaging_evidence",
+            "uploading_export",
+            "ready_for_download"
+          ],
+          "title": "Progress Stage",
+          "type": "string"
+        },
         "status": {
           "enum": [
             "requested",
+            "queued",
             "processing",
             "ready",
-            "failed"
+            "failed",
+            "expired"
           ],
           "title": "Status",
           "type": "string"
@@ -166,12 +181,27 @@
           "title": "Export Id",
           "type": "string"
         },
+        "progress_stage": {
+          "default": "ready_for_download",
+          "enum": [
+            "request_accepted",
+            "gathering_incident_data",
+            "assembling_documents",
+            "packaging_evidence",
+            "uploading_export",
+            "ready_for_download"
+          ],
+          "title": "Progress Stage",
+          "type": "string"
+        },
         "status": {
           "enum": [
             "requested",
+            "queued",
             "processing",
             "ready",
-            "failed"
+            "failed",
+            "expired"
           ],
           "title": "Status",
           "type": "string"
@@ -472,6 +502,37 @@
         },
         "ExportSummary": {
           "properties": {
+            "artifact_count": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Artifact Count",
+              "type": "integer"
+            },
+            "byte_size": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Byte Size"
+            },
+            "completed_at_utc": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Completed At Utc"
+            },
             "created_at_utc": {
               "anyOf": [
                 {
@@ -485,20 +546,159 @@
               "default": null,
               "title": "Created At Utc"
             },
+            "error_message": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Error Message"
+            },
+            "expires_at_utc": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Expires At Utc"
+            },
             "export_id": {
               "format": "uuid",
               "title": "Export Id",
               "type": "string"
             },
+            "export_type": {
+              "default": "court_defense",
+              "enum": [
+                "court_defense",
+                "insurer_packet",
+                "internal_review",
+                "compliance_audit"
+              ],
+              "title": "Export Type",
+              "type": "string"
+            },
+            "incident_id": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Incident Id"
+            },
+            "options_json": {
+              "additionalProperties": true,
+              "title": "Options Json",
+              "type": "object"
+            },
+            "package_sha256": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Package Sha256"
+            },
+            "processing_started_at_utc": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Processing Started At Utc"
+            },
+            "progress_stage": {
+              "default": "request_accepted",
+              "enum": [
+                "request_accepted",
+                "gathering_incident_data",
+                "assembling_documents",
+                "packaging_evidence",
+                "uploading_export",
+                "ready_for_download"
+              ],
+              "title": "Progress Stage",
+              "type": "string"
+            },
+            "requested_at_utc": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Requested At Utc"
+            },
+            "requested_by_user_id": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Requested By User Id"
+            },
             "status": {
               "enum": [
                 "requested",
+                "queued",
                 "processing",
                 "ready",
-                "failed"
+                "failed",
+                "expired"
               ],
               "title": "Status",
               "type": "string"
+            },
+            "timeline_event_count": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Timeline Event Count",
+              "type": "integer"
+            },
+            "updated_at_utc": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Updated At Utc"
             }
           },
           "required": [


### PR DESCRIPTION
### Motivation

- Provide a first-class API to request exports (`POST /exports`) that validates input, enforces org ownership and user roles, and returns the agreed response contract.
- Ensure export generation is performed asynchronously by enqueueing a Celery task and recording audit events for both request and queueing steps.

### Description

- Added `POST /exports/` handler in `routes_exports.py` which validates the incident exists and belongs to the caller's orgs, requires `admin` or `safety_manager` via `require_user_role`, creates an `Export` row in status `requested`, enqueues the Celery task and transitions the row to `queued` on success, and emits `export_requested` and `export_queued` events.
- Introduced `CreateExportRequest` and `CreateExportEnqueueResponse` schemas in `app.api.schemas` and implemented validation that enforces the MVP default profile for `court_defense` exports and rejects unsupported `options_json` for other types.
- Enriched the audit/event model by adding `SystemEventType.EXPORT_QUEUED` and updated `build_export` task signature to accept an optional `attempt_context` and log the attempt metadata.
- Updated tests and frontend contract expectations to exercise the new endpoint and response shape, including tests for authorization/ownership, invalid incident, invalid `export_type` and `options_json`, and successful enqueue and response fields; refreshed the runtime API contract snapshot.

### Testing

- Ran formatting/lint checks with `make lint` in the repo root and the linter completed with all checks passed.
- Executed the focused API and contract tests with `pytest` (including `tests/test_api_endpoints.py::TestRequestExport`, `tests/test_frontend_contracts.py::test_export_response_contract_matches_frontend`, `tests/test_system_event_types.py`, and the runtime contract snapshot check) and all ran green.
- Generated and updated the runtime contract using `python scripts/generate_runtime_api_contract.py` and validated with `pytest tests/test_runtime_contract_snapshot.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d44e7fe67c83219d56823b6a611e4d)