### PR TITLE
Add retry endpoint for failed exports with linked retry attempts and UI actions

### DIFF
--- a/backend/app/api/routes_exports.py
+++ b/backend/app/api/routes_exports.py
@@ -16,6 +16,7 @@ from app.api.schemas import (
     ExportContentsResponse,
     ExportStatusResponse,
     ExportSummary,
+    RetryExportRequest,
 )
 from app.core.deps import (
     enforce_resource_org_ownership,
@@ -27,7 +28,13 @@ from app.core.logging import set_log_context
 from app.core.metrics import MetricNames, increment, timed
 from app.db.models import User
 from app.db.session import get_db
-from app.db.repo.exports import create_export, get_export, list_exports_for_org_ids, update_export
+from app.db.repo.exports import (
+    create_export,
+    get_export,
+    get_exports_by_incident,
+    list_exports_for_org_ids,
+    update_export,
+)
 from app.db.repo.artifacts import get_artifacts_by_incident
 from app.db.repo.events import create_event, get_events_by_incident
 from app.db.repo.incidents import get_incident
@@ -136,6 +143,90 @@ def create_export_endpoint(
     )
 
 
+@router.post("/{export_id}/retry", response_model=CreateExportEnqueueResponse, status_code=201)
+def retry_export_endpoint(
+    export_id: uuid.UUID,
+    body: RetryExportRequest,
+    db: Session = Depends(get_db),
+    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
+    current_user: User = Depends(require_user_role("admin", "safety_manager")),
+):
+    org_ids = get_user_org_ids(db, current_user.id)
+    failed_export = _resolve_authorized_export(db, export_id, org_ids)
+    if failed_export.status != "failed":
+        raise HTTPException(status_code=409, detail="Only failed exports can be retried")
+
+    new_export = create_export(
+        db,
+        incident_id=failed_export.incident_id,
+        org_id=failed_export.org_id,
+        status="requested",
+        export_type=body.export_type or failed_export.export_type,
+        requested_by_user_id=current_user.id,
+        retry_parent_export_id=failed_export.export_id,
+        options_json=body.options_json
+        if body.options_json is not None
+        else (failed_export.options_json or {}),
+        progress_stage="request_accepted",
+    )
+
+    attempt_number = _get_retry_attempt_number(db, new_export)
+    create_event(
+        db,
+        incident_id=failed_export.incident_id,
+        event_type=SystemEventType.EXPORT_RETRY_REQUESTED,
+        actor_type="user",
+        actor_id=str(current_user.id),
+        payload={
+            "export_id": str(new_export.export_id),
+            "prior_export_id": str(failed_export.export_id),
+            "incident_id": str(failed_export.incident_id),
+            "export_type": new_export.export_type,
+            "status": "requested",
+            "attempt_number": attempt_number,
+            "actor": {"type": "user", "id": str(current_user.id)},
+        },
+    )
+
+    try:
+        task_result = build_export.delay(
+            str(failed_export.incident_id),
+            str(new_export.export_id),
+            {"attempt_number": attempt_number, "trigger": "retry_api"},
+        )
+    except Exception as exc:
+        logger.exception("Failed to enqueue retry export task")
+        raise HTTPException(
+            status_code=502,
+            detail="Unable to enqueue export generation",
+        ) from exc
+    new_export = update_export(db, new_export.export_id, status="queued") or new_export
+    task_id = getattr(task_result, "id", None)
+    create_event(
+        db,
+        incident_id=failed_export.incident_id,
+        event_type=SystemEventType.EXPORT_QUEUED,
+        actor_type="system",
+        actor_id="api",
+        payload={
+            "export_id": str(new_export.export_id),
+            "incident_id": str(failed_export.incident_id),
+            "export_type": new_export.export_type,
+            "status": "queued",
+            "task_id": str(task_id) if isinstance(task_id, (str, uuid.UUID)) else None,
+            "attempt_number": attempt_number,
+            "actor": {"type": "system", "id": "api"},
+        },
+    )
+    return CreateExportEnqueueResponse(
+        export_id=new_export.export_id,
+        incident_id=new_export.incident_id,
+        export_type=new_export.export_type,
+        status=new_export.status,
+        created_at_utc=new_export.created_at_utc,
+    )
+
+
 def _get_export_owner_org_id(db: Session, export):
     """Resolve org ownership for an export, including legacy null-org rows."""
     if export.org_id is not None:
@@ -154,6 +245,9 @@ def _serialize_export(export):
         "export_type": export.export_type,
         "requested_by_user_id": (
             str(export.requested_by_user_id) if export.requested_by_user_id else None
+        ),
+        "retry_parent_export_id": (
+            str(export.retry_parent_export_id) if export.retry_parent_export_id else None
         ),
         "options_json": export.options_json or {},
         "status": export.status,
@@ -185,6 +279,25 @@ def _resolve_authorized_export(
     if export_org_id is None or export_org_id not in org_ids:
         raise HTTPException(status_code=403, detail="Forbidden")
     return export
+
+
+def _get_retry_attempt_number(db: Session, retry_export) -> int:
+    chain_exports = get_exports_by_incident(db, retry_export.incident_id)
+    by_id = {item.export_id: item for item in chain_exports}
+    root_id = retry_export.export_id
+    cursor = retry_export
+    while cursor.retry_parent_export_id and cursor.retry_parent_export_id in by_id:
+        root_id = cursor.retry_parent_export_id
+        cursor = by_id[cursor.retry_parent_export_id]
+
+    attempts = 0
+    for item in chain_exports:
+        candidate = item
+        while candidate.retry_parent_export_id and candidate.retry_parent_export_id in by_id:
+            candidate = by_id[candidate.retry_parent_export_id]
+        if candidate.export_id == root_id:
+            attempts += 1
+    return attempts
 
 
 def _is_presigned_https_url(url: str) -> bool:

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -162,6 +162,7 @@ class ExportSummary(BaseModel):
     incident_id: Optional[uuid.UUID] = None
     export_type: ExportType = "court_defense"
     requested_by_user_id: Optional[uuid.UUID] = None
+    retry_parent_export_id: Optional[uuid.UUID] = None
     options_json: dict[str, Any] = Field(default_factory=dict)
     status: ExportStatus
     progress_stage: ExportProgressStage = "request_accepted"
@@ -268,6 +269,11 @@ class CreateExportEnqueueResponse(BaseModel):
     export_type: ExportType
     status: ExportStatus
     created_at_utc: datetime
+
+
+class RetryExportRequest(BaseModel):
+    export_type: Optional[ExportType] = None
+    options_json: Optional[dict[str, Any]] = None
 
 
 class DownloadExportResponse(BaseModel):

--- a/backend/app/db/migrations/versions/0010_add_retry_parent_export_id.py
+++ b/backend/app/db/migrations/versions/0010_add_retry_parent_export_id.py
@@ -1,0 +1,45 @@
+"""add retry parent link to exports
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-04-07
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0010"
+down_revision: Union[str, None] = "0009"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "exports",
+        sa.Column("retry_parent_export_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_exports_retry_parent_export_id",
+        "exports",
+        "exports",
+        ["retry_parent_export_id"],
+        ["export_id"],
+    )
+    op.create_index(
+        "ix_exports_retry_parent_export_id",
+        "exports",
+        ["retry_parent_export_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_exports_retry_parent_export_id", table_name="exports")
+    op.drop_constraint("fk_exports_retry_parent_export_id", "exports", type_="foreignkey")
+    op.drop_column("exports", "retry_parent_export_id")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -191,6 +191,12 @@ class Export(Base):
         server_default="court_defense",
     )
     requested_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    retry_parent_export_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("exports.export_id"),
+        nullable=True,
+        index=True,
+    )
     options_json = Column(JSONB, nullable=False, default=dict)
     status = Column(
         Enum(*EXPORT_STATUSES, name="export_status"),

--- a/backend/app/db/repo/exports.py
+++ b/backend/app/db/repo/exports.py
@@ -50,6 +50,7 @@ def create_export(
     status: str = "requested",
     export_type: str = "court_defense",
     requested_by_user_id: Optional[_uuid.UUID] = None,
+    retry_parent_export_id: Optional[_uuid.UUID] = None,
     options_json: Optional[dict[str, Any]] = None,
     progress_stage: str = "request_accepted",
     s3_bucket: Optional[str] = None,
@@ -61,6 +62,7 @@ def create_export(
         incident_id=incident_id,
         export_type=export_type,
         requested_by_user_id=requested_by_user_id,
+        retry_parent_export_id=retry_parent_export_id,
         options_json=options_json or {},
         status=status,
         progress_stage=progress_stage,
@@ -71,6 +73,8 @@ def create_export(
     db.commit()
     db.refresh(export)
     return export
+
+
 
 
 def update_export(

--- a/backend/app/domain/system_event_types.py
+++ b/backend/app/domain/system_event_types.py
@@ -30,6 +30,7 @@ class SystemEventType(str, Enum):
 
     # ── Exports ─────────────────────────────────────────────────────
     EXPORT_REQUESTED = "export_requested"
+    EXPORT_RETRY_REQUESTED = "export_retry_requested"
     EXPORT_QUEUED = "export_queued"
     EXPORT_PROCESSING_STARTED = "export_processing_started"
     EXPORT_SECTION_GENERATED = "export_section_generated"

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from app.db.models import Base, Incident, Artifact, Export, User, Org, UserOrg
+from app.db.models import Base, Incident, Artifact, Event, Export, User, Org, UserOrg
 from app.db.session import get_db
 from app.core.security import hash_password, create_access_token
 from app.main import app
@@ -561,6 +561,115 @@ class TestRequestExport:
             headers=auth_headers,
         )
         assert resp.status_code == 201
+
+    @patch("app.api.routes_exports.build_export")
+    def test_retry_failed_export_creates_linked_attempt_and_reuses_config(
+        self, mock_gen, client, db_session, test_org, test_user, auth_headers
+    ):
+        mock_gen.delay = MagicMock()
+        incident = Incident(status="open", org_id=test_org.id)
+        db_session.add(incident)
+        db_session.commit()
+        db_session.refresh(incident)
+
+        failed = Export(
+            incident_id=incident.incident_id,
+            org_id=test_org.id,
+            export_type="court_defense",
+            requested_by_user_id=test_user.id,
+            options_json={"profile": "mvp_default", "include_media": False},
+            status="failed",
+            progress_stage="packaging_evidence",
+            error_message="zip failed",
+        )
+        db_session.add(failed)
+        db_session.commit()
+        db_session.refresh(failed)
+
+        resp = client.post(f"/exports/{failed.export_id}/retry", json={}, headers=auth_headers)
+        assert resp.status_code == 201
+        payload = resp.json()
+        assert payload["status"] == "queued"
+        assert payload["incident_id"] == str(incident.incident_id)
+
+        created = (
+            db_session.query(Export)
+            .filter(Export.export_id == uuid.UUID(payload["export_id"]))
+            .first()
+        )
+        assert created is not None
+        assert created.retry_parent_export_id == failed.export_id
+        assert created.export_type == failed.export_type
+        assert created.options_json == failed.options_json
+        refreshed_failed = db_session.query(Export).filter(Export.export_id == failed.export_id).first()
+        assert refreshed_failed.status == "failed"
+        retry_event = (
+            db_session.query(Event)
+            .filter(Event.event_type == "export_retry_requested")
+            .order_by(Event.created_at_utc.desc())
+            .first()
+        )
+        assert retry_event is not None
+        assert retry_event.payload["prior_export_id"] == str(failed.export_id)
+
+        mock_gen.delay.assert_called_once_with(
+            str(incident.incident_id),
+            str(created.export_id),
+            {"attempt_number": 2, "trigger": "retry_api"},
+        )
+
+    @patch("app.api.routes_exports.build_export")
+    def test_retry_failed_export_accepts_overrides(self, mock_gen, client, db_session, test_org, auth_headers):
+        mock_gen.delay = MagicMock()
+        incident = Incident(status="open", org_id=test_org.id)
+        db_session.add(incident)
+        db_session.commit()
+        db_session.refresh(incident)
+        failed = Export(
+            incident_id=incident.incident_id,
+            org_id=test_org.id,
+            export_type="internal_review",
+            options_json={},
+            status="failed",
+        )
+        db_session.add(failed)
+        db_session.commit()
+        db_session.refresh(failed)
+
+        resp = client.post(
+            f"/exports/{failed.export_id}/retry",
+            json={"export_type": "court_defense", "options_json": {"profile": "mvp_default"}},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 201
+        created = db_session.query(Export).filter(Export.export_id == uuid.UUID(resp.json()["export_id"])).first()
+        assert created.export_type == "court_defense"
+        assert created.options_json == {"profile": "mvp_default"}
+
+    def test_retry_export_rejects_non_failed_and_preserves_ready_export(
+        self, client, db_session, test_org, auth_headers
+    ):
+        incident = Incident(status="open", org_id=test_org.id)
+        db_session.add(incident)
+        db_session.commit()
+        db_session.refresh(incident)
+        ready = Export(
+            incident_id=incident.incident_id,
+            org_id=test_org.id,
+            export_type="court_defense",
+            options_json={"profile": "mvp_default"},
+            status="ready",
+            package_sha256="abc123",
+        )
+        db_session.add(ready)
+        db_session.commit()
+        db_session.refresh(ready)
+
+        resp = client.post(f"/exports/{ready.export_id}/retry", json={}, headers=auth_headers)
+        assert resp.status_code == 409
+        db_session.refresh(ready)
+        assert ready.status == "ready"
+        assert ready.package_sha256 == "abc123"
 
 
 # ── GET /exports/{export_id}/download ───────────────────────────────

--- a/backend/tests/test_system_event_types.py
+++ b/backend/tests/test_system_event_types.py
@@ -7,8 +7,8 @@ class TestSystemEventType:
     """Validate the SystemEventType contract."""
 
     def test_total_count(self):
-        """There must be exactly 38 system event types."""
-        assert len(SystemEventType) == 38
+        """There must be exactly 39 system event types."""
+        assert len(SystemEventType) == 39
 
     def test_is_str_enum(self):
         """Every member must be usable as a plain string."""
@@ -73,6 +73,9 @@ class TestSystemEventType:
 
     def test_export_generated(self):
         assert SystemEventType.EXPORT_GENERATED == "export_generated"
+
+    def test_export_retry_requested(self):
+        assert SystemEventType.EXPORT_RETRY_REQUESTED == "export_retry_requested"
 
     def test_export_queued(self):
         assert SystemEventType.EXPORT_QUEUED == "export_queued"
@@ -151,6 +154,7 @@ class TestSystemEventType:
         """All export types must be present."""
         expected = {
             "export_requested",
+            "export_retry_requested",
             "export_queued",
             "export_processing_started",
             "export_section_generated",

--- a/frontend/components/ExportPanel.tsx
+++ b/frontend/components/ExportPanel.tsx
@@ -28,6 +28,7 @@ interface ExportPanelProps {
   exports: ExportSummary[];
   onExport: () => void;
   onDownload: (exportId: string) => void;
+  onRetry: (exportId: string) => void;
   exporting?: boolean;
 }
 
@@ -66,6 +67,7 @@ export default function ExportPanel({
   exports: exportList,
   onExport,
   onDownload,
+  onRetry,
   exporting = false,
 }: ExportPanelProps) {
   const latestExport = exportList[0];
@@ -186,6 +188,14 @@ export default function ExportPanel({
                     className="rounded bg-green-600 px-3 py-1 text-xs font-medium text-white hover:bg-green-700"
                   >
                     Download ZIP
+                  </button>
+                )}
+                {ex.status === "failed" && (
+                  <button
+                    onClick={() => onRetry(ex.export_id)}
+                    className="rounded border border-red-300 px-3 py-1 text-xs font-medium text-red-700 hover:bg-red-50"
+                  >
+                    Retry export
                   </button>
                 )}
               </div>

--- a/frontend/components/IncidentDetailExportPanel.tsx
+++ b/frontend/components/IncidentDetailExportPanel.tsx
@@ -6,6 +6,7 @@ import {
   downloadExport,
   getExport,
   getExportStatus,
+  retryExport,
   type ExportProgressStage,
   type ExportStatus,
   type ExportSummary,
@@ -50,6 +51,10 @@ export default function IncidentDetailExportPanel({
   const [readyExport, setReadyExport] = useState<ExportSummary | null>(null);
 
   const recentExports = exports.slice(0, 5);
+  const latestFailedExportId =
+    activeExportId && (status === "failed" || status === "expired")
+      ? activeExportId
+      : recentExports.find((item) => item.status === "failed")?.export_id ?? null;
   const recentWarnings = useMemo(
     () =>
       recentExports.reduce((count, item) => {
@@ -126,6 +131,23 @@ export default function IncidentDetailExportPanel({
     window.open(result.url, "_blank");
   }
 
+  async function handleRetry(exportId: string) {
+    setSubmitting(true);
+    setErrorMessage("");
+    try {
+      const created = await retryExport(exportId);
+      setActiveExportId(created.export_id);
+      setStatus(created.status);
+      setStage("request_accepted");
+      setReadyExport(null);
+      await onExportsChanged();
+    } catch (err: unknown) {
+      setErrorMessage(err instanceof Error ? err.message : "Failed to retry export");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   const isProcessing = status === "requested" || status === "queued" || status === "processing";
   const isFailed = status === "failed" || status === "expired";
 
@@ -169,9 +191,10 @@ export default function IncidentDetailExportPanel({
           <p>{errorMessage || "Export did not complete successfully."}</p>
           <button
             className="mt-2 rounded border border-red-300 px-3 py-1 text-xs"
-            onClick={() => setShowModal(true)}
+            onClick={() => latestFailedExportId && handleRetry(latestFailedExportId)}
+            disabled={!latestFailedExportId || submitting}
           >
-            Retry (placeholder)
+            Retry failed export
           </button>
         </div>
       )}
@@ -199,12 +222,13 @@ export default function IncidentDetailExportPanel({
                     Download
                   </button>
                 )}
-                {(item.status === "failed" || item.status === "expired") && (
+                {item.status === "failed" && (
                   <button
-                    onClick={() => setShowModal(true)}
+                    onClick={() => handleRetry(item.export_id)}
+                    disabled={submitting}
                     className="rounded border border-gray-300 px-3 py-1 text-xs"
                   >
-                    Retry placeholder
+                    Retry export
                   </button>
                 )}
               </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -172,6 +172,7 @@ export interface ExportSummary {
   incident_id?: string | null;
   export_type: ExportType;
   requested_by_user_id?: string | null;
+  retry_parent_export_id?: string | null;
   options_json: Record<string, unknown>;
   status: ExportStatus;
   progress_stage: ExportProgressStage;
@@ -263,6 +264,11 @@ export interface CreateExportEnqueueResponse {
   created_at_utc: string;
 }
 
+export interface RetryExportRequest {
+  export_type?: ExportType;
+  options_json?: Record<string, unknown>;
+}
+
 export interface ExportStatusResponse {
   status: ExportStatus;
   progress_stage: ExportProgressStage;
@@ -306,6 +312,13 @@ export function requestExport(incidentId: string) {
 
 export function createExport(data: CreateExportRequest) {
   return request<CreateExportEnqueueResponse>("/exports/", {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export function retryExport(exportId: string, data: RetryExportRequest = {}) {
+  return request<CreateExportEnqueueResponse>(`/exports/${exportId}/retry`, {
     method: "POST",
     body: JSON.stringify(data),
   });


### PR DESCRIPTION
### Motivation
- Provide a safe retry flow for export generation that does not mutate previous attempts and allows operators to re-run failed exports.
- Preserve the failed export's configuration by default while permitting explicit overrides on retry. 
- Surface a retry action in the UI so users can initiate retries from failed export surfaces.

### Description
- Implemented `POST /exports/{export_id}/retry` which only succeeds for exports with status `failed` and returns a new queued export attempt linked by `retry_parent_export_id` instead of mutating the original row. 
- New persistence and migration: added `retry_parent_export_id` to the `Export` model and created migration `0010_add_retry_parent_export_id.py`. 
- Retry semantics: the endpoint reuses `export_type` and `options_json` from the failed export unless overridden, emits `export_retry_requested`, enqueues the generation task via `build_export.delay(...)`, and then emits `export_queued` for the new attempt. 
- Frontend and schema updates: exposed `retry_parent_export_id` in `ExportSummary`, added `RetryExportRequest` and `retryExport()` client API, and added retry buttons/flows in `ExportPanel` and `IncidentDetailExportPanel`. 

### Testing
- Ran backend linting with `ruff` (`cd backend && ruff check app tests`) which passed. 
- Ran targeted backend tests for the new retry behavior and system-event coverage (`pytest` on affected tests) and they passed: `TestRequestExport::test_retry_failed_export_creates_linked_attempt_and_reuses_config`, `test_retry_failed_export_accepts_overrides`, `test_retry_export_rejects_non_failed_and_preserves_ready_export`, and `TestSystemEventType::test_export_retry_requested`. 
- Ran a broader backend test run (`pytest tests/test_api_endpoints.py tests/test_system_event_types.py`) which succeeded except for one unrelated pre-existing failure in `TestGetIncident::test_get_incident_forbidden_for_other_org` (expected `403` but returned `404`). 
- Frontend checks: `npm run lint` (one existing unrelated warning), `npm run typecheck`, and `npm test` all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d469cc8ee083219e7725978f2980d7)