### PR TITLE
Add structured export package builder with manifest and integrity outputs

### DIFF
--- a/backend/app/services/export_builder.py
+++ b/backend/app/services/export_builder.py
@@ -1,20 +1,80 @@
-"""Export builder service."""
+"""Coordinator service for building ADC export packages."""
 
-import logging
+from __future__ import annotations
 
-logger = logging.getLogger(__name__)
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from app.services.export_content_resolver import resolve_export_content
+from app.services.export_manifest import build_export_manifest
+from app.services.export_zip_service import (
+    build_checksums_sha256,
+    build_export_zip,
+    build_package_integrity,
+    hash_bytes,
+    to_json_bytes,
+)
 
 
-def build_export(incident_id: str, format: str) -> bytes:
-    """Build an export package for a given incident.
+@dataclass
+class ExportBuildResult:
+    zip_bytes: bytes
+    package_sha256: str
+    byte_size: int
+    included_files: list[str]
+    missing_items: list[dict[str, str]]
+    warnings: list[dict[str, str]]
 
-    Args:
-        incident_id: The UUID of the incident to export.
-        format: The desired export format (e.g. 'pdf', 'zip').
 
-    Returns:
-        Raw bytes of the export file.
-    """
-    logger.info("Building %s export for incident %s", format, incident_id)
-    # Placeholder: assemble evidence and generate export
-    return b""
+def build_export_package(
+    *,
+    incident_id: str,
+    export_id: str,
+    artifacts: list,
+    events: list,
+    s3,
+    options: dict,
+) -> ExportBuildResult:
+    package_root = f"ADC_Export_{incident_id}_{datetime.now(timezone.utc).strftime('%Y%m%d')}"
+    resolved = resolve_export_content(
+        incident_id=incident_id,
+        export_id=export_id,
+        artifacts=artifacts,
+        events=events,
+        s3=s3,
+        package_root=package_root,
+    )
+
+    files = dict(resolved.files)
+    checksums = build_checksums_sha256(files, package_root)
+    files[f"{package_root}/integrity/checksums.sha256"] = checksums
+
+    manifest = build_export_manifest(
+        options=options,
+        included_files=list(files.keys()),
+        missing_items=resolved.missing_items,
+        status_metadata={
+            "warnings_count": len(resolved.warnings),
+            "missing_items_count": len(resolved.missing_items),
+            "artifact_count": len(artifacts),
+            "timeline_event_count": len(events),
+        },
+    )
+    files[f"{package_root}/metadata/export_manifest.json"] = to_json_bytes(manifest)
+
+    zip_bytes = build_export_zip(files)
+    package_sha256 = hash_bytes(zip_bytes)
+    integrity = build_package_integrity(package_sha256=package_sha256, file_count=len(files))
+    files[f"{package_root}/metadata/package_integrity.json"] = to_json_bytes(integrity)
+
+    zip_bytes = build_export_zip(files)
+    package_sha256 = hash_bytes(zip_bytes)
+
+    return ExportBuildResult(
+        zip_bytes=zip_bytes,
+        package_sha256=package_sha256,
+        byte_size=len(zip_bytes),
+        included_files=sorted(files.keys()),
+        missing_items=resolved.missing_items,
+        warnings=resolved.warnings,
+    )

--- a/backend/app/services/export_content_resolver.py
+++ b/backend/app/services/export_content_resolver.py
@@ -1,0 +1,144 @@
+"""Resolve export package contents and canonical paths."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import PurePosixPath
+from typing import Any
+
+
+@dataclass
+class ResolvedExportContent:
+    files: dict[str, bytes]
+    missing_items: list[dict[str, str]]
+    warnings: list[dict[str, str]]
+
+
+def _csv_bytes(headers: list[str], rows: list[list[Any]]) -> bytes:
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(headers)
+    writer.writerows(rows)
+    return buf.getvalue().encode()
+
+
+def _artifact_filename(s3_key: str | None) -> str:
+    if not s3_key:
+        return ""
+    return s3_key.rsplit("/", 1)[-1]
+
+
+def _target_folder(artifact_type: str, filename: str) -> str:
+    if artifact_type == "gps_trail":
+        return "gps"
+    if artifact_type == "eld_log":
+        return "eld"
+    if artifact_type == "safety_event":
+        return "safety"
+    if artifact_type == "vehicle_state":
+        return "vehicle"
+    lower_type = (artifact_type or "").lower()
+    lower_name = (filename or "").lower()
+    if "dashcam" in lower_type or lower_name.endswith((".mp4", ".jpg", ".jpeg", ".png")):
+        return "media"
+    return "media/other"
+
+
+def resolve_export_content(
+    *,
+    incident_id: str,
+    export_id: str,
+    artifacts: list[Any],
+    events: list[Any],
+    s3: Any,
+    package_root: str,
+) -> ResolvedExportContent:
+    files: dict[str, bytes] = {}
+    warnings: list[dict[str, str]] = []
+    missing_items: list[dict[str, str]] = []
+
+    incident_summary = {
+        "incident_id": incident_id,
+        "export_id": export_id,
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "artifact_count": len(artifacts),
+        "timeline_event_count": len(events),
+    }
+    files[f"{package_root}/01_Incident_Summary.json"] = json.dumps(
+        incident_summary,
+        indent=2,
+        default=str,
+    ).encode()
+
+    inventory_rows = [
+        [
+            str(a.artifact_id),
+            a.artifact_type,
+            a.status,
+            a.s3_key or "",
+            a.sha256 or "",
+            a.byte_size or "",
+        ]
+        for a in artifacts
+    ]
+    files[f"{package_root}/02_Evidence_Inventory.csv"] = _csv_bytes(
+        ["artifact_id", "artifact_type", "status", "s3_key", "sha256", "byte_size"],
+        inventory_rows,
+    )
+
+    sorted_events = sorted(events, key=lambda e: str(e.occurred_at_utc))
+    coc_rows = [
+        [str(e.id), e.event_type, str(e.occurred_at_utc), e.actor_type, e.actor_id] for e in sorted_events
+    ]
+    files[f"{package_root}/03_Chain_of_Custody.csv"] = _csv_bytes(
+        ["event_id", "event_type", "occurred_at_utc", "actor_type", "actor_id"],
+        coc_rows,
+    )
+
+    timeline_rows = [
+        [
+            str(e.occurred_at_utc),
+            e.event_type,
+            e.actor_type,
+            e.actor_id,
+            json.dumps(e.payload or {}, default=str),
+        ]
+        for e in sorted_events
+    ]
+    files[f"{package_root}/04_Timeline.csv"] = _csv_bytes(
+        ["occurred_at_utc", "event_type", "actor_type", "actor_id", "payload_json"],
+        timeline_rows,
+    )
+
+    statement_marker = "Driver statement unavailable at export generation time."
+    files[f"{package_root}/05_Driver_Statement.txt"] = statement_marker.encode()
+
+    for artifact in artifacts:
+        filename = _artifact_filename(artifact.s3_key)
+        if artifact.status != "captured" or not artifact.s3_key or not filename:
+            missing_items.append({"kind": artifact.artifact_type, "item": filename or str(artifact.artifact_id)})
+            continue
+        target = _target_folder(artifact.artifact_type, filename)
+        path = str(PurePosixPath(package_root) / target / filename)
+        try:
+            data = s3.download(artifact.s3_key)
+        except Exception as exc:
+            warnings.append({"kind": "artifact_missing_from_s3", "item": artifact.s3_key, "reason": str(exc)})
+            missing_items.append({"kind": artifact.artifact_type, "item": filename})
+            continue
+        files[path] = data
+
+        if artifact.artifact_type in {"driver_statement", "driver_narrative", "driver_report"}:
+            try:
+                files[f"{package_root}/05_Driver_Statement.txt"] = data.decode(errors="replace").encode()
+            except Exception:
+                pass
+
+    readme = """ADC Export Package\n\nVerification:\n1. cd into the package root folder.\n2. Run: sha256sum -c integrity/checksums.sha256\n\nInterpretation guidance:\n- 01_Incident_Summary.json: high-level package metadata.\n- 02_Evidence_Inventory.csv: inventory of known artifacts.\n- 03_Chain_of_Custody.csv: event custody log.\n- 04_Timeline.csv: chronological timeline of recorded events.\n- 05_Driver_Statement.txt: driver narrative or unavailable marker.\n"""
+    files[f"{package_root}/readme/00_README.txt"] = readme.encode()
+
+    return ResolvedExportContent(files=files, missing_items=missing_items, warnings=warnings)

--- a/backend/app/services/export_manifest.py
+++ b/backend/app/services/export_manifest.py
@@ -1,0 +1,22 @@
+"""Export manifest generation helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def build_export_manifest(
+    *,
+    options: dict[str, Any],
+    included_files: list[str],
+    missing_items: list[dict[str, str]],
+    status_metadata: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "options": options,
+        "included_files": sorted(included_files),
+        "missing_items": missing_items,
+        "status_metadata": status_metadata,
+    }

--- a/backend/app/services/export_zip_service.py
+++ b/backend/app/services/export_zip_service.py
@@ -1,0 +1,44 @@
+"""ZIP packaging + integrity helpers for exports."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import zipfile
+from typing import Any
+
+
+def hash_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def build_checksums_sha256(files: dict[str, bytes], package_root: str) -> bytes:
+    lines: list[str] = []
+    for path in sorted(files.keys()):
+        rel = path.removeprefix(f"{package_root}/")
+        lines.append(f"{hash_bytes(files[path])}  {rel}")
+    return ("\n".join(lines) + "\n").encode()
+
+
+def build_export_zip(files: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for path in sorted(files.keys()):
+            zf.writestr(path, files[path])
+    return buf.getvalue()
+
+
+def build_package_integrity(*, package_sha256: str, file_count: int) -> dict[str, Any]:
+    return {
+        "package_sha256": package_sha256,
+        "file_count": file_count,
+        "verification_instructions": [
+            "Use sha256sum -c integrity/checksums.sha256 from the package root.",
+            "Compare the ZIP SHA-256 with the persisted export record value.",
+        ],
+    }
+
+
+def to_json_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, indent=2, default=str).encode()

--- a/backend/app/tasks/export_tasks.py
+++ b/backend/app/tasks/export_tasks.py
@@ -365,6 +365,7 @@ def build_export(
     from app.db.repo.exports import get_export, update_export
     from app.domain.system_event_types import SystemEventType
     from app.services import s3_key_builder
+    from app.services.export_builder import build_export_package
     from app.services.vault_s3 import VaultS3
 
     inc_uuid = _uuid.UUID(incident_id)
@@ -465,33 +466,37 @@ def build_export(
         _persist_warnings(ctx)
         _emit_stage(ctx, "after", "gathering_incident_data")
 
-        # 3. Build machine-readable docs
+        # 3-6. Build export content, manifest, and ZIP package
         _emit_stage(ctx, "before", "assembling_documents")
         _set_progress_stage(ctx, "assembling_documents")
-        _build_machine_readable_docs(ctx)
+        build_result = build_export_package(
+            incident_id=ctx.incident_id,
+            export_id=ctx.export_id,
+            artifacts=ctx.artifacts,
+            events=ctx.events,
+            s3=ctx.s3,
+            options=dict(ctx.export_row.options_json or {}),
+        )
+        ctx.zip_bytes = build_result.zip_bytes
+        ctx.warnings.extend(build_result.warnings)
+        ctx.missing_items.extend(build_result.missing_items)
+        _persist_warnings(ctx)
         _emit_stage(ctx, "after", "assembling_documents")
 
-        # 4. Render human-readable docs
-        _emit_stage(ctx, "before", "assembling_documents")
-        _render_human_readable_docs(ctx)
-        _emit_stage(ctx, "after", "assembling_documents")
-
-        # 5. Assemble ZIP
         _emit_stage(ctx, "before", "packaging_evidence")
         _set_progress_stage(ctx, "packaging_evidence")
-        _assemble_zip(ctx)
-        _persist_warnings(ctx)
-        _emit_stage(ctx, "after", "packaging_evidence")
-
-        # 6. Integrity generation
-        _emit_stage(ctx, "before", "packaging_evidence")
-        _generate_integrity(ctx)
         _emit_stage(ctx, "after", "packaging_evidence")
 
         # 7. Upload + finalize
         _emit_stage(ctx, "before", "uploading_export")
         _set_progress_stage(ctx, "uploading_export")
         _upload_and_finalize(ctx)
+        update_export(
+            ctx.db,
+            export_id=ctx.export_uuid,
+            package_sha256=build_result.package_sha256,
+            byte_size=build_result.byte_size,
+        )
         _emit_stage(ctx, "after", "uploading_export")
 
         # 8. Emit EXPORT_GENERATED

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -623,16 +623,22 @@ class TestBuildExport:
         zip_bytes = s3_inst.put_bytes.call_args[0][1]
         with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
             names = set(zf.namelist())
+            package_root = next(name.split("/", 1)[0] for name in names if "/" in name)
             expected = {
-                "ADC_Court_Package/00_README.txt",
-                "ADC_Court_Package/02_Evidence_Inventory.csv",
-                "ADC_Court_Package/03_Chain_of_Custody.csv",
-                "ADC_Court_Package/integrity_appendix.csv",
-                "ADC_Court_Package/artifacts/eld_log/eld.json",
+                f"{package_root}/01_Incident_Summary.json",
+                f"{package_root}/02_Evidence_Inventory.csv",
+                f"{package_root}/03_Chain_of_Custody.csv",
+                f"{package_root}/04_Timeline.csv",
+                f"{package_root}/05_Driver_Statement.txt",
+                f"{package_root}/integrity/checksums.sha256",
+                f"{package_root}/metadata/export_manifest.json",
+                f"{package_root}/metadata/package_integrity.json",
+                f"{package_root}/eld/eld.json",
+                f"{package_root}/readme/00_README.txt",
             }
             assert expected.issubset(names)
-            readme = zf.read("ADC_Court_Package/00_README.txt").decode()
-            assert "Capture window (UTC" in readme
+            readme = zf.read(f"{package_root}/readme/00_README.txt").decode()
+            assert "Verification" in readme
 
     @patch("app.tasks.export_tasks._get_db")
     @patch("app.services.vault_s3.VaultS3")


### PR DESCRIPTION
### Motivation
- Provide a canonical, court-ready ADC export ZIP layout rooted at `ADC_Export_{incident_id}_{YYYYMMDD}` to standardize file placement and metadata. 
- Include human- and machine-readable core files (incident summary, inventory, chain-of-custody, timeline, driver statement) and place telemetry/media under specified folders. 
- Produce per-file checksums and package integrity metadata so recipients can verify exports and the system can persist a package SHA-256 and byte size. 

### Description
- Add `backend/app/services/export_content_resolver.py` to resolve package contents, canonical paths, required core files (`01_Incident_Summary.json`, `02_Evidence_Inventory.csv`, `03_Chain_of_Custody.csv`, `04_Timeline.csv`, `05_Driver_Statement.txt`), media/telemetry placement (`gps/`, `eld/`, `safety/`, `vehicle/`, `media/...`), and `readme/00_README.txt`.
- Add `backend/app/services/export_manifest.py` to build `metadata/export_manifest.json` containing options, included files, missing items, and status metadata.
- Add `backend/app/services/export_zip_service.py` to create deterministic ZIPs, produce `integrity/checksums.sha256`, and assemble `metadata/package_integrity.json`; includes helpers to hash bytes and serialize JSON bytes.
- Add `backend/app/services/export_builder.py` coordinator that composes the resolver, manifest, integrity steps, returns ZIP bytes, package SHA-256, byte size, and lists of included/missing files.
- Update the Celery export task `build_export` to call the coordinator, merge warnings/missing items back into the export options, and persist `package_sha256` and `byte_size` on the export row after upload.
- Adjust test assertions in `backend/tests/test_celery_tasks.py` to validate the new canonical package root and presence of manifest/integrity/readme files.

### Testing
- Ran linter: `make lint` in repo root, and it completed with no issues.
- Ran `pytest backend/tests/test_celery_tasks.py -q`, and the suite passed (33 tests passed, 1 warning reported by config).
- Ran `pytest backend/tests/test_exports.py -q`, and the suite passed (3 tests passed, warnings only from framework deprecations).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d45d771730832184c9074e899121f6)