### PR TITLE
Standardize export event lifecycle and add download audit API

### DIFF
--- a/backend/app/api/routes_exports.py
+++ b/backend/app/api/routes_exports.py
@@ -10,6 +10,7 @@ from app.api.schemas import (
     CreateExportEnqueueResponse,
     CreateExportRequest,
     DownloadExportResponse,
+    ExportDownloadAuditResponse,
     ExportContentsResponse,
     ExportStatusResponse,
     ExportSummary,
@@ -26,7 +27,7 @@ from app.db.models import User
 from app.db.session import get_db
 from app.db.repo.exports import create_export, get_export, list_exports_for_org_ids, update_export
 from app.db.repo.artifacts import get_artifacts_by_incident
-from app.db.repo.events import create_event
+from app.db.repo.events import create_event, get_events_by_incident
 from app.db.repo.incidents import get_incident
 from app.db.repo.users import get_user_org_ids
 from app.domain.system_event_types import SystemEventType
@@ -82,7 +83,13 @@ def create_export_endpoint(
         event_type=SystemEventType.EXPORT_REQUESTED,
         actor_type="user",
         actor_id=str(current_user.id),
-        payload={"export_id": str(export.export_id), "export_type": body.export_type},
+        payload={
+            "export_id": str(export.export_id),
+            "incident_id": str(body.incident_id),
+            "export_type": body.export_type,
+            "status": "requested",
+            "actor": {"type": "user", "id": str(current_user.id)},
+        },
     )
 
     try:
@@ -109,8 +116,12 @@ def create_export_endpoint(
         actor_id="api",
         payload={
             "export_id": str(export.export_id),
+            "incident_id": str(body.incident_id),
+            "export_type": export.export_type,
+            "status": "queued",
             "task_id": str(task_id) if isinstance(task_id, (str, uuid.UUID)) else None,
             "attempt_number": 1,
+            "actor": {"type": "system", "id": "api"},
         },
     )
 
@@ -401,7 +412,16 @@ def download_export_endpoint(
         event_type=SystemEventType.EXPORT_DOWNLOADED,
         actor_type="system",
         actor_id="api",
-        payload={"export_id": str(export.export_id)},
+        payload={
+            "export_id": str(export.export_id),
+            "incident_id": str(export.incident_id),
+            "export_type": export.export_type,
+            "status": "ready",
+            "s3_bucket": bucket,
+            "s3_key": key,
+            "download_url_expires_in_seconds": expires_in_seconds,
+            "actor": {"type": "system", "id": "api"},
+        },
     )
 
     return DownloadExportResponse(
@@ -409,4 +429,36 @@ def download_export_endpoint(
         url=presigned_url,
         status="ready",
         progress_stage="ready_for_download",
+    )
+
+
+@router.get("/{export_id}/downloads", response_model=ExportDownloadAuditResponse)
+def get_export_downloads_endpoint(
+    export_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
+    current_user: User = Depends(get_current_user),
+):
+    org_ids = get_user_org_ids(db, current_user.id)
+    export = _resolve_authorized_export(db, export_id, org_ids)
+    events = get_events_by_incident(db, export.incident_id)
+    download_events = [
+        event
+        for event in events
+        if event.event_type == SystemEventType.EXPORT_DOWNLOADED
+        and isinstance(event.payload, dict)
+        and event.payload.get("export_id") == str(export.export_id)
+    ]
+    ordered_events = sorted(download_events, key=lambda event: event.occurred_at_utc or "")
+    return ExportDownloadAuditResponse(
+        export_id=export.export_id,
+        downloads=[
+            {
+                "event_type": event.event_type,
+                "occurred_at_utc": event.occurred_at_utc,
+                "actor_type": event.actor_type,
+                "payload": event.payload,
+            }
+            for event in ordered_events
+        ],
     )

--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -264,10 +264,32 @@ def request_export_endpoint(
         event_type=SystemEventType.EXPORT_REQUESTED,
         actor_type="user",
         actor_id=str(current_user.id),
-        payload={"export_id": str(export.export_id)},
+        payload={
+            "export_id": str(export.export_id),
+            "incident_id": str(incident_id),
+            "export_type": "court_defense",
+            "status": "requested",
+            "actor": {"type": "user", "id": str(current_user.id)},
+        },
     )
 
     logger.info("Queueing export build task", extra={"request_id": get_request_id()})
-    build_export.delay(str(incident_id), str(export.export_id))
+    task_result = build_export.delay(str(incident_id), str(export.export_id))
+    create_event(
+        db,
+        incident_id=incident_id,
+        event_type=SystemEventType.EXPORT_QUEUED,
+        actor_type="system",
+        actor_id="api",
+        payload={
+            "export_id": str(export.export_id),
+            "incident_id": str(incident_id),
+            "export_type": "court_defense",
+            "status": "queued",
+            "task_id": str(getattr(task_result, "id", "") or ""),
+            "attempt_number": 1,
+            "actor": {"type": "system", "id": "api"},
+        },
+    )
 
     return CreateExportResponse(export_id=export.export_id, status=export.status, progress_stage=export.progress_stage)

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -311,6 +311,11 @@ class ExportContentsResponse(BaseModel):
     warnings: list[dict[str, str]] = Field(default_factory=list)
 
 
+class ExportDownloadAuditResponse(BaseModel):
+    export_id: uuid.UUID
+    downloads: list[EventSummary] = Field(default_factory=list)
+
+
 # ── Driver ──────────────────────────────────────────────────────────
 
 

--- a/backend/app/domain/system_event_types.py
+++ b/backend/app/domain/system_event_types.py
@@ -31,6 +31,9 @@ class SystemEventType(str, Enum):
     # ── Exports ─────────────────────────────────────────────────────
     EXPORT_REQUESTED = "export_requested"
     EXPORT_QUEUED = "export_queued"
+    EXPORT_PROCESSING_STARTED = "export_processing_started"
+    EXPORT_SECTION_GENERATED = "export_section_generated"
+    EXPORT_PACKAGE_UPLOADED = "export_package_uploaded"
     EXPORT_GENERATED = "export_generated"
     EXPORT_FAILED = "export_failed"
     EXPORT_DOWNLOADED = "export_downloaded"

--- a/backend/app/tasks/export_tasks.py
+++ b/backend/app/tasks/export_tasks.py
@@ -162,6 +162,24 @@ def _emit_stage(ctx: ExportRuntimeContext, phase: str, stage: str):
     )
 
 
+def _export_event_payload(
+    ctx: ExportRuntimeContext,
+    status: str,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "idempotency_key": ctx.workflow_key,
+        "export_id": ctx.export_id,
+        "incident_id": ctx.incident_id,
+        "export_type": ctx.export_row.export_type,
+        "status": status,
+        "actor": {"type": "system", "id": "celery"},
+    }
+    if extra:
+        payload.update(extra)
+    return payload
+
+
 def _persist_warnings(ctx: ExportRuntimeContext):
     from app.db.repo.exports import update_export
 
@@ -459,10 +477,18 @@ def build_export(
                 inc_uuid,
                 SystemEventType.EXPORT_REQUESTED,
                 workflow_key,
-                {
-                    "export_id": export_id,
-                },
+                _export_event_payload(
+                    ctx,
+                    "requested",
+                ),
             )
+        _emit_once(
+            db,
+            inc_uuid,
+            SystemEventType.EXPORT_PROCESSING_STARTED,
+            workflow_key,
+            _export_event_payload(ctx, "processing"),
+        )
         # 2. Load context
         _emit_stage(ctx, "before", "gathering_incident_data")
         _set_progress_stage(ctx, "gathering_incident_data")
@@ -492,6 +518,19 @@ def build_export(
         update_export(ctx.db, export_id=ctx.export_uuid, options_json=options)
         ctx.export_row.options_json = options
         _emit_stage(ctx, "after", "assembling_documents")
+        _emit(
+            ctx.db,
+            ctx.incident_uuid,
+            SystemEventType.EXPORT_SECTION_GENERATED,
+            _export_event_payload(
+                ctx,
+                "processing",
+                {
+                    "section": "document_bundle",
+                    "file_manifest_count": len(build_result.file_manifest),
+                },
+            ),
+        )
 
         _emit_stage(ctx, "before", "packaging_evidence")
         _set_progress_stage(ctx, "packaging_evidence")
@@ -508,6 +547,23 @@ def build_export(
             byte_size=build_result.byte_size,
         )
         _emit_stage(ctx, "after", "uploading_export")
+        _emit(
+            ctx.db,
+            ctx.incident_uuid,
+            SystemEventType.EXPORT_PACKAGE_UPLOADED,
+            _export_event_payload(
+                ctx,
+                "ready",
+                {
+                    "package": {
+                        "s3_bucket": ctx.settings.S3_BUCKET,
+                        "s3_key": ctx.zip_key,
+                        "sha256": build_result.package_sha256,
+                        "byte_size": build_result.byte_size,
+                    }
+                },
+            ),
+        )
 
         # 8. Emit EXPORT_GENERATED
         _emit_once(
@@ -515,14 +571,22 @@ def build_export(
             inc_uuid,
             SystemEventType.EXPORT_GENERATED,
             workflow_key,
-            {
-                "export_id": export_id,
-                "s3_key": ctx.zip_key,
-                "sha256": _hash_bytes(ctx.zip_bytes),
-                "byte_size": len(ctx.zip_bytes),
-                "warnings_count": len(ctx.warnings),
-                "missing_items_count": len(ctx.missing_items),
-            },
+            _export_event_payload(
+                ctx,
+                "ready",
+                {
+                    "package": {
+                        "s3_bucket": ctx.settings.S3_BUCKET,
+                        "s3_key": ctx.zip_key,
+                        "sha256": _hash_bytes(ctx.zip_bytes),
+                        "byte_size": len(ctx.zip_bytes),
+                    },
+                    "sha256": _hash_bytes(ctx.zip_bytes),
+                    "byte_size": len(ctx.zip_bytes),
+                    "warnings_count": len(ctx.warnings),
+                    "missing_items_count": len(ctx.missing_items),
+                },
+            ),
         )
 
         return {
@@ -553,7 +617,11 @@ def build_export(
             SystemEventType.EXPORT_FAILED,
             workflow_key,
             {
+                "idempotency_key": workflow_key,
                 "export_id": export_id,
+                "incident_id": incident_id,
+                "status": "failed",
+                "actor": {"type": "system", "id": "celery"},
                 "error_message": str(exc),
             },
         )

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -651,6 +651,11 @@ class TestDownloadExport:
         )
         event_types = [e.event_type for e in events]
         assert "export_downloaded" in event_types
+        download_event = next(e for e in events if e.event_type == "export_downloaded")
+        assert download_event.payload["export_id"] == str(exp.export_id)
+        assert download_event.payload["status"] == "ready"
+        assert download_event.payload["s3_bucket"] == "b"
+        assert download_event.payload["s3_key"] == "k"
 
     def test_download_export_no_auth_returns_401(self, client):
         fake_id = str(uuid.uuid4())
@@ -820,6 +825,37 @@ class TestGetExport:
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"] == "requested"
+
+    def test_get_export_downloads_returns_audit_history(
+        self, client, db_session, test_org, auth_headers
+    ):
+        inc = Incident(status="open", org_id=test_org.id)
+        db_session.add(inc)
+        db_session.commit()
+        db_session.refresh(inc)
+
+        exp = Export(incident_id=inc.incident_id, org_id=test_org.id, status="ready")
+        db_session.add(exp)
+        db_session.commit()
+        db_session.refresh(exp)
+
+        from app.db.repo.events import create_event
+
+        create_event(
+            db_session,
+            incident_id=inc.incident_id,
+            event_type="export_downloaded",
+            actor_type="system",
+            actor_id="api",
+            payload={"export_id": str(exp.export_id), "status": "ready"},
+        )
+
+        resp = client.get(f"/exports/{exp.export_id}/downloads", headers=auth_headers)
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["export_id"] == str(exp.export_id)
+        assert len(payload["downloads"]) == 1
+        assert payload["downloads"][0]["event_type"] == "export_downloaded"
 
     def test_get_export_no_auth_returns_401(self, client):
         fake_id = str(uuid.uuid4())

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -668,7 +668,11 @@ class TestBuildExport:
         event_types = [e.event_type for e in events]
 
         assert "export_requested" in event_types
+        assert "export_processing_started" in event_types
+        assert "export_section_generated" in event_types
+        assert "export_package_uploaded" in event_types
         assert "export_generated" in event_types
+        assert event_types.index("export_processing_started") < event_types.index("export_generated")
 
     @patch("app.tasks.export_tasks._get_db")
     @patch("app.services.vault_s3.VaultS3")
@@ -775,6 +779,15 @@ class TestBuildExport:
             .all()
         )
         assert len(events) == 1
+        all_event_types = [
+            row.event_type
+            for row in db_session.query(Event)
+            .filter(Event.incident_id == incident.incident_id)
+            .order_by(Event.created_at_utc.asc())
+            .all()
+        ]
+        assert "export_processing_started" in all_event_types
+        assert all_event_types[-1] == "export_failed"
         updated_export = (
             db_session.query(Export)
             .filter(Export.export_id == export_row.export_id)

--- a/backend/tests/test_system_event_types.py
+++ b/backend/tests/test_system_event_types.py
@@ -7,8 +7,8 @@ class TestSystemEventType:
     """Validate the SystemEventType contract."""
 
     def test_total_count(self):
-        """There must be exactly 35 system event types."""
-        assert len(SystemEventType) == 35
+        """There must be exactly 38 system event types."""
+        assert len(SystemEventType) == 38
 
     def test_is_str_enum(self):
         """Every member must be usable as a plain string."""
@@ -77,6 +77,17 @@ class TestSystemEventType:
     def test_export_queued(self):
         assert SystemEventType.EXPORT_QUEUED == "export_queued"
 
+    def test_export_processing_started(self):
+        assert (
+            SystemEventType.EXPORT_PROCESSING_STARTED == "export_processing_started"
+        )
+
+    def test_export_section_generated(self):
+        assert SystemEventType.EXPORT_SECTION_GENERATED == "export_section_generated"
+
+    def test_export_package_uploaded(self):
+        assert SystemEventType.EXPORT_PACKAGE_UPLOADED == "export_package_uploaded"
+
     def test_export_failed(self):
         assert SystemEventType.EXPORT_FAILED == "export_failed"
 
@@ -141,6 +152,9 @@ class TestSystemEventType:
         expected = {
             "export_requested",
             "export_queued",
+            "export_processing_started",
+            "export_section_generated",
+            "export_package_uploaded",
             "export_generated",
             "export_failed",
             "export_downloaded",

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -219,6 +219,11 @@ export interface EventSummary {
   payload?: Record<string, unknown> | null;
 }
 
+export interface ExportDownloadAuditResponse {
+  export_id: string;
+  downloads: EventSummary[];
+}
+
 export interface IncidentDetail extends Incident {
   evidence_inventory: ArtifactSummary[];
   export_status: ExportSummary[];
@@ -258,6 +263,10 @@ export function downloadExport(exportId: string) {
   return request<{ export_id: string; url: string; status: ExportStatus; progress_stage: ExportProgressStage }>(
     `/exports/${exportId}/download`
   );
+}
+
+export function getExportDownloadHistory(exportId: string) {
+  return request<ExportDownloadAuditResponse>(`/exports/${exportId}/downloads`);
 }
 
 /* ── Exports listing ──────────────────────────────────────────────── */


### PR DESCRIPTION
### Motivation

- Provide a consistent, observable export lifecycle so consumers (UI/ops) can rely on stable event types and payload shapes. 
- Include canonical identifiers, actor context, status and package metadata in export events to improve auditability and troubleshooting. 
- Emit a download event on successful presigned-URL generation and expose export download history for the export-detail UI. 
- Cover success and failure flows with tests to prevent regressions.

### Description

- Add new export lifecycle event types `export_processing_started`, `export_section_generated`, and `export_package_uploaded` to `SystemEventType` and extend the enum tests. 
- Introduce `_export_event_payload` helper and emit enriched events from the export worker (`build_export`) for requested, processing-started, section-generated, package-uploaded, generated, and failed phases; include `export_id`, `incident_id`, `status`, `actor`, and package metadata where applicable. 
- Enrich API-created events in `routes_incidents` and `routes_exports` so `export_requested` / `export_queued` payloads include identifiers, status and actor info. 
- Emit `export_downloaded` with package metadata on successful presigned URL generation in `GET /exports/{export_id}/download`. 
- Add `GET /exports/{export_id}/downloads` endpoint and `ExportDownloadAuditResponse` schema to return ordered download audit events, and add `getExportDownloadHistory` client helper and typings in the frontend. 
- Update backend tests to assert new event coverage and sequencing for success and failure paths and to validate the download-audit API.

### Testing

- Ran focused backend tests: `cd backend && pytest tests/test_system_event_types.py tests/test_celery_tasks.py::TestBuildExport::test_export_emits_events tests/test_celery_tasks.py::TestBuildExport::test_export_failure_emits_failed_event tests/test_celery_tasks.py::TestBuildExport::test_export_contains_sha256 tests/test_api_endpoints.py::TestDownloadExport::test_download_export_logs_event tests/test_api_endpoints.py::TestGetExport::test_get_export_downloads_returns_audit_history -q` and all executed tests passed. 
- Verified a broader subset run for export-related suites which completed successfully (`37 passed` for the exercised export tests). 
- Ran Python linter: `cd backend && ruff check app tests` which passed. 
- Ran frontend linter: `cd frontend && npm run -s lint` which completed with one unrelated warning (`frontend/components/marketing/Hero.tsx` variable unused) that is outside these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d46374c9388321a0b58b114c8653cc)