### PR TITLE
Centralize authorization policy checks for protected backend routes

### DIFF
--- a/backend/app/api/routes_admin.py
+++ b/backend/app/api/routes_admin.py
@@ -19,11 +19,10 @@ from app.api.schemas import (
     RotateQrResponse,
 )
 from app.core.config import settings
-from app.core.deps import (
-    get_current_user_org_ids,
-    require_capabilities,
-)
+from app.core.deps import get_current_user
 from app.security.permissions import Capability
+from app.security.authn import build_user_auth_context
+from app.security.authz import can_access_admin_org, require_policy
 from app.db.models import (
     DriverInstructionSet,
     DriverInstructionStep as DriverInstructionStepModel,
@@ -142,10 +141,11 @@ def _serialize_instruction_steps(
 )
 def get_driver_protocol_settings(
     db: Session = Depends(get_db),
-    admin_org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
-    admin: User = Depends(require_capabilities(Capability.DRIVER_PROTOCOL_READ)),
+    admin: User = Depends(get_current_user),
 ):
-    org = _get_admin_org(db, admin_org_ids[0])
+    context = build_user_auth_context(db, admin)
+    require_policy(can_access_admin_org(context, context.org_ids[0], Capability.DRIVER_PROTOCOL_WRITE))
+    org = _get_admin_org(db, context.org_ids[0])
     return DriverProtocolSettingsResponse(
         instruction_source=org.instruction_source,
         require_ack=org.require_driver_ack,
@@ -162,10 +162,11 @@ def get_driver_protocol_settings(
 def update_driver_protocol_settings(
     body: DriverProtocolSettingsRequest,
     db: Session = Depends(get_db),
-    admin_org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
-    admin: User = Depends(require_capabilities(Capability.DRIVER_PROTOCOL_WRITE)),
+    admin: User = Depends(get_current_user),
 ):
-    org = _get_admin_org(db, admin_org_ids[0])
+    context = build_user_auth_context(db, admin)
+    require_policy(can_access_admin_org(context, context.org_ids[0], Capability.DRIVER_PROTOCOL_WRITE))
+    org = _get_admin_org(db, context.org_ids[0])
     org.instruction_source = _normalize_instruction_scope(body.instruction_source)
     org.require_driver_ack = body.require_ack
     org.sms_enabled = body.sms_enabled
@@ -188,10 +189,11 @@ def update_driver_protocol_settings(
 def get_driver_protocol_instructions(
     scope: str | None = None,
     db: Session = Depends(get_db),
-    admin_org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
-    admin: User = Depends(require_capabilities(Capability.DRIVER_PROTOCOL_READ)),
+    admin: User = Depends(get_current_user),
 ):
-    org = _get_admin_org(db, admin_org_ids[0])
+    context = build_user_auth_context(db, admin)
+    require_policy(can_access_admin_org(context, context.org_ids[0], Capability.DRIVER_PROTOCOL_READ))
+    org = _get_admin_org(db, context.org_ids[0])
     resolved_scope = _normalize_instruction_scope(scope or org.instruction_source)
     instruction_set = _get_or_create_instruction_set(db, org.id, resolved_scope)
     steps = (
@@ -220,10 +222,11 @@ def get_driver_protocol_instructions(
 def update_driver_protocol_instructions(
     body: DriverInstructionSetRequest,
     db: Session = Depends(get_db),
-    admin_org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
-    admin: User = Depends(require_capabilities(Capability.DRIVER_PROTOCOL_WRITE)),
+    admin: User = Depends(get_current_user),
 ):
-    org = _get_admin_org(db, admin_org_ids[0])
+    context = build_user_auth_context(db, admin)
+    require_policy(can_access_admin_org(context, context.org_ids[0], Capability.DRIVER_PROTOCOL_WRITE))
+    org = _get_admin_org(db, context.org_ids[0])
     resolved_scope = _normalize_instruction_scope(body.scope)
     instruction_set = _get_or_create_instruction_set(db, org.id, resolved_scope)
     db.query(DriverInstructionStepModel).filter(
@@ -256,10 +259,11 @@ def update_driver_protocol_instructions(
 def reset_driver_protocol_instructions(
     scope: str | None = None,
     db: Session = Depends(get_db),
-    admin_org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
-    admin: User = Depends(require_capabilities(Capability.DRIVER_PROTOCOL_WRITE)),
+    admin: User = Depends(get_current_user),
 ):
-    org = _get_admin_org(db, admin_org_ids[0])
+    context = build_user_auth_context(db, admin)
+    require_policy(can_access_admin_org(context, context.org_ids[0], Capability.DRIVER_PROTOCOL_WRITE))
+    org = _get_admin_org(db, context.org_ids[0])
     resolved_scope = _normalize_instruction_scope(scope or org.instruction_source)
     instruction_set = _get_or_create_instruction_set(db, org.id, resolved_scope)
     db.query(DriverInstructionStepModel).filter(
@@ -277,8 +281,11 @@ def reset_driver_protocol_instructions(
 
 @router.get("/vehicles", response_model=list[AdminVehicleSummary])
 def list_admin_vehicles(
-    admin: User = Depends(require_capabilities(Capability.VEHICLE_QR_READ)),
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_user),
 ):
+    context = build_user_auth_context(db, admin)
+    require_policy(can_access_admin_org(context, context.org_ids[0], Capability.VEHICLE_QR_READ))
     return [AdminVehicleSummary(**vehicle) for vehicle in ADMIN_VEHICLES]
 
 
@@ -290,17 +297,19 @@ def list_admin_vehicles(
 def rotate_qr(
     vehicle_id: str,
     db: Session = Depends(get_db),
-    admin_org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
-    admin: User = Depends(require_capabilities(Capability.VEHICLE_QR_WRITE)),
+    admin: User = Depends(get_current_user),
 ):
     """Revoke the current active QR token for a vehicle and issue a new one."""
+    context = build_user_auth_context(db, admin)
+    require_policy(can_access_admin_org(context, context.org_ids[0], Capability.VEHICLE_QR_WRITE))
+
     # Revoke existing active token(s)
     active_tokens = (
         db.query(VehicleQrToken)
         .filter(
             VehicleQrToken.adc_vehicle_id == vehicle_id,
             VehicleQrToken.status == "active",
-            VehicleQrToken.org_id.in_(admin_org_ids),
+            VehicleQrToken.org_id.in_(context.org_ids),
         )
         .all()
     )
@@ -311,7 +320,7 @@ def rotate_qr(
     new_token = secrets.token_urlsafe(32)
 
     # Determine org_id from the admin's org membership
-    org_id = admin_org_ids[0]
+    org_id = context.org_ids[0]
 
     qr = VehicleQrToken(
         qr_token=new_token,
@@ -350,9 +359,12 @@ def rotate_qr(
 @router.get("/vehicles/{vehicle_id}/qr", response_model=QrPayloadResponse)
 def get_qr_payload(
     vehicle_id: str,
-    admin: User = Depends(require_capabilities(Capability.VEHICLE_QR_READ)),
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_user),
 ):
     """Return the deep link string for QR code generation."""
+    context = build_user_auth_context(db, admin)
+    require_policy(can_access_admin_org(context, context.org_ids[0], Capability.VEHICLE_QR_READ))
     scheme = settings.DRIVER_APP_DEEPLINK_SCHEME
     deep_link = f"{scheme}://vehicle/{vehicle_id}"
     return QrPayloadResponse(deep_link=deep_link)

--- a/backend/app/api/routes_driver.py
+++ b/backend/app/api/routes_driver.py
@@ -51,6 +51,8 @@ from app.services.incident_workflow_service import (
     incident_status_summary,
     initiate_driver_incident,
 )
+from app.security.authn import build_driver_auth_context
+from app.security.authz import can_access_driver_incident, require_policy
 from app.tasks.evidence_tasks import capture_dashcam, capture_telematics_bundle
 from app.tasks.notification_tasks import notify_safety_manager
 
@@ -410,6 +412,7 @@ def _get_driver_incident(
     incident_id: uuid.UUID,
     driver: Driver,
 ) -> Incident:
+    context = build_driver_auth_context(driver)
     incident = (
         db.query(Incident)
         .filter(
@@ -421,6 +424,7 @@ def _get_driver_incident(
     )
     if incident is None:
         raise HTTPException(status_code=404, detail="Incident not found")
+    require_policy(can_access_driver_incident(context, incident))
     return incident
 
 

--- a/backend/app/api/routes_exports.py
+++ b/backend/app/api/routes_exports.py
@@ -18,11 +18,7 @@ from app.api.schemas import (
     ExportSummary,
     RetryExportRequest,
 )
-from app.core.deps import (
-    enforce_resource_org_ownership,
-    get_current_user_org_ids,
-    require_capabilities,
-)
+from app.core.deps import get_current_user
 from app.core.logging import set_log_context
 from app.core.metrics import MetricNames, increment, timed
 from app.db.models import User
@@ -37,12 +33,12 @@ from app.db.repo.exports import (
 from app.db.repo.artifacts import get_artifacts_by_incident
 from app.db.repo.events import create_event, get_events_by_incident
 from app.db.repo.incidents import get_incident
-from app.db.repo.users import get_user_org_ids
 from app.domain.system_event_types import SystemEventType
 from app.core.config import settings
 from app.tasks.export_tasks import build_export
 from app.domain.packet_profiles import get_default_packet_profile
-from app.security.permissions import Capability
+from app.security.authn import UserAuthContext, build_user_auth_context
+from app.security.authz import can_download_export, can_request_export, require_policy
 from app.services.vault_s3 import (
     S3PresignConfigurationError,
     S3PresignGenerationError,
@@ -59,17 +55,16 @@ STABLE_EXPORT_CONTENT_KINDS: tuple[str, ...] = ("summary_pdf", "raw_telemetry", 
 def create_export_endpoint(
     body: CreateExportRequest,
     db: Session = Depends(get_db),
-    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
-    current_user: User = Depends(require_capabilities(Capability.EXPORT_WRITE)),
+    current_user: User = Depends(get_current_user),
 ):
     increment(MetricNames.EXPORT_REQUEST_ATTEMPTS)
 
-    org_ids = get_user_org_ids(db, current_user.id)
+    context = build_user_auth_context(db, current_user)
     incident = get_incident(db, body.incident_id)
     if incident is None:
         increment(MetricNames.EXPORT_REQUEST_FAILURES)
         raise HTTPException(status_code=404, detail="Incident not found")
-    enforce_resource_org_ownership(incident.org_id, org_ids)
+    require_policy(can_request_export(context, incident))
 
     set_log_context(
         user_id=str(current_user.id),
@@ -150,11 +145,10 @@ def retry_export_endpoint(
     export_id: uuid.UUID,
     body: RetryExportRequest,
     db: Session = Depends(get_db),
-    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
-    current_user: User = Depends(require_capabilities(Capability.EXPORT_WRITE)),
+    current_user: User = Depends(get_current_user),
 ):
-    org_ids = get_user_org_ids(db, current_user.id)
-    failed_export = _resolve_authorized_export(db, export_id, org_ids)
+    context = build_user_auth_context(db, current_user)
+    failed_export = _resolve_authorized_export(db, export_id, list(context.org_ids), context=context)
     if failed_export.status != "failed":
         raise HTTPException(status_code=409, detail="Only failed exports can be retried")
 
@@ -282,13 +276,16 @@ def _resolve_authorized_export(
     db: Session,
     export_id: uuid.UUID,
     org_ids: list[uuid.UUID],
+    context: UserAuthContext | None = None,
 ):
     export = get_export(db, export_id)
     if not export:
         raise HTTPException(status_code=404, detail="Export not found")
 
     export_org_id = _get_export_owner_org_id(db, export)
-    if export_org_id is None or export_org_id not in org_ids:
+    if context is not None:
+        require_policy(can_download_export(context, export, export_org_id=export_org_id))
+    elif export_org_id is None or export_org_id not in org_ids:
         raise HTTPException(status_code=403, detail="Forbidden")
     return export
 
@@ -435,10 +432,10 @@ def _build_contents_manifest(db: Session, export) -> list[dict]:
 @router.get("/", response_model=list[ExportSummary])
 def list_exports_endpoint(
     db: Session = Depends(get_db),
-    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
-    current_user: User = Depends(require_capabilities(Capability.EXPORT_READ)),
+    current_user: User = Depends(get_current_user),
 ):
-    org_ids = get_user_org_ids(db, current_user.id)
+    context = build_user_auth_context(db, current_user)
+    org_ids = list(context.org_ids)
     set_log_context(
         user_id=str(current_user.id), org_id=str(org_ids[0]) if org_ids else None
     )
@@ -450,15 +447,15 @@ def list_exports_endpoint(
 def get_export_endpoint(
     export_id: uuid.UUID,
     db: Session = Depends(get_db),
-    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
-    current_user: User = Depends(require_capabilities(Capability.EXPORT_READ)),
+    current_user: User = Depends(get_current_user),
 ):
-    org_ids = get_user_org_ids(db, current_user.id)
+    context = build_user_auth_context(db, current_user)
+    org_ids = list(context.org_ids)
     set_log_context(
         user_id=str(current_user.id), org_id=str(org_ids[0]) if org_ids else None
     )
     try:
-        export = _resolve_authorized_export(db, export_id, org_ids)
+        export = _resolve_authorized_export(db, export_id, org_ids, context=context)
     except HTTPException:
         increment(MetricNames.EXPORT_DOWNLOAD_FAILURES)
         raise
@@ -470,11 +467,11 @@ def get_export_endpoint(
 def get_export_status_endpoint(
     export_id: uuid.UUID,
     db: Session = Depends(get_db),
-    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
-    current_user: User = Depends(require_capabilities(Capability.EXPORT_READ)),
+    current_user: User = Depends(get_current_user),
 ):
-    org_ids = get_user_org_ids(db, current_user.id)
-    export = _resolve_authorized_export(db, export_id, org_ids)
+    context = build_user_auth_context(db, current_user)
+    org_ids = list(context.org_ids)
+    export = _resolve_authorized_export(db, export_id, org_ids, context=context)
     return ExportStatusResponse(
         status=export.status,
         progress_stage=export.progress_stage,
@@ -486,11 +483,11 @@ def get_export_status_endpoint(
 def get_export_contents_endpoint(
     export_id: uuid.UUID,
     db: Session = Depends(get_db),
-    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
-    current_user: User = Depends(require_capabilities(Capability.EXPORT_READ)),
+    current_user: User = Depends(get_current_user),
 ):
-    org_ids = get_user_org_ids(db, current_user.id)
-    export = _resolve_authorized_export(db, export_id, org_ids)
+    context = build_user_auth_context(db, current_user)
+    org_ids = list(context.org_ids)
+    export = _resolve_authorized_export(db, export_id, org_ids, context=context)
     manifest = _build_contents_manifest(db, export)
     options = export.options_json or {}
     missing_items = options.get("missing_items") if isinstance(options, dict) else []
@@ -509,12 +506,12 @@ def get_export_contents_endpoint(
 def download_export_endpoint(
     export_id: uuid.UUID,
     db: Session = Depends(get_db),
-    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
-    current_user: User = Depends(require_capabilities(Capability.EXPORT_READ)),
+    current_user: User = Depends(get_current_user),
 ):
     increment(MetricNames.EXPORT_DOWNLOAD_ATTEMPTS)
+    context = build_user_auth_context(db, current_user)
+    org_ids = list(context.org_ids)
     with timed(MetricNames.EXPORT_DOWNLOAD_ATTEMPTS):
-        org_ids = get_user_org_ids(db, current_user.id)
         set_log_context(
             user_id=str(current_user.id), org_id=str(org_ids[0]) if org_ids else None
         )
@@ -524,7 +521,7 @@ def download_export_endpoint(
         raise HTTPException(status_code=404, detail="Export not found")
 
     export_org_id = _get_export_owner_org_id(db, export)
-    if export_org_id is None or export_org_id not in org_ids:
+    if not can_download_export(context, export, export_org_id=export_org_id):
         increment(MetricNames.EXPORT_DOWNLOAD_FAILURES)
         raise HTTPException(status_code=403, detail="Forbidden")
 
@@ -592,11 +589,11 @@ def download_export_endpoint(
 def get_export_downloads_endpoint(
     export_id: uuid.UUID,
     db: Session = Depends(get_db),
-    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
-    current_user: User = Depends(require_capabilities(Capability.EXPORT_READ)),
+    current_user: User = Depends(get_current_user),
 ):
-    org_ids = get_user_org_ids(db, current_user.id)
-    export = _resolve_authorized_export(db, export_id, org_ids)
+    context = build_user_auth_context(db, current_user)
+    org_ids = list(context.org_ids)
+    export = _resolve_authorized_export(db, export_id, org_ids, context=context)
     events = get_events_by_incident(db, export.incident_id)
     download_events = [
         event

--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -16,12 +16,7 @@ from app.api.schemas import (
     IncidentDetailResponse,
     IncidentListItem,
 )
-from app.core.deps import (
-    enforce_resource_org_ownership,
-    get_current_user,
-    get_current_user_org_ids,
-    get_current_user_primary_org_id,
-)
+from app.core.deps import get_current_user
 from app.core.logging import get_request_id, set_log_context
 from app.core.metrics import MetricNames, increment, timed
 from app.db.models import User
@@ -29,12 +24,18 @@ from app.db.repo.artifacts import get_artifacts_by_incident
 from app.db.repo.events import create_event, get_events_by_incident
 from app.db.repo.exports import create_export, get_exports_by_incident
 from app.db.repo.incidents import create_incident, get_incident, list_incidents
-from app.db.repo.users import get_user_org_ids
 from app.db.session import get_db
 from app.domain.system_event_types import SystemEventType
 from app.domain.packet_profiles import get_default_packet_profile
 from app.tasks.evidence_tasks import capture_dashcam, capture_telematics_bundle
 from app.tasks.export_tasks import build_export
+from app.security.authn import build_user_auth_context
+from app.security.authz import (
+    can_create_incident,
+    can_request_export,
+    can_view_incident,
+    require_policy,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -44,10 +45,10 @@ router = APIRouter()
 @router.get("/", response_model=list[IncidentListItem])
 def list_incidents_endpoint(
     db: Session = Depends(get_db),
-    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
     current_user: User = Depends(get_current_user),
 ):
-    org_ids = get_user_org_ids(db, current_user.id)
+    context = build_user_auth_context(db, current_user)
+    org_ids = list(context.org_ids)
     set_log_context(
         user_id=str(current_user.id), org_id=str(org_ids[0]) if org_ids else None
     )
@@ -78,14 +79,14 @@ def list_incidents_endpoint(
 def create_incident_endpoint(
     body: CreateIncidentRequest,
     db: Session = Depends(get_db),
-    org_id: uuid.UUID = Depends(get_current_user_primary_org_id),
     current_user: User = Depends(get_current_user),
 ):
     increment(MetricNames.INCIDENT_CREATE_ATTEMPTS)
 
     with timed(MetricNames.INCIDENT_CREATE_ATTEMPTS):
-        org_ids = get_user_org_ids(db, current_user.id)
-        org_id = org_ids[0] if org_ids else None
+        context = build_user_auth_context(db, current_user)
+        require_policy(can_create_incident(context))
+        org_id = context.org_ids[0]
         set_log_context(
             user_id=str(current_user.id), org_id=str(org_id) if org_id else None
         )
@@ -142,10 +143,10 @@ def create_incident_endpoint(
 def get_incident_endpoint(
     incident_id: uuid.UUID,
     db: Session = Depends(get_db),
-    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
     current_user: User = Depends(get_current_user),
 ):
-    org_ids = get_user_org_ids(db, current_user.id)
+    context = build_user_auth_context(db, current_user)
+    org_ids = list(context.org_ids)
     set_log_context(
         user_id=str(current_user.id), org_id=str(org_ids[0]) if org_ids else None
     )
@@ -153,7 +154,7 @@ def get_incident_endpoint(
     incident = get_incident(db, incident_id, org_ids=org_ids)
     if not incident:
         raise HTTPException(status_code=404, detail="Incident not found")
-    enforce_resource_org_ownership(incident.org_id, org_ids)
+    require_policy(can_view_incident(context, incident))
 
     artifacts = get_artifacts_by_incident(db, incident_id)
     exports = get_exports_by_incident(db, incident_id)
@@ -233,17 +234,17 @@ def get_incident_endpoint(
 def request_export_endpoint(
     incident_id: uuid.UUID,
     db: Session = Depends(get_db),
-    org_ids: list[uuid.UUID] = Depends(get_current_user_org_ids),
     current_user: User = Depends(get_current_user),
 ):
     increment(MetricNames.EXPORT_REQUEST_ATTEMPTS)
 
-    org_ids = get_user_org_ids(db, current_user.id)
+    context = build_user_auth_context(db, current_user)
+    org_ids = list(context.org_ids)
     incident = get_incident(db, incident_id, org_ids=org_ids)
     if not incident:
         increment(MetricNames.EXPORT_REQUEST_FAILURES)
         raise HTTPException(status_code=404, detail="Incident not found")
-    enforce_resource_org_ownership(incident.org_id, org_ids)
+    require_policy(can_request_export(context, incident))
 
     set_log_context(
         user_id=str(current_user.id),

--- a/backend/app/security/authn.py
+++ b/backend/app/security/authn.py
@@ -1,0 +1,49 @@
+"""Authentication context helpers backed by persisted DB relationships."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db.models import Driver, User
+from app.db.repo.users import get_user_org_ids
+
+
+@dataclass(frozen=True)
+class UserAuthContext:
+    """Authenticated web user context."""
+
+    user: User
+    org_ids: tuple[uuid.UUID, ...]
+
+
+@dataclass(frozen=True)
+class DriverAuthContext:
+    """Authenticated driver context."""
+
+    driver: Driver
+    org_id: uuid.UUID
+
+
+def build_user_auth_context(db: Session, user: User) -> UserAuthContext:
+    """Resolve org memberships from DB for an authenticated user."""
+    org_ids = tuple(get_user_org_ids(db, user.id))
+    if not org_ids:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Organization membership required",
+        )
+    return UserAuthContext(user=user, org_ids=org_ids)
+
+
+def build_driver_auth_context(driver: Driver) -> DriverAuthContext:
+    """Resolve driver org context from persisted driver row."""
+    if driver.org_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Organization membership required",
+        )
+    return DriverAuthContext(driver=driver, org_id=driver.org_id)

--- a/backend/app/security/authz.py
+++ b/backend/app/security/authz.py
@@ -1,0 +1,71 @@
+"""Centralized authorization policy checks."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import HTTPException, status
+
+from app.db.models import Export, Incident
+from app.security.authn import DriverAuthContext, UserAuthContext
+from app.security.permissions import Capability, has_capability
+
+
+FORBIDDEN = HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
+
+def _belongs_to_member_org(resource_org_id: uuid.UUID | None, member_org_ids: tuple[uuid.UUID, ...]) -> bool:
+    return resource_org_id is not None and resource_org_id in member_org_ids
+
+
+def can_create_incident(context: UserAuthContext) -> bool:
+    return has_capability(context.user.role, Capability.INCIDENT_WRITE) and bool(context.org_ids)
+
+
+def can_view_incident(context: UserAuthContext, incident: Incident | None) -> bool:
+    return (
+        incident is not None
+        and has_capability(context.user.role, Capability.INCIDENT_READ)
+        and _belongs_to_member_org(incident.org_id, context.org_ids)
+    )
+
+
+def can_modify_incident(context: UserAuthContext, incident: Incident | None) -> bool:
+    return (
+        incident is not None
+        and has_capability(context.user.role, Capability.INCIDENT_WRITE)
+        and _belongs_to_member_org(incident.org_id, context.org_ids)
+    )
+
+
+def can_request_export(context: UserAuthContext, incident: Incident | None) -> bool:
+    return (
+        incident is not None
+        and has_capability(context.user.role, Capability.EXPORT_WRITE)
+        and _belongs_to_member_org(incident.org_id, context.org_ids)
+    )
+
+
+def can_download_export(context: UserAuthContext, export: Export | None, *, export_org_id: uuid.UUID | None) -> bool:
+    return (
+        export is not None
+        and has_capability(context.user.role, Capability.EXPORT_READ)
+        and _belongs_to_member_org(export_org_id, context.org_ids)
+    )
+
+
+def can_access_admin_org(context: UserAuthContext, org_id: uuid.UUID | None, capability: Capability) -> bool:
+    return org_id is not None and has_capability(context.user.role, capability) and org_id in context.org_ids
+
+
+def can_access_driver_incident(context: DriverAuthContext, incident: Incident | None) -> bool:
+    return (
+        incident is not None
+        and incident.org_id == context.org_id
+        and incident.adc_driver_id == str(context.driver.driver_id)
+    )
+
+
+def require_policy(allowed: bool) -> None:
+    if not allowed:
+        raise FORBIDDEN

--- a/backend/app/security/permissions.py
+++ b/backend/app/security/permissions.py
@@ -59,3 +59,8 @@ def normalize_role(raw_role: str | None) -> Role:
 
 def get_user_capabilities(raw_role: str | None) -> frozenset[Capability]:
     return ROLE_CAPABILITIES[normalize_role(raw_role)]
+
+
+def has_capability(raw_role: str | None, capability: Capability | str) -> bool:
+    resolved = capability if isinstance(capability, Capability) else Capability(capability)
+    return resolved in get_user_capabilities(raw_role)

--- a/backend/tests/test_authorization_regressions.py
+++ b/backend/tests/test_authorization_regressions.py
@@ -1,0 +1,117 @@
+"""Authorization regression coverage for protected routes."""
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.security import create_access_token, hash_password
+from app.db.models import Base, Driver, Export, Incident, Org, User, UserOrg
+from app.db.session import get_db
+from app.main import app
+
+
+@pytest.fixture()
+def db_session():
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override
+    with TestClient(app) as tc:
+        yield tc
+    app.dependency_overrides.clear()
+
+
+def _user_headers(user_id: uuid.UUID, role: str) -> dict[str, str]:
+    token = create_access_token({"sub": str(user_id), "role": role})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _driver_headers(driver_id: uuid.UUID) -> dict[str, str]:
+    token = create_access_token({"sub": str(driver_id), "scope": "driver"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_incident_create_requires_org_membership(client, db_session):
+    user = User(email="no-org@ex.com", password_hash=hash_password("x"), role="safety_manager")
+    db_session.add(user)
+    db_session.commit()
+
+    response = client.post(
+        "/incidents/",
+        json={"severity": "minor", "adc_vehicle_id": "v1", "samsara_vehicle_id": "s1", "adc_driver_id": "d1"},
+        headers=_user_headers(user.id, user.role),
+    )
+    assert response.status_code == 403
+
+
+def test_export_download_checks_org_membership(client, db_session):
+    member_org = Org(name="Member")
+    foreign_org = Org(name="Foreign")
+    user = User(email="member@ex.com", password_hash=hash_password("x"), role="safety_manager")
+    db_session.add_all([member_org, foreign_org, user])
+    db_session.commit()
+    db_session.add(UserOrg(user_id=user.id, org_id=member_org.id))
+    incident = Incident(status="open", org_id=foreign_org.id)
+    db_session.add(incident)
+    db_session.commit()
+    export = Export(incident_id=incident.incident_id, org_id=foreign_org.id, status="ready", s3_bucket="b", s3_key="k")
+    db_session.add(export)
+    db_session.commit()
+
+    response = client.get(f"/exports/{export.export_id}/download", headers=_user_headers(user.id, user.role))
+    assert response.status_code == 403
+
+
+def test_admin_vehicle_list_requires_vehicle_qr_read_capability(client, db_session):
+    org = Org(name="Admin Org")
+    manager = User(email="manager@ex.com", password_hash=hash_password("x"), role="safety_manager")
+    admin = User(email="admin@ex.com", password_hash=hash_password("x"), role="admin")
+    db_session.add_all([org, manager, admin])
+    db_session.commit()
+    db_session.add_all([UserOrg(user_id=manager.id, org_id=org.id), UserOrg(user_id=admin.id, org_id=org.id)])
+    db_session.commit()
+
+    denied = client.get("/admin/vehicles", headers=_user_headers(manager.id, manager.role))
+    allowed = client.get("/admin/vehicles", headers=_user_headers(admin.id, admin.role))
+
+    assert denied.status_code == 403
+    assert allowed.status_code == 200
+
+
+def test_driver_status_requires_incident_ownership(client, db_session):
+    org = Org(name="Driver Org")
+    db_session.add(org)
+    db_session.commit()
+    owner = Driver(org_id=org.id, phone_e164="+15551000001", display_name="owner")
+    other = Driver(org_id=org.id, phone_e164="+15551000002", display_name="other")
+    db_session.add_all([owner, other])
+    db_session.commit()
+    incident = Incident(status="open", org_id=org.id, adc_driver_id=str(owner.driver_id))
+    db_session.add(incident)
+    db_session.commit()
+
+    denied = client.get(
+        f"/driver/incidents/{incident.incident_id}/status",
+        headers=_driver_headers(other.driver_id),
+    )
+    assert denied.status_code == 404


### PR DESCRIPTION
### Motivation
- Consolidate authorization logic to a small set of policy functions so every sensitive route consistently validates authenticated identity, role/capability, organization membership, and resource ownership/visibility using persisted DB relationships.
- Reduce duplicated per-route checks and make it straightforward to audit or extend authorization behavior across incidents, exports, admin, and driver endpoints.

### Description
- Added `backend/app/security/authn.py` with `build_user_auth_context` and `build_driver_auth_context` to resolve DB-backed org membership context for authenticated web users and drivers respectively.
- Added `backend/app/security/authz.py` with policy functions such as `can_view_incident`, `can_request_export`, `can_modify_incident`, `can_download_export`, `can_access_admin_org`, `can_access_driver_incident`, and `require_policy` to centralize enforcement.
- Extended `backend/app/security/permissions.py` with `has_capability` to unify capability checks used by the policy layer.
- Refactored protected routes to call the centralized policies: `backend/app/api/routes_incidents.py`, `backend/app/api/routes_exports.py`, `backend/app/api/routes_admin.py`, and `backend/app/api/routes_driver.py` now build auth contexts and call `require_policy(...)` with the appropriate `can_*` functions.
- Added `backend/tests/test_authorization_regressions.py` to assert org membership, capability gating, and resource ownership checks for the protected endpoints.

### Testing
- Ran the linter with `cd backend && ruff check app tests` and the run passed without errors.
- Ran the API test suite with `cd backend && pytest tests/test_api_endpoints.py tests/test_authorization_regressions.py -q`, and all tests passed (`60 passed, 3 warnings`).
- The new regression test module `backend/tests/test_authorization_regressions.py` executed and validated incident creation/org membership, export download org checks, admin vehicle capability gating, and driver incident ownership behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4dbbe85a48321846dc852a8bb6164)