### PR TITLE
Add incident export generation flow with processing, ready and failed states

### DIFF
--- a/frontend/app/incidents/[id]/IncidentDetailClient.tsx
+++ b/frontend/app/incidents/[id]/IncidentDetailClient.tsx
@@ -6,8 +6,6 @@ import Link from "next/link";
 import {
   getIncident,
   getDriverProtocolSettings,
-  requestExport,
-  downloadExport,
   type IncidentDetail,
   type DriverProtocolSummary,
   type DriverResponseSummary,
@@ -15,7 +13,7 @@ import {
 import { useAuth } from "@/lib/useAuth";
 import EvidenceTable, { EVIDENCE_TYPES } from "@/components/EvidenceTable";
 import Timeline from "@/components/Timeline";
-import ExportPanel from "@/components/ExportPanel";
+import IncidentDetailExportPanel from "@/components/IncidentDetailExportPanel";
 
 function formatTime(iso?: string | null): string {
   if (!iso) return "—";
@@ -37,7 +35,6 @@ export default function IncidentDetailClient() {
   const [incident, setIncident] = useState<IncidentDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [exporting, setExporting] = useState(false);
   const [driverProtocolSettings, setDriverProtocolSettings] =
     useState<DriverProtocolSummary | null>(null);
 
@@ -127,28 +124,6 @@ export default function IncidentDetailClient() {
     }, REFRESH_INTERVAL_MS);
     return () => window.clearInterval(interval);
   }, [isCapturing, refreshIncident, user]);
-
-  async function handleExport() {
-    setExporting(true);
-    try {
-      await requestExport(id);
-      const updated = await getIncident(id);
-      setIncident(updated);
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Export failed");
-    } finally {
-      setExporting(false);
-    }
-  }
-
-  async function handleDownload(exportId: string) {
-    try {
-      const data = await downloadExport(exportId);
-      window.open(data.url, "_blank");
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Download failed");
-    }
-  }
 
   if (loading || authLoading) {
     return (
@@ -278,11 +253,10 @@ export default function IncidentDetailClient() {
           <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-500">
             C) Export Actions
           </h2>
-          <ExportPanel
+          <IncidentDetailExportPanel
+            incidentId={id}
             exports={incident.export_status}
-            onExport={handleExport}
-            onDownload={handleDownload}
-            exporting={exporting}
+            onExportsChanged={refreshIncident}
           />
         </div>
 

--- a/frontend/components/GenerateExportModal.tsx
+++ b/frontend/components/GenerateExportModal.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { ExportType } from "@/lib/api";
+
+interface ExportOptions {
+  profile: "mvp_default";
+  include_media: boolean;
+  include_raw_telemetry: boolean;
+  include_driver_statement: boolean;
+}
+
+interface GenerateExportModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (payload: { exportType: ExportType; options: ExportOptions }) => Promise<void>;
+  disabled?: boolean;
+  warningCount?: number;
+}
+
+const EXPORT_TYPE_OPTIONS: Array<{ value: ExportType; label: string; description: string }> = [
+  {
+    value: "court_defense",
+    label: "Court Defense (MVP)",
+    description: "Includes evidence package sections required by the MVP profile.",
+  },
+  {
+    value: "insurer_packet",
+    label: "Insurer Packet",
+    description: "Placeholder for insurer-specific packet workflow.",
+  },
+  {
+    value: "internal_review",
+    label: "Internal Review",
+    description: "Placeholder for internal review workflow.",
+  },
+  {
+    value: "compliance_audit",
+    label: "Compliance Audit",
+    description: "Placeholder for compliance audit workflow.",
+  },
+];
+
+const NON_BLOCKING_WARNINGS = [
+  "Unavailable artifacts are flagged in the package and do not block export generation.",
+  "Timeline ordering is best-effort if upstream systems report delayed timestamps.",
+];
+
+const DEFAULT_OPTIONS: ExportOptions = {
+  profile: "mvp_default",
+  include_media: true,
+  include_raw_telemetry: true,
+  include_driver_statement: true,
+};
+
+export default function GenerateExportModal({
+  open,
+  onClose,
+  onSubmit,
+  disabled = false,
+  warningCount = 0,
+}: GenerateExportModalProps) {
+  const [step, setStep] = useState<"configure" | "review">("configure");
+  const [exportType, setExportType] = useState<ExportType>("court_defense");
+  const [options, setOptions] = useState<ExportOptions>(DEFAULT_OPTIONS);
+
+  const includedSections = useMemo(
+    () => [
+      options.include_media ? "Incident media bundle" : null,
+      options.include_raw_telemetry ? "Raw telemetry records" : null,
+      options.include_driver_statement ? "Driver statement + protocol timeline" : null,
+      "Evidence inventory snapshot",
+      "Chain-of-custody digest",
+      "Integrity verification report",
+    ].filter(Boolean) as string[],
+    [options]
+  );
+
+  if (!open) return null;
+
+  const isMvpExport = exportType === "court_defense";
+
+  async function handleSubmit() {
+    await onSubmit({ exportType, options });
+    setStep("configure");
+  }
+
+  function handleClose() {
+    setStep("configure");
+    onClose();
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-2xl rounded-lg bg-white p-6 shadow-xl dark:bg-gray-800">
+        <div className="mb-4 flex items-start justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Generate export</h3>
+            <p className="text-sm text-gray-500">
+              {step === "configure" ? "Choose export settings." : "Review included sections and warnings."}
+            </p>
+          </div>
+          <button onClick={handleClose} className="text-sm text-gray-500 hover:underline">
+            Close
+          </button>
+        </div>
+
+        {step === "configure" ? (
+          <div className="space-y-4">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200">
+              Export type
+              <select
+                value={exportType}
+                onChange={(e) => setExportType(e.target.value as ExportType)}
+                className="mt-1 w-full rounded border border-gray-300 p-2 text-sm dark:border-gray-600 dark:bg-gray-900"
+              >
+                {EXPORT_TYPE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <p className="text-xs text-gray-500">
+              {EXPORT_TYPE_OPTIONS.find((option) => option.value === exportType)?.description}
+            </p>
+
+            {isMvpExport ? (
+              <div className="rounded border border-blue-100 bg-blue-50 p-3 text-sm">
+                <p className="font-medium text-blue-900">MVP defaults (court defense)</p>
+                <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={options.include_media}
+                      onChange={(e) => setOptions((prev) => ({ ...prev, include_media: e.target.checked }))}
+                    />
+                    Include media
+                  </label>
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={options.include_raw_telemetry}
+                      onChange={(e) =>
+                        setOptions((prev) => ({ ...prev, include_raw_telemetry: e.target.checked }))
+                      }
+                    />
+                    Include raw telemetry
+                  </label>
+                  <label className="flex items-center gap-2 sm:col-span-2">
+                    <input
+                      type="checkbox"
+                      checked={options.include_driver_statement}
+                      onChange={(e) =>
+                        setOptions((prev) => ({ ...prev, include_driver_statement: e.target.checked }))
+                      }
+                    />
+                    Include driver statement
+                  </label>
+                </div>
+              </div>
+            ) : (
+              <div className="rounded border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+                Non-court export types are placeholders and currently submit with no custom options.
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div>
+              <p className="text-sm font-medium text-gray-700 dark:text-gray-200">Included sections</p>
+              <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-gray-600 dark:text-gray-300">
+                {includedSections.map((section) => (
+                  <li key={section}>{section}</li>
+                ))}
+              </ul>
+            </div>
+            <div className="rounded border border-amber-200 bg-amber-50 p-3">
+              <p className="text-sm font-medium text-amber-900">Non-blocking warnings</p>
+              <ul className="mt-2 list-disc space-y-1 pl-5 text-xs text-amber-900">
+                {NON_BLOCKING_WARNINGS.map((warning) => (
+                  <li key={warning}>{warning}</li>
+                ))}
+                {warningCount > 0 && <li>{warningCount} warning(s) detected on recent export attempts.</li>}
+              </ul>
+            </div>
+          </div>
+        )}
+
+        <div className="mt-6 flex justify-between">
+          <button
+            onClick={() => setStep((prev) => (prev === "configure" ? "review" : "configure"))}
+            className="rounded border border-gray-300 px-3 py-2 text-sm hover:bg-gray-50"
+          >
+            {step === "configure" ? "Review" : "Back"}
+          </button>
+          {step === "review" && (
+            <button
+              onClick={handleSubmit}
+              disabled={disabled}
+              className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {disabled ? "Submitting…" : "Submit export"}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/IncidentDetailExportPanel.tsx
+++ b/frontend/components/IncidentDetailExportPanel.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  createExport,
+  downloadExport,
+  getExport,
+  getExportStatus,
+  type ExportProgressStage,
+  type ExportStatus,
+  type ExportSummary,
+  type ExportType,
+} from "@/lib/api";
+import { getExportStatusBadgeClass, getExportStatusLabel } from "@/lib/exportStatus";
+import GenerateExportModal from "@/components/GenerateExportModal";
+
+interface IncidentDetailExportPanelProps {
+  incidentId: string;
+  exports: ExportSummary[];
+  onExportsChanged: () => Promise<void>;
+}
+
+const STAGE_TEXT: Record<ExportProgressStage, string> = {
+  request_accepted: "Request accepted",
+  gathering_incident_data: "Gathering incident data",
+  assembling_documents: "Assembling documents",
+  packaging_evidence: "Packaging evidence",
+  uploading_export: "Uploading export",
+  ready_for_download: "Ready for download",
+};
+
+function formatBytes(value?: number | null): string {
+  if (value == null) return "—";
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`;
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export default function IncidentDetailExportPanel({
+  incidentId,
+  exports,
+  onExportsChanged,
+}: IncidentDetailExportPanelProps) {
+  const [showModal, setShowModal] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [activeExportId, setActiveExportId] = useState<string | null>(null);
+  const [status, setStatus] = useState<ExportStatus | null>(null);
+  const [stage, setStage] = useState<ExportProgressStage | null>(null);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [readyExport, setReadyExport] = useState<ExportSummary | null>(null);
+
+  const recentExports = exports.slice(0, 5);
+  const recentWarnings = useMemo(
+    () =>
+      recentExports.reduce((count, item) => {
+        const warnings = Array.isArray(item.options_json?.warnings) ? item.options_json.warnings : [];
+        return count + warnings.length;
+      }, 0),
+    [recentExports]
+  );
+
+  useEffect(() => {
+    if (!activeExportId || !status || (status !== "queued" && status !== "processing" && status !== "requested")) {
+      return;
+    }
+
+    const timer = window.setInterval(async () => {
+      try {
+        const result = await getExportStatus(activeExportId);
+        setStatus(result.status);
+        setStage(result.progress_stage);
+        setErrorMessage(result.error_message ?? "");
+
+        if (result.status === "ready") {
+          const full = await getExport(activeExportId);
+          setReadyExport(full);
+          await onExportsChanged();
+          window.clearInterval(timer);
+        }
+
+        if (result.status === "failed" || result.status === "expired") {
+          await onExportsChanged();
+          window.clearInterval(timer);
+        }
+      } catch (err: unknown) {
+        setErrorMessage(err instanceof Error ? err.message : "Unable to poll export status");
+      }
+    }, 2500);
+
+    return () => window.clearInterval(timer);
+  }, [activeExportId, onExportsChanged, status]);
+
+  async function startExport(payload: {
+    exportType: ExportType;
+    options: {
+      profile: "mvp_default";
+      include_media: boolean;
+      include_raw_telemetry: boolean;
+      include_driver_statement: boolean;
+    };
+  }) {
+    setSubmitting(true);
+    setErrorMessage("");
+    try {
+      const options = payload.exportType === "court_defense" ? payload.options : {};
+      const created = await createExport({
+        incident_id: incidentId,
+        export_type: payload.exportType,
+        options_json: options,
+      });
+      setActiveExportId(created.export_id);
+      setStatus(created.status);
+      setStage("request_accepted");
+      setReadyExport(null);
+      setShowModal(false);
+      await onExportsChanged();
+    } catch (err: unknown) {
+      setErrorMessage(err instanceof Error ? err.message : "Failed to create export");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleDownload(exportId: string) {
+    const result = await downloadExport(exportId);
+    window.open(result.url, "_blank");
+  }
+
+  const isProcessing = status === "requested" || status === "queued" || status === "processing";
+  const isFailed = status === "failed" || status === "expired";
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-gray-500">Recent exports and generation status.</p>
+        <button
+          onClick={() => setShowModal(true)}
+          className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          New export
+        </button>
+      </div>
+
+      {isProcessing && (
+        <div className="rounded border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900">
+          <p className="font-medium">ExportProcessingState</p>
+          <p>{stage ? STAGE_TEXT[stage] : "Starting export workflow"}</p>
+          <p className="text-xs">Polling /exports/{activeExportId}/status…</p>
+        </div>
+      )}
+
+      {readyExport && (
+        <div className="rounded border border-green-200 bg-green-50 p-3 text-sm text-green-900">
+          <p className="font-medium">ExportReadyState</p>
+          <p>Checksum: {readyExport.package_sha256 ?? "—"}</p>
+          <p>Size: {formatBytes(readyExport.byte_size)}</p>
+          <button
+            onClick={() => handleDownload(readyExport.export_id)}
+            className="mt-2 rounded bg-green-600 px-3 py-1 text-xs font-medium text-white hover:bg-green-700"
+          >
+            Download export
+          </button>
+        </div>
+      )}
+
+      {isFailed && (
+        <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-900">
+          <p className="font-medium">Export failed</p>
+          <p>{errorMessage || "Export did not complete successfully."}</p>
+          <button
+            className="mt-2 rounded border border-red-300 px-3 py-1 text-xs"
+            onClick={() => setShowModal(true)}
+          >
+            Retry (placeholder)
+          </button>
+        </div>
+      )}
+
+      {errorMessage && !isFailed && <p className="text-sm text-red-600">{errorMessage}</p>}
+
+      {recentExports.length === 0 ? (
+        <p className="text-sm text-gray-400">No exports yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {recentExports.map((item) => (
+            <li key={item.export_id} className="rounded border px-3 py-2 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="font-mono text-xs text-gray-600">{item.export_id.slice(0, 8)}…</span>
+                <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${getExportStatusBadgeClass(item.status)}`}>
+                  {getExportStatusLabel(item.status)}
+                </span>
+              </div>
+              <div className="mt-2 flex gap-2">
+                {item.status === "ready" && (
+                  <button
+                    onClick={() => handleDownload(item.export_id)}
+                    className="rounded bg-green-600 px-3 py-1 text-xs font-medium text-white hover:bg-green-700"
+                  >
+                    Download
+                  </button>
+                )}
+                {(item.status === "failed" || item.status === "expired") && (
+                  <button
+                    onClick={() => setShowModal(true)}
+                    className="rounded border border-gray-300 px-3 py-1 text-xs"
+                  >
+                    Retry placeholder
+                  </button>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <GenerateExportModal
+        open={showModal}
+        onClose={() => setShowModal(false)}
+        onSubmit={startExport}
+        disabled={submitting}
+        warningCount={recentWarnings}
+      />
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -224,6 +224,26 @@ export interface ExportDownloadAuditResponse {
   downloads: EventSummary[];
 }
 
+export interface CreateExportRequest {
+  incident_id: string;
+  export_type: ExportType;
+  options_json?: Record<string, unknown>;
+}
+
+export interface CreateExportEnqueueResponse {
+  export_id: string;
+  incident_id: string;
+  export_type: ExportType;
+  status: ExportStatus;
+  created_at_utc: string;
+}
+
+export interface ExportStatusResponse {
+  status: ExportStatus;
+  progress_stage: ExportProgressStage;
+  error_message?: string | null;
+}
+
 export interface IncidentDetail extends Incident {
   evidence_inventory: ArtifactSummary[];
   export_status: ExportSummary[];
@@ -257,6 +277,21 @@ export function requestExport(incidentId: string) {
     `/incidents/${incidentId}/exports`,
     { method: "POST" }
   );
+}
+
+export function createExport(data: CreateExportRequest) {
+  return request<CreateExportEnqueueResponse>("/exports/", {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export function getExport(exportId: string) {
+  return request<ExportSummary>(`/exports/${exportId}`);
+}
+
+export function getExportStatus(exportId: string) {
+  return request<ExportStatusResponse>(`/exports/${exportId}/status`);
 }
 
 export function downloadExport(exportId: string) {


### PR DESCRIPTION
### Motivation
- Provide an integrated export-generation UX on the incident detail page that supports creating exports, reviewing included sections and warnings, and tracking server-side processing until the package is ready for download.

### Description
- Added `GenerateExportModal` (`frontend/components/GenerateExportModal.tsx`) with export type selector, MVP defaults for `court_defense`, and a review step showing included sections and non-blocking warnings.
- Implemented `IncidentDetailExportPanel` (`frontend/components/IncidentDetailExportPanel.tsx`) which lists recent exports, starts export creation, polls `GET /exports/{id}/status` with progress-stage→text mapping, and surfaces `ExportProcessingState`, `ExportReadyState` (checksum, size, download), and a failed/expired state with retry placeholder.
- Wired the incident detail page to use the new panel and refresh incident data on export changes by updating `frontend/app/incidents/[id]/IncidentDetailClient.tsx`.
- Extended the frontend API client (`frontend/lib/api.ts`) with `createExport`, `getExport`, and `getExportStatus` to call `POST /exports`, `GET /exports/{id}`, and `GET /exports/{id}/status` respectively.

### Testing
- Ran lint with `npm --prefix frontend run lint`, which completed (one preexisting unrelated warning in `frontend/components/marketing/Hero.tsx`).
- Ran typecheck with `npm --prefix frontend run typecheck`, which succeeded.
- Ran frontend tests with `npm --prefix frontend test`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d465fb5998832189f02d00ab7b1aab)