### PR TITLE
Add org-scoped export status and contents endpoints

### DIFF
--- a/backend/app/api/routes_exports.py
+++ b/backend/app/api/routes_exports.py
@@ -10,6 +10,8 @@ from app.api.schemas import (
     CreateExportEnqueueResponse,
     CreateExportRequest,
     DownloadExportResponse,
+    ExportContentsResponse,
+    ExportStatusResponse,
     ExportSummary,
 )
 from app.core.deps import (
@@ -23,6 +25,7 @@ from app.core.metrics import MetricNames, increment, timed
 from app.db.models import User
 from app.db.session import get_db
 from app.db.repo.exports import create_export, get_export, list_exports_for_org_ids, update_export
+from app.db.repo.artifacts import get_artifacts_by_incident
 from app.db.repo.events import create_event
 from app.db.repo.incidents import get_incident
 from app.db.repo.users import get_user_org_ids
@@ -38,6 +41,7 @@ from app.services.vault_s3 import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+STABLE_EXPORT_CONTENT_KINDS: tuple[str, ...] = ("summary_pdf", "raw_telemetry", "photo")
 
 
 @router.post("/", response_model=CreateExportEnqueueResponse, status_code=201)
@@ -155,6 +159,90 @@ def _serialize_export(export):
     }
 
 
+def _resolve_authorized_export(
+    db: Session,
+    export_id: uuid.UUID,
+    org_ids: list[uuid.UUID],
+):
+    export = get_export(db, export_id)
+    if not export:
+        raise HTTPException(status_code=404, detail="Export not found")
+
+    export_org_id = _get_export_owner_org_id(db, export)
+    if export_org_id is None or export_org_id not in org_ids:
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return export
+
+
+def _normalize_manifest_rows(rows) -> list[dict]:
+    normalized: dict[str, dict] = {}
+    for row in rows or []:
+        if not isinstance(row, dict):
+            continue
+        kind = row.get("kind")
+        if kind not in STABLE_EXPORT_CONTENT_KINDS:
+            continue
+        byte_size = row.get("byte_size")
+        normalized[kind] = {
+            "kind": kind,
+            "included": bool(row.get("included", False)),
+            "byte_size": byte_size if isinstance(byte_size, int) and byte_size >= 0 else None,
+        }
+    return [normalized.get(kind, {"kind": kind, "included": False, "byte_size": None}) for kind in STABLE_EXPORT_CONTENT_KINDS]
+
+
+def _reconstruct_manifest(db: Session, export) -> list[dict]:
+    artifacts = get_artifacts_by_incident(db, export.incident_id)
+    has_captured_photos = any(
+        a.status == "captured" and (a.artifact_type or "").lower() == "photo"
+        for a in artifacts
+    )
+    raw_telemetry_bytes = sum(
+        int(a.byte_size)
+        for a in artifacts
+        if a.status == "captured"
+        and (a.artifact_type or "").lower() in {"eld_log", "gps_trail", "safety_event", "vehicle_state"}
+        and isinstance(a.byte_size, int)
+        and a.byte_size >= 0
+    )
+
+    return [
+        {
+            "kind": "summary_pdf",
+            "included": export.status in {"ready", "processing", "failed"},
+            "byte_size": None,
+        },
+        {
+            "kind": "raw_telemetry",
+            "included": raw_telemetry_bytes > 0,
+            "byte_size": raw_telemetry_bytes or None,
+        },
+        {
+            "kind": "photo",
+            "included": has_captured_photos,
+            "byte_size": sum(
+                int(a.byte_size)
+                for a in artifacts
+                if a.status == "captured"
+                and (a.artifact_type or "").lower() == "photo"
+                and isinstance(a.byte_size, int)
+                and a.byte_size >= 0
+            )
+            or None,
+        },
+    ]
+
+
+def _build_contents_manifest(db: Session, export) -> list[dict]:
+    options = export.options_json or {}
+    manifest_rows = options.get("contents_manifest") if isinstance(options, dict) else None
+    if isinstance(manifest_rows, list):
+        normalized = _normalize_manifest_rows(manifest_rows)
+        if normalized:
+            return normalized
+    return _reconstruct_manifest(db, export)
+
+
 @router.get("/", response_model=list[ExportSummary])
 def list_exports_endpoint(
     db: Session = Depends(get_db),
@@ -180,17 +268,49 @@ def get_export_endpoint(
     set_log_context(
         user_id=str(current_user.id), org_id=str(org_ids[0]) if org_ids else None
     )
-    export = get_export(db, export_id)
-    if not export:
+    try:
+        export = _resolve_authorized_export(db, export_id, org_ids)
+    except HTTPException:
         increment(MetricNames.EXPORT_DOWNLOAD_FAILURES)
-        raise HTTPException(status_code=404, detail="Export not found")
-
-    export_org_id = _get_export_owner_org_id(db, export)
-    if export_org_id is None or export_org_id not in org_ids:
-        increment(MetricNames.EXPORT_DOWNLOAD_FAILURES)
-        raise HTTPException(status_code=403, detail="Forbidden")
+        raise
 
     return _serialize_export(export)
+
+
+@router.get("/{export_id}/status", response_model=ExportStatusResponse)
+def get_export_status_endpoint(
+    export_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
+    current_user: User = Depends(get_current_user),
+):
+    org_ids = get_user_org_ids(db, current_user.id)
+    export = _resolve_authorized_export(db, export_id, org_ids)
+    return ExportStatusResponse(
+        status=export.status,
+        progress_stage=export.progress_stage,
+        error_message=export.error_message,
+    )
+
+
+@router.get("/{export_id}/contents", response_model=ExportContentsResponse)
+def get_export_contents_endpoint(
+    export_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
+    current_user: User = Depends(get_current_user),
+):
+    org_ids = get_user_org_ids(db, current_user.id)
+    export = _resolve_authorized_export(db, export_id, org_ids)
+    manifest = _build_contents_manifest(db, export)
+    missing_items = [row["kind"] for row in manifest if not row["included"]]
+    return ExportContentsResponse(
+        export_id=export.export_id,
+        status=export.status,
+        progress_stage=export.progress_stage,
+        file_manifest=manifest,
+        missing_items=missing_items,
+    )
 
 
 @router.get("/{export_id}/download", response_model=DownloadExportResponse)

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -266,6 +266,29 @@ class DownloadExportResponse(BaseModel):
     progress_stage: ExportProgressStage = "ready_for_download"
 
 
+ExportContentKind = Literal["summary_pdf", "raw_telemetry", "photo"]
+
+
+class ExportStatusResponse(BaseModel):
+    status: ExportStatus
+    progress_stage: ExportProgressStage
+    error_message: Optional[str] = None
+
+
+class ExportContentsItem(BaseModel):
+    kind: ExportContentKind
+    included: bool
+    byte_size: Optional[int] = None
+
+
+class ExportContentsResponse(BaseModel):
+    export_id: uuid.UUID
+    status: ExportStatus
+    progress_stage: ExportProgressStage
+    file_manifest: list[ExportContentsItem] = Field(default_factory=list)
+    missing_items: list[ExportContentKind] = Field(default_factory=list)
+
+
 # ── Driver ──────────────────────────────────────────────────────────
 
 

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -862,6 +862,130 @@ class TestGetExport:
         assert resp.status_code == 403
 
 
+class TestExportStatusAndContents:
+    @pytest.mark.parametrize(
+        ("status", "progress_stage", "error_message"),
+        [
+            ("ready", "ready_for_download", None),
+            ("processing", "assembling_documents", None),
+            ("failed", "packaging_evidence", "zip generation failed"),
+        ],
+    )
+    def test_get_export_status_returns_expected_states(
+        self,
+        client,
+        db_session,
+        test_org,
+        auth_headers,
+        status,
+        progress_stage,
+        error_message,
+    ):
+        inc = Incident(status="open", org_id=test_org.id)
+        db_session.add(inc)
+        db_session.commit()
+        db_session.refresh(inc)
+
+        exp = Export(
+            incident_id=inc.incident_id,
+            org_id=test_org.id,
+            status=status,
+            progress_stage=progress_stage,
+            error_message=error_message,
+        )
+        db_session.add(exp)
+        db_session.commit()
+        db_session.refresh(exp)
+
+        resp = client.get(f"/exports/{exp.export_id}/status", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "status": status,
+            "progress_stage": progress_stage,
+            "error_message": error_message,
+        }
+
+    def test_get_export_contents_returns_manifest_with_stable_kinds(
+        self, client, db_session, test_org, auth_headers
+    ):
+        inc = Incident(status="open", org_id=test_org.id)
+        db_session.add(inc)
+        db_session.commit()
+        db_session.refresh(inc)
+
+        db_session.add_all(
+            [
+                Artifact(
+                    incident_id=inc.incident_id,
+                    org_id=test_org.id,
+                    artifact_type="photo",
+                    status="captured",
+                    byte_size=2048,
+                ),
+                Artifact(
+                    incident_id=inc.incident_id,
+                    org_id=test_org.id,
+                    artifact_type="eld_log",
+                    status="captured",
+                    byte_size=4096,
+                ),
+            ]
+        )
+        exp = Export(
+            incident_id=inc.incident_id,
+            org_id=test_org.id,
+            status="ready",
+            progress_stage="ready_for_download",
+        )
+        db_session.add(exp)
+        db_session.commit()
+        db_session.refresh(exp)
+
+        resp = client.get(f"/exports/{exp.export_id}/contents", headers=auth_headers)
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["export_id"] == str(exp.export_id)
+        assert payload["status"] == "ready"
+        manifest_by_kind = {row["kind"]: row for row in payload["file_manifest"]}
+        assert set(manifest_by_kind.keys()) == {"summary_pdf", "raw_telemetry", "photo"}
+        assert manifest_by_kind["summary_pdf"]["included"] is True
+        assert manifest_by_kind["raw_telemetry"]["included"] is True
+        assert manifest_by_kind["raw_telemetry"]["byte_size"] == 4096
+        assert manifest_by_kind["photo"]["included"] is True
+        assert manifest_by_kind["photo"]["byte_size"] == 2048
+        assert payload["missing_items"] == []
+
+    def test_export_status_and_contents_forbidden_for_other_org(
+        self, client, db_session, auth_headers
+    ):
+        other_org = Org(name="Other Org")
+        db_session.add(other_org)
+        db_session.commit()
+        db_session.refresh(other_org)
+
+        inc = Incident(status="open", org_id=other_org.id)
+        db_session.add(inc)
+        db_session.commit()
+        db_session.refresh(inc)
+
+        exp = Export(
+            incident_id=inc.incident_id,
+            org_id=other_org.id,
+            status="processing",
+            progress_stage="assembling_documents",
+        )
+        db_session.add(exp)
+        db_session.commit()
+        db_session.refresh(exp)
+
+        status_resp = client.get(f"/exports/{exp.export_id}/status", headers=auth_headers)
+        contents_resp = client.get(
+            f"/exports/{exp.export_id}/contents", headers=auth_headers
+        )
+        assert status_resp.status_code == 403
+        assert contents_resp.status_code == 403
+
+
 class TestListExports:
     def test_list_exports_no_org_links_returns_empty(self, client, no_org_auth_headers):
         resp = client.get("/exports/", headers=no_org_auth_headers)


### PR DESCRIPTION
### Motivation
- Expose export progress and errors via a simple status endpoint so callers can poll export generation state (`status`, `progress_stage`, `error_message`).
- Provide a stable, machine-friendly contents manifest for an export with stable `kind` values and per-item `included`/`byte_size` info so callers can decide which pieces are available before downloading the package.
- Enforce organization-scoped authorization for these read endpoints, including the existing legacy null-org export fallback to the incident org.
- Prefer persisted manifest data when available and fall back to deterministic reconstruction from incident artifacts when not.

### Description
- Added DTOs to `app.api.schemas`: `ExportStatusResponse`, `ExportContentsResponse`, `ExportContentsItem`, and `ExportContentKind` with stable `kind` values (`summary_pdf`, `raw_telemetry`, `photo`).
- Implemented `GET /exports/{export_id}/status` returning `status`, `progress_stage`, and `error_message` in `app.api.routes_exports`.
- Implemented `GET /exports/{export_id}/contents` returning `file_manifest` (list of stable-`kind` items with `included` and optional `byte_size`) and `missing_items`, with a `STABLE_EXPORT_CONTENT_KINDS` ordering.
- Centralized org-scoped authorization into `_resolve_authorized_export` (includes legacy null-org export -> incident org fallback) and used it from the new endpoints and updated `GET /exports/{export_id}` to reuse the same check.
- Manifest population logic prefers `export.options_json['contents_manifest']` when present and valid (normalized), otherwise reconstructs manifest deterministically from incident artifacts by querying `get_artifacts_by_incident`.
- Added tests in `backend/tests/test_api_endpoints.py` (class `TestExportStatusAndContents`) to cover `ready`/`processing`/`failed` status responses, manifest content and byte sizes, and forbidden cross-org access for both `/status` and `/contents`.

### Testing
- Ran linter: `make lint` — all checks passed.
- Ran targeted endpoint tests: `pytest tests/test_api_endpoints.py -k 'ExportStatusAndContents or TestGetExport or TestDownloadExport' -q` — passed (21 passed, 22 deselected).
- Ran exports unit tests: `pytest tests/test_exports.py -q` — passed.
- Ran combined `pytest tests/test_api_endpoints.py tests/test_exports.py -q` which surfaced one unrelated, pre-existing failure in `TestGetIncident::test_get_incident_forbidden_for_other_org` (expected 403 but received 404); the failure is not caused by these changes and other export-related tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d450bfa49c83219d1c4bcc8b322303)