### PR TITLE
Add cover summary PDF generation (Section 11) and tests

### DIFF
--- a/backend/app/services/export_builder.py
+++ b/backend/app/services/export_builder.py
@@ -7,6 +7,10 @@ from datetime import datetime, timezone
 
 from app.services.export_content_resolver import resolve_export_content
 from app.services.export_manifest import build_export_manifest
+from app.services.export_pdf_service import (
+    build_export_pdf_context,
+    render_cover_summary_pdf,
+)
 from app.services.export_zip_service import (
     build_checksums_sha256,
     build_export_zip,
@@ -34,6 +38,8 @@ def build_export_package(
     events: list,
     s3,
     options: dict,
+    incident=None,
+    export=None,
 ) -> ExportBuildResult:
     package_root = f"ADC_Export_{incident_id}_{datetime.now(timezone.utc).strftime('%Y%m%d')}"
     resolved = resolve_export_content(
@@ -46,6 +52,18 @@ def build_export_package(
     )
 
     files = dict(resolved.files)
+
+    pdf_context = build_export_pdf_context(
+        package_root=package_root,
+        incident=incident,
+        export=export,
+        artifacts=artifacts,
+        events=events,
+        warnings=resolved.warnings,
+        missing_items=resolved.missing_items,
+    )
+    files[f"{package_root}/00_Cover_Summary.pdf"] = render_cover_summary_pdf(pdf_context)
+
     checksums = build_checksums_sha256(files, package_root)
     files[f"{package_root}/integrity/checksums.sha256"] = checksums
 

--- a/backend/app/services/export_pdf_service.py
+++ b/backend/app/services/export_pdf_service.py
@@ -1,0 +1,222 @@
+"""Cover summary PDF generation for export packages."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from html import escape
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ExportPdfContext:
+    """Template context for the cover summary PDF (Section 11)."""
+
+    package_root: str
+    generated_at_utc: str
+    incident_id: str
+    incident_status: str
+    incident_created_at_utc: str
+    incident_severity: str
+    export_id: str
+    export_type: str
+    export_status: str
+    artifact_count: int
+    timeline_event_count: int
+    key_events: list[dict[str, str]]
+    evidence_summary_counts: list[dict[str, int]]
+    missing_unavailable_warnings: list[dict[str, str]]
+    verification_instructions: list[str]
+
+
+DEFAULT_VERIFICATION_INSTRUCTIONS = [
+    "Run: sha256sum -c integrity/checksums.sha256 from package root.",
+    "Compare package SHA-256 with the persisted export record value.",
+    "Treat any checksum mismatch as potential evidence integrity failure.",
+]
+
+
+HTML_TEMPLATE = """<!doctype html>
+<html>
+<head>
+  <meta charset=\"utf-8\" />
+  <style>
+    @page {{ size: A4; margin: 1.6cm; }}
+    body {{ font-family: Arial, sans-serif; color: #111; font-size: 11pt; }}
+    h1, h2 {{ margin: 0 0 8px 0; }}
+    h1 {{ font-size: 18pt; }}
+    h2 {{ font-size: 13pt; margin-top: 14px; }}
+    .muted {{ color: #555; }}
+    table {{ width: 100%; border-collapse: collapse; margin-top: 6px; }}
+    th, td {{ border: 1px solid #ccc; padding: 6px; text-align: left; vertical-align: top; }}
+    ul {{ margin-top: 4px; }}
+    .warning {{ color: #8a2c2c; }}
+  </style>
+</head>
+<body>
+  <h1>ADC Export Cover Summary</h1>
+  <p class=\"muted\">Package: {package_root}</p>
+  <p class=\"muted\">Generated: {generated_at_utc}</p>
+
+  <h2>Incident Summary Facts</h2>
+  <table>
+    <tr><th>Incident ID</th><td>{incident_id}</td></tr>
+    <tr><th>Incident Status</th><td>{incident_status}</td></tr>
+    <tr><th>Incident Created</th><td>{incident_created_at_utc}</td></tr>
+    <tr><th>Severity</th><td>{incident_severity}</td></tr>
+    <tr><th>Export ID</th><td>{export_id}</td></tr>
+    <tr><th>Export Type</th><td>{export_type}</td></tr>
+    <tr><th>Export Status</th><td>{export_status}</td></tr>
+    <tr><th>Artifact Count</th><td>{artifact_count}</td></tr>
+    <tr><th>Timeline Event Count</th><td>{timeline_event_count}</td></tr>
+  </table>
+
+  <h2>Key Events</h2>
+  <table>
+    <tr><th>Occurred UTC</th><th>Event Type</th><th>Actor</th></tr>
+    {key_events_rows}
+  </table>
+
+  <h2>Evidence Summary Counts</h2>
+  <table>
+    <tr><th>Artifact Type</th><th>Count</th></tr>
+    {evidence_summary_rows}
+  </table>
+
+  <h2>Missing/Unavailable Warnings</h2>
+  <ul>
+    {warning_rows}
+  </ul>
+
+  <h2>Verification Instructions</h2>
+  <ol>
+    {verification_rows}
+  </ol>
+</body>
+</html>
+"""
+
+
+def _iso(dt: Any) -> str:
+    if not dt:
+        return "unknown"
+    if isinstance(dt, datetime):
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).isoformat()
+    return str(dt)
+
+
+def build_export_pdf_context(
+    *,
+    package_root: str,
+    incident: Any,
+    export: Any,
+    artifacts: list[Any],
+    events: list[Any],
+    warnings: list[dict[str, str]],
+    missing_items: list[dict[str, str]],
+    verification_instructions: list[str] | None = None,
+    generated_at_utc: str | None = None,
+) -> ExportPdfContext:
+    counts: dict[str, int] = {}
+    for artifact in artifacts:
+        kind = str(getattr(artifact, "artifact_type", "unknown") or "unknown")
+        counts[kind] = counts.get(kind, 0) + 1
+
+    evidence_summary_counts = [
+        {"artifact_type": kind, "count": count}
+        for kind, count in sorted(counts.items(), key=lambda item: item[0])
+    ]
+
+    sorted_events = sorted(
+        events,
+        key=lambda event: (_iso(getattr(event, "occurred_at_utc", None)), str(getattr(event, "event_type", ""))),
+    )
+    key_events = [
+        {
+            "occurred_at_utc": _iso(getattr(event, "occurred_at_utc", None)),
+            "event_type": str(getattr(event, "event_type", "unknown") or "unknown"),
+            "actor": f"{getattr(event, 'actor_type', 'unknown')}:{getattr(event, 'actor_id', 'unknown')}",
+        }
+        for event in sorted_events[:10]
+    ]
+
+    merged_warnings = [
+        {
+            "kind": str(item.get("kind") or "warning"),
+            "item": str(item.get("item") or "unknown"),
+            "reason": str(item.get("reason") or ""),
+        }
+        for item in [*warnings, *missing_items]
+    ]
+
+    return ExportPdfContext(
+        package_root=package_root,
+        generated_at_utc=generated_at_utc or datetime.now(timezone.utc).isoformat(),
+        incident_id=str(getattr(incident, "incident_id", "unknown")),
+        incident_status=str(getattr(incident, "status", "unknown") or "unknown"),
+        incident_created_at_utc=_iso(getattr(incident, "created_at_utc", None)),
+        incident_severity=str(getattr(incident, "severity", "unknown") or "unknown"),
+        export_id=str(getattr(export, "export_id", "unknown")),
+        export_type=str(getattr(export, "export_type", "unknown") or "unknown"),
+        export_status=str(getattr(export, "status", "unknown") or "unknown"),
+        artifact_count=len(artifacts),
+        timeline_event_count=len(events),
+        key_events=key_events,
+        evidence_summary_counts=evidence_summary_counts,
+        missing_unavailable_warnings=merged_warnings,
+        verification_instructions=verification_instructions or DEFAULT_VERIFICATION_INSTRUCTIONS,
+    )
+
+
+def render_cover_summary_pdf(context: ExportPdfContext) -> bytes:
+    key_events_rows = "".join(
+        f"<tr><td>{escape(event['occurred_at_utc'])}</td><td>{escape(event['event_type'])}</td><td>{escape(event['actor'])}</td></tr>"
+        for event in context.key_events
+    ) or "<tr><td colspan='3'>No events recorded.</td></tr>"
+
+    evidence_summary_rows = "".join(
+        f"<tr><td>{escape(row['artifact_type'])}</td><td>{row['count']}</td></tr>"
+        for row in context.evidence_summary_counts
+    ) or "<tr><td colspan='2'>No artifacts listed.</td></tr>"
+
+    warning_rows = "".join(
+        f"<li class='warning'>{escape(row['kind'])} / {escape(row['item'])} {escape(row['reason'])}</li>"
+        for row in context.missing_unavailable_warnings
+    ) or "<li>No warnings.</li>"
+
+    verification_rows = "".join(
+        f"<li>{escape(item)}</li>" for item in context.verification_instructions
+    )
+
+    html = HTML_TEMPLATE.format(
+        **{k: escape(str(v)) for k, v in asdict(context).items() if not isinstance(v, list)},
+        key_events_rows=key_events_rows,
+        evidence_summary_rows=evidence_summary_rows,
+        warning_rows=warning_rows,
+        verification_rows=verification_rows,
+    )
+
+    try:
+        from weasyprint import HTML  # type: ignore
+
+        pdf_bytes = HTML(string=html).write_pdf()
+    except Exception as exc:  # hard-fail policy for MVP defensibility
+        logger.exception(
+            "Failed to generate cover summary PDF for export_id=%s incident_id=%s",
+            context.export_id,
+            context.incident_id,
+        )
+        raise RuntimeError(
+            f"Cover summary PDF generation failed for export {context.export_id}: {exc}"
+        ) from exc
+
+    if not pdf_bytes:
+        raise RuntimeError(
+            f"Cover summary PDF generation returned empty output for export {context.export_id}"
+        )
+    return pdf_bytes

--- a/backend/app/tasks/export_tasks.py
+++ b/backend/app/tasks/export_tasks.py
@@ -47,6 +47,7 @@ class ExportRuntimeContext:
     s3_key_builder: Any
     s3: Any
     export_row: Any
+    incident_row: Any
     warnings: list[dict[str, str]]
     missing_items: list[dict[str, str]]
     artifacts: list[Any]
@@ -363,6 +364,7 @@ def build_export(
     )
     from app.core.config import settings
     from app.db.repo.exports import get_export, update_export
+    from app.db.repo.incidents import get_incident
     from app.domain.system_event_types import SystemEventType
     from app.services import s3_key_builder
     from app.services.export_builder import build_export_package
@@ -380,6 +382,7 @@ def build_export(
         export_row = get_export(db, exp_uuid)
         if export_row is None:
             raise ValueError(f"Export {export_id} not found")
+        incident_row = get_incident(db, inc_uuid)
 
         attempt_id = str((attempt_context or {}).get("attempt_id") or workflow_key)
         if export_row.status == "ready" and export_row.s3_key:
@@ -427,6 +430,7 @@ def build_export(
             s3_key_builder=s3_key_builder,
             s3=VaultS3(bucket=settings.S3_BUCKET, region=settings.AWS_REGION),
             export_row=export_row,
+            incident_row=incident_row,
             warnings=[],
             missing_items=[],
             artifacts=[],
@@ -476,6 +480,8 @@ def build_export(
             events=ctx.events,
             s3=ctx.s3,
             options=dict(ctx.export_row.options_json or {}),
+            incident=ctx.incident_row,
+            export=ctx.export_row,
         )
         ctx.zip_bytes = build_result.zip_bytes
         ctx.warnings.extend(build_result.warnings)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,7 +1,10 @@
 """Shared test fixtures and SQLite compatibility shims."""
 
-from sqlalchemy.ext.compiler import compiles
+from types import SimpleNamespace
+
+import pytest
 from sqlalchemy.dialects.postgresql import JSONB as PG_JSONB, UUID as PG_UUID
+from sqlalchemy.ext.compiler import compiles
 
 
 # Register SQLite type compilers so that Postgres-specific column types
@@ -16,3 +19,17 @@ def _compile_jsonb_sqlite(element, compiler, **kw):
 @compiles(PG_UUID, "sqlite")
 def _compile_uuid_sqlite(element, compiler, **kw):
     return "CHAR(32)"
+
+
+@pytest.fixture(autouse=True)
+def _fake_weasyprint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide deterministic PDF bytes for tests without native WeasyPrint deps."""
+
+    class _FakeHTML:
+        def __init__(self, string: str):
+            self.string = string
+
+        def write_pdf(self) -> bytes:
+            return b"%PDF-1.4\nunit-test-pdf"
+
+    monkeypatch.setitem(__import__("sys").modules, "weasyprint", SimpleNamespace(HTML=_FakeHTML))

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -625,6 +625,7 @@ class TestBuildExport:
             names = set(zf.namelist())
             package_root = next(name.split("/", 1)[0] for name in names if "/" in name)
             expected = {
+                f"{package_root}/00_Cover_Summary.pdf",
                 f"{package_root}/01_Incident_Summary.json",
                 f"{package_root}/02_Evidence_Inventory.csv",
                 f"{package_root}/03_Chain_of_Custody.csv",

--- a/backend/tests/test_export_pdf_service.py
+++ b/backend/tests/test_export_pdf_service.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.export_pdf_service import (
+    build_export_pdf_context,
+    render_cover_summary_pdf,
+)
+
+
+def test_build_export_pdf_context_snapshot_structure() -> None:
+    incident = SimpleNamespace(
+        incident_id="inc-123",
+        status="open",
+        created_at_utc=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        severity="high",
+    )
+    export = SimpleNamespace(export_id="exp-456", export_type="court_defense", status="processing")
+    artifacts = [
+        SimpleNamespace(artifact_type="eld_log"),
+        SimpleNamespace(artifact_type="eld_log"),
+        SimpleNamespace(artifact_type="gps_trail"),
+    ]
+    events = [
+        SimpleNamespace(
+            occurred_at_utc=datetime(2026, 1, 2, 4, 4, 5, tzinfo=timezone.utc),
+            event_type="artifact_recorded",
+            actor_type="system",
+            actor_id="celery",
+        ),
+        SimpleNamespace(
+            occurred_at_utc=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+            event_type="incident_opened",
+            actor_type="driver",
+            actor_id="d-1",
+        ),
+    ]
+
+    context = build_export_pdf_context(
+        package_root="ADC_Export_inc-123_20260102",
+        incident=incident,
+        export=export,
+        artifacts=artifacts,
+        events=events,
+        warnings=[{"kind": "artifact_missing_from_s3", "item": "eld/1.json", "reason": "not found"}],
+        missing_items=[{"kind": "dashcam", "item": "clip.mp4"}],
+        generated_at_utc="2026-01-02T03:04:06+00:00",
+    )
+
+    assert context.package_root == "ADC_Export_inc-123_20260102"
+    assert context.generated_at_utc == "2026-01-02T03:04:06+00:00"
+    assert context.incident_id == "inc-123"
+    assert context.artifact_count == 3
+    assert context.timeline_event_count == 2
+    assert context.evidence_summary_counts == [
+        {"artifact_type": "eld_log", "count": 2},
+        {"artifact_type": "gps_trail", "count": 1},
+    ]
+    assert context.key_events == [
+        {
+            "occurred_at_utc": "2026-01-02T03:04:05+00:00",
+            "event_type": "incident_opened",
+            "actor": "driver:d-1",
+        },
+        {
+            "occurred_at_utc": "2026-01-02T04:04:05+00:00",
+            "event_type": "artifact_recorded",
+            "actor": "system:celery",
+        },
+    ]
+    assert context.missing_unavailable_warnings == [
+        {"kind": "artifact_missing_from_s3", "item": "eld/1.json", "reason": "not found"},
+        {"kind": "dashcam", "item": "clip.mp4", "reason": ""},
+    ]
+
+
+def test_render_cover_summary_pdf_non_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeHtml:
+        def __init__(self, string: str):
+            self.string = string
+
+        def write_pdf(self) -> bytes:
+            return b"%PDF-1.4\nnon-empty"
+
+    monkeypatch.setitem(__import__("sys").modules, "weasyprint", SimpleNamespace(HTML=_FakeHtml))
+
+    context = build_export_pdf_context(
+        package_root="ADC_Export_inc-123_20260102",
+        incident=SimpleNamespace(incident_id="inc-123", status="open", created_at_utc=None, severity=None),
+        export=SimpleNamespace(export_id="exp-456", export_type="court_defense", status="processing"),
+        artifacts=[],
+        events=[],
+        warnings=[],
+        missing_items=[],
+        generated_at_utc="2026-01-02T03:04:06+00:00",
+    )
+
+    pdf_bytes = render_cover_summary_pdf(context)
+    assert pdf_bytes.startswith(b"%PDF")
+    assert len(pdf_bytes) > 10
+
+
+def test_render_cover_summary_pdf_hard_fails_on_engine_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _ExplodingHtml:
+        def __init__(self, string: str):
+            self.string = string
+
+        def write_pdf(self) -> bytes:
+            raise RuntimeError("engine failed")
+
+    monkeypatch.setitem(__import__("sys").modules, "weasyprint", SimpleNamespace(HTML=_ExplodingHtml))
+
+    context = build_export_pdf_context(
+        package_root="ADC_Export_inc-123_20260102",
+        incident=SimpleNamespace(incident_id="inc-123", status="open", created_at_utc=None, severity=None),
+        export=SimpleNamespace(export_id="exp-456", export_type="court_defense", status="processing"),
+        artifacts=[],
+        events=[],
+        warnings=[],
+        missing_items=[],
+        generated_at_utc="2026-01-02T03:04:06+00:00",
+    )
+
+    with pytest.raises(RuntimeError, match="Cover summary PDF generation failed"):
+        render_cover_summary_pdf(context)


### PR DESCRIPTION
### Motivation
- Provide a deterministic, human-readable cover-summary PDF (Section 11) inside export packages to surface incident/export facts, key events, evidence counts, missing/unavailable warnings, and verification instructions.
- Map live incident/export/artifact/event data into a stable template context so the cover page can be included in the package integrity workflow and reviewed by downstream consumers.
- Enforce a defensible failure policy for PDF rendering in the MVP so generation errors are explicit and do not silently produce invalid packages.

### Description
- Add `backend/app/services/export_pdf_service.py` which defines `ExportPdfContext`, maps incident/export/artifact/event/warning data, provides an HTML template and renders a PDF via WeasyPrint with escaping and a deterministic structure.
- Integrate PDF generation into packaging by calling `build_export_pdf_context` and `render_cover_summary_pdf` from `backend/app/services/export_builder.py` and writing the file as `00_Cover_Summary.pdf` at the package root.
- Pass real `incident_row`/`export_row` into the package build flow by loading the incident in `backend/app/tasks/export_tasks.py` and adding `incident_row` to `ExportRuntimeContext` so Section 11 fields are populated.
- Add tests and test-support: new `backend/tests/test_export_pdf_service.py` for context snapshot and rendering behavior, update `backend/tests/conftest.py` with an autouse fake WeasyPrint shim for deterministic unit tests, and update `backend/tests/test_celery_tasks.py` expectations to include the new `00_Cover_Summary.pdf` file.
- Implement hard-fail behavior: rendering exceptions are logged and re-raised as `RuntimeError`, and empty PDF output is rejected.

### Testing
- Ran linter: `cd backend && ruff check app/ tests/` and all checks passed.
- Ran focused tests: `cd backend && pytest -q tests/test_export_pdf_service.py tests/test_celery_tasks.py -k "export"` which passed (export-related tests are green).
- Ran full backend test suite: `cd backend && pytest -q` which completed but surfaced one pre-existing unrelated API test failure `tests/test_api_endpoints.py::TestGetIncident::test_get_incident_forbidden_for_other_org` (expected `403` but got `404`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d45ec115d083219abee72353b5cd77)