### PR TITLE
Add production hardening plan, machine-readable checklist, and CI gate check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test fmt lint guard-duplicates
+.PHONY: dev test fmt lint guard-duplicates check-prod-hardening-gates
 
 ## Start all services (infra + backend + worker + frontend) from repo root
 ## Uses docker compose (plugin-style command)
@@ -23,3 +23,7 @@ lint:
 ## Ensure no stale duplicate runtime modules reappear
 guard-duplicates:
 	python scripts/check_no_duplicate_modules.py
+
+## Enforce Priority-1 production hardening gates for production tags
+check-prod-hardening-gates:
+	python scripts/check_release_hardening_gates.py

--- a/docs/production-hardening/checklist.yaml
+++ b/docs/production-hardening/checklist.yaml
@@ -1,0 +1,172 @@
+[
+  {
+    "section": 5,
+    "requirement": "Identity and authorization gate",
+    "priority": 1,
+    "status": "incomplete",
+    "owner": "Security Engineering",
+    "target_sprint": "Sprint-24",
+    "evidence_link": "docs/jwt-key-rotation-runbook.md",
+    "gate": "identity_authz"
+  },
+  {
+    "section": 6,
+    "requirement": "Audit logging gate",
+    "priority": 1,
+    "status": "incomplete",
+    "owner": "Backend Platform",
+    "target_sprint": "Sprint-24",
+    "evidence_link": "docs/release-readiness-checklist.md",
+    "gate": "audit_logging"
+  },
+  {
+    "section": 7,
+    "requirement": "Observability gate",
+    "priority": 1,
+    "status": "incomplete",
+    "owner": "SRE",
+    "target_sprint": "Sprint-25",
+    "evidence_link": "docs/reliability-and-incident-response-runbook.md",
+    "gate": "observability"
+  },
+  {
+    "section": 8,
+    "requirement": "Backup and restore gate",
+    "priority": 1,
+    "status": "incomplete",
+    "owner": "SRE",
+    "target_sprint": "Sprint-25",
+    "evidence_link": "docs/reliability-and-incident-response-runbook.md",
+    "gate": "backups"
+  },
+  {
+    "section": 9,
+    "requirement": "Release flow gate",
+    "priority": 1,
+    "status": "incomplete",
+    "owner": "Release Management",
+    "target_sprint": "Sprint-24",
+    "evidence_link": "docs/release-readiness-checklist.md",
+    "gate": "release_flow"
+  },
+  {
+    "section": 10,
+    "requirement": "Secrets management",
+    "priority": 2,
+    "status": "incomplete",
+    "owner": "Security Engineering",
+    "target_sprint": "Sprint-25",
+    "evidence_link": "docs/api-keys-rotation-runbook.md",
+    "gate": "secrets_management"
+  },
+  {
+    "section": 11,
+    "requirement": "Data encryption",
+    "priority": 2,
+    "status": "incomplete",
+    "owner": "Platform Security",
+    "target_sprint": "Sprint-25",
+    "evidence_link": "docs/db-credentials-rotation-runbook.md",
+    "gate": "data_encryption"
+  },
+  {
+    "section": 12,
+    "requirement": "Dependency and vulnerability management",
+    "priority": 2,
+    "status": "incomplete",
+    "owner": "Platform Engineering",
+    "target_sprint": "Sprint-24",
+    "evidence_link": "docs/release-readiness-checklist.md",
+    "gate": "dependency_vulnerability"
+  },
+  {
+    "section": 13,
+    "requirement": "API contract governance",
+    "priority": 2,
+    "status": "incomplete",
+    "owner": "Backend Platform",
+    "target_sprint": "Sprint-24",
+    "evidence_link": "contracts/schemas/README.md",
+    "gate": "api_contract_governance"
+  },
+  {
+    "section": 14,
+    "requirement": "Infrastructure as code conformance",
+    "priority": 2,
+    "status": "incomplete",
+    "owner": "Infrastructure Engineering",
+    "target_sprint": "Sprint-26",
+    "evidence_link": "infra/production/backend-deployment.yaml",
+    "gate": "iac_conformance"
+  },
+  {
+    "section": 15,
+    "requirement": "Access lifecycle management",
+    "priority": 2,
+    "status": "incomplete",
+    "owner": "IT Security",
+    "target_sprint": "Sprint-26",
+    "evidence_link": "docs/jwt-key-rotation-runbook.md",
+    "gate": "access_lifecycle"
+  },
+  {
+    "section": 16,
+    "requirement": "Data retention and legal hold",
+    "priority": 2,
+    "status": "incomplete",
+    "owner": "Compliance",
+    "target_sprint": "Sprint-27",
+    "evidence_link": "docs/reliability-and-incident-response-runbook.md",
+    "gate": "retention_legal_hold"
+  },
+  {
+    "section": 17,
+    "requirement": "Incident response readiness",
+    "priority": 2,
+    "status": "incomplete",
+    "owner": "SRE",
+    "target_sprint": "Sprint-24",
+    "evidence_link": "docs/reliability-and-incident-response-runbook.md",
+    "gate": "incident_response"
+  },
+  {
+    "section": 18,
+    "requirement": "Business continuity and disaster recovery",
+    "priority": 2,
+    "status": "incomplete",
+    "owner": "SRE",
+    "target_sprint": "Sprint-26",
+    "evidence_link": "docs/reliability-and-incident-response-runbook.md",
+    "gate": "business_continuity_dr"
+  },
+  {
+    "section": 19,
+    "requirement": "Performance and capacity engineering",
+    "priority": 2,
+    "status": "incomplete",
+    "owner": "Platform Engineering",
+    "target_sprint": "Sprint-27",
+    "evidence_link": "docs/driver-protocol-test-matrix.md",
+    "gate": "performance_capacity"
+  },
+  {
+    "section": 20,
+    "requirement": "Privacy and compliance evidence",
+    "priority": 2,
+    "status": "incomplete",
+    "owner": "Compliance",
+    "target_sprint": "Sprint-27",
+    "evidence_link": "docs/release-readiness-checklist.md",
+    "gate": "privacy_compliance"
+  },
+  {
+    "section": 21,
+    "requirement": "Change management and post-release verification",
+    "priority": 2,
+    "status": "incomplete",
+    "owner": "Release Management",
+    "target_sprint": "Sprint-24",
+    "evidence_link": "docs/release-readiness-checklist.md",
+    "gate": "change_management"
+  }
+]

--- a/docs/production-hardening/program-plan.md
+++ b/docs/production-hardening/program-plan.md
@@ -1,0 +1,69 @@
+# Production Hardening Program Plan
+
+This plan converts the six product goals into measurable checkpoints, clear owners, and release evidence.
+
+## Six product goals mapped to checkpoints and owners
+
+| Goal ID | Product goal | Measurable checkpoints | Owner | Cadence / target |
+| --- | --- | --- | --- | --- |
+| G1 | Protect tenant data and access boundaries | 1) 100% of production API routes enforce org-scoped authorization. 2) Monthly cross-tenant access regression suite passes with 0 critical defects. 3) SSO/JWT key rotation drill completed quarterly. | Security Engineering (DRI) + Backend Lead | Complete by Sprint 24; maintain monthly/quarterly |
+| G2 | Establish complete, queryable audit trail for critical actions | 1) Critical domain events (auth, incident mutations, export generation, admin changes) have audit coverage >= 99%. 2) Audit events searchable in central sink within 5 minutes. 3) Tamper-evidence validation run monthly. | Platform/Backend + Compliance | Complete by Sprint 24; then monthly |
+| G3 | Operate with production-grade observability and SLO guardrails | 1) Golden signals dashboard published for API, worker, DB, queue, and OTP provider. 2) P1 alerts mapped to pager routes and tested in game day. 3) Error-budget policy documented and used in release decisions. | SRE Lead | Complete by Sprint 25; then per release |
+| G4 | Guarantee recoverability of transactional and evidence data | 1) Backups enabled for Postgres, Redis, and object storage with policy compliance at 100%. 2) Point-in-time restore drill passes RPO<=15m, RTO<=60m. 3) Quarterly disaster recovery test documented. | SRE + Data Engineering | Complete by Sprint 25; quarterly drills |
+| G5 | Enforce safe, repeatable production release flow | 1) Production tag promotion gated on required checks. 2) Rollback artifact and runbook verified before each release. 3) Change approval recorded for 100% of production tags. | Release Manager + Engineering Manager | Complete by Sprint 24; enforce every release |
+| G6 | Reduce incident handling risk through operational readiness | 1) On-call roster and escalation policy current each sprint. 2) Incident runbooks reviewed quarterly. 3) MTTA and sev-1 comms SLA tracked and met in >= 95% incidents. | Incident Commander Rotation Owner | Complete by Sprint 26; track each sprint |
+
+## Hardening requirement catalog (Sections 5-21)
+
+> Each section below is represented by exactly one machine-readable checklist entry in `checklist.yaml`.
+
+### 5) Identity and authorization gate (Priority-1)
+- Enforce strong authentication, role-based authorization, and tenant isolation controls for all production endpoints.
+
+### 6) Audit logging gate (Priority-1)
+- Emit immutable audit events for all critical actor and system actions with correlation IDs.
+
+### 7) Observability gate (Priority-1)
+- Provide logs, metrics, traces, dashboards, and actionable paging alerts for core journeys.
+
+### 8) Backup and restore gate (Priority-1)
+- Enforce backup policy and prove restores meet defined RPO/RTO targets.
+
+### 9) Release flow gate (Priority-1)
+- Require policy-driven CI/CD checks, approvals, and rollback readiness before production tags.
+
+### 10) Secrets management
+- Store and rotate secrets using managed secret providers with documented rotation cadence.
+
+### 11) Data encryption
+- Encrypt data in transit and at rest, including evidence artifacts and backups.
+
+### 12) Dependency and vulnerability management
+- Scan dependencies/images and block release on unresolved high-severity issues.
+
+### 13) API contract governance
+- Version and validate runtime contracts with backward-compatibility policy.
+
+### 14) Infrastructure as code conformance
+- Provision production infrastructure via reviewed, reproducible IaC with drift detection.
+
+### 15) Access lifecycle management
+- Enforce least-privilege access, periodic entitlement reviews, and rapid offboarding.
+
+### 16) Data retention and legal hold
+- Apply retention schedules, deletion workflows, and legal hold overrides.
+
+### 17) Incident response readiness
+- Maintain and test incident command, communications, and severity playbooks.
+
+### 18) Business continuity and disaster recovery
+- Validate region/provider contingency plans and recovery runbooks.
+
+### 19) Performance and capacity engineering
+- Define capacity thresholds, load-test critical paths, and maintain scaling plans.
+
+### 20) Privacy and compliance evidence
+- Track compliance controls with auditable evidence mapped to control owners.
+
+### 21) Change management and post-release verification
+- Require post-release checks, rollback validation, and lessons-learned closure.

--- a/scripts/check_release_hardening_gates.py
+++ b/scripts/check_release_hardening_gates.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Fail CI for production release tags when Priority-1 hardening gates are incomplete."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+PRIORITY_1_GATES = {
+    "identity_authz",
+    "audit_logging",
+    "observability",
+    "backups",
+    "release_flow",
+}
+COMPLETE_STATUSES = {"complete", "completed", "done", "verified"}
+PRODUCTION_TAG_PATTERN = r"(?i)(^prod[-_/]|^production[-_/]|[-_/]prod[-_/]|[-_/]production[-_/]|^v\d+\.\d+\.\d+-prod$)"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--checklist",
+        default="docs/production-hardening/checklist.yaml",
+        help="Path to the hardening checklist file (JSON-compatible YAML).",
+    )
+    parser.add_argument(
+        "--tag",
+        default="",
+        help="Release tag to evaluate. Defaults to CI env (GITHUB_REF_NAME/CI_COMMIT_TAG).",
+    )
+    return parser.parse_args()
+
+
+def detect_tag(explicit_tag: str) -> str:
+    if explicit_tag:
+        return explicit_tag
+
+    for var in ("GITHUB_REF_NAME", "CI_COMMIT_TAG", "GIT_TAG"):
+        value = os.getenv(var, "").strip()
+        if value:
+            return value
+
+    github_ref = os.getenv("GITHUB_REF", "")
+    prefix = "refs/tags/"
+    if github_ref.startswith(prefix):
+        return github_ref[len(prefix) :]
+
+    return ""
+
+
+def is_production_tag(tag: str) -> bool:
+    return bool(tag) and re.search(PRODUCTION_TAG_PATTERN, tag) is not None
+
+
+def load_checklist(path: Path) -> list[dict[str, Any]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SystemExit(f"Checklist file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Checklist must be JSON-compatible YAML: {exc}") from exc
+
+    if not isinstance(data, list):
+        raise SystemExit("Checklist root must be a list of requirement entries.")
+
+    for index, entry in enumerate(data, start=1):
+        if not isinstance(entry, dict):
+            raise SystemExit(f"Checklist entry #{index} is not an object.")
+
+    return data
+
+
+def find_incomplete_priority_1(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    failures: list[dict[str, Any]] = []
+    for entry in entries:
+        gate = str(entry.get("gate", "")).strip()
+        priority = int(entry.get("priority", 0))
+        status = str(entry.get("status", "")).strip().lower()
+        if priority == 1 and gate in PRIORITY_1_GATES and status not in COMPLETE_STATUSES:
+            failures.append(entry)
+    return failures
+
+
+def main() -> int:
+    args = parse_args()
+    tag = detect_tag(args.tag)
+
+    if not is_production_tag(tag):
+        print(f"Skipping hardening gate enforcement for non-production tag: {tag or '<none>'}")
+        return 0
+
+    checklist_path = Path(args.checklist)
+    entries = load_checklist(checklist_path)
+    failures = find_incomplete_priority_1(entries)
+
+    if not failures:
+        print(f"All Priority-1 gates are complete for production tag '{tag}'.")
+        return 0
+
+    print(f"Production tag '{tag}' blocked: incomplete Priority-1 gates detected:")
+    for entry in failures:
+        print(
+            " - section {section} [{gate}] status={status} owner={owner} target={target}".format(
+                section=entry.get("section", "?"),
+                gate=entry.get("gate", "unknown"),
+                status=entry.get("status", "unknown"),
+                owner=entry.get("owner", "unknown"),
+                target=entry.get("target_sprint", "unknown"),
+            )
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation

- Provide a clear, owner-assigned program that maps the six product goals to measurable checkpoints and target cadence so hardening work can be tracked and signed off. 
- Make the hardening requirements machine-readable so CI/automation can evaluate release readiness for sections 5–21. 
- Prevent accidental production promotions by failing CI for production tags when any Priority-1 gate (identity/authz, audit logging, observability, backups, release flow) remains incomplete.

### Description

- Add `docs/production-hardening/program-plan.md` which maps the six product goals to measurable checkpoints, owners, and target cadence/sprints. 
- Add `docs/production-hardening/checklist.yaml` as a JSON-compatible YAML tracker with one entry per requirement (sections 5–21) including `status`, `owner`, `target_sprint`, `evidence_link`, `priority`, and `gate`. 
- Add `scripts/check_release_hardening_gates.py` which detects production-like tags, loads the checklist, and fails (non-zero) if any Priority-1 gate (`identity_authz`, `audit_logging`, `observability`, `backups`, `release_flow`) is not marked complete. 
- Add a `Makefile` target `check-prod-hardening-gates` to run the gate check from CI workflows.

### Testing

- Ran `python scripts/check_release_hardening_gates.py --tag dev-2026-04-07` which skipped enforcement for a non-production tag and exited 0. 
- Ran `python scripts/check_release_hardening_gates.py --tag prod-2026.04.07` which printed the incomplete Priority-1 gates and exited non-zero as expected while gates are incomplete. 
- Ran `ruff check scripts/check_release_hardening_gates.py` which passed linting for the new script. 
- Ran `make lint` (repo lint target) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4d47862c4832180a4abc2739d67d2)