### PR TITLE
Add CSRF checks for cookie auth and enforce production cookie invariants

### DIFF
--- a/backend/app/api/routes_auth.py
+++ b/backend/app/api/routes_auth.py
@@ -29,6 +29,7 @@ from app.db.repo.users import (
     link_user_org,
 )
 from app.db.session import get_db
+from app.security.csrf import CSRF_COOKIE_NAME, issue_csrf_token, validate_csrf_request
 from app.security.permissions import get_user_capabilities, normalize_role
 from app.security.session import create_session, revoke_session, rotate_refresh_token
 
@@ -72,20 +73,29 @@ def login(body: LoginRequest, request: Request, response: Response, db: Session 
             token_claims={"role": normalize_role(user.role).value},
         )
 
+    csrf_token = issue_csrf_token()
     response.set_cookie(
         key="access_token",
         value=access_token,
-        httponly=True,
+        httponly=settings.COOKIE_HTTPONLY,
         secure=settings.COOKIE_SECURE,
-        samesite="lax",
+        samesite=settings.cookie_samesite,
         max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
     )
     response.set_cookie(
         key="refresh_token",
         value=refresh_token,
-        httponly=True,
+        httponly=settings.COOKIE_HTTPONLY,
         secure=settings.COOKIE_SECURE,
-        samesite="lax",
+        samesite=settings.cookie_samesite,
+        max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 86400,
+    )
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        httponly=False,
+        secure=settings.COOKIE_SECURE,
+        samesite=settings.cookie_samesite,
         max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 86400,
     )
 
@@ -98,6 +108,7 @@ def login(body: LoginRequest, request: Request, response: Response, db: Session 
 
 @router.post("/refresh", response_model=RefreshResponse)
 def refresh(request: Request, response: Response, db: Session = Depends(get_db)):
+    validate_csrf_request(request)
     refresh_cookie = request.cookies.get("refresh_token")
     if not refresh_cookie:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Refresh token missing")
@@ -133,17 +144,17 @@ def refresh(request: Request, response: Response, db: Session = Depends(get_db))
     response.set_cookie(
         key="access_token",
         value=token,
-        httponly=True,
+        httponly=settings.COOKIE_HTTPONLY,
         secure=settings.COOKIE_SECURE,
-        samesite="lax",
+        samesite=settings.cookie_samesite,
         max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
     )
     response.set_cookie(
         key="refresh_token",
         value=next_refresh,
-        httponly=True,
+        httponly=settings.COOKIE_HTTPONLY,
         secure=settings.COOKIE_SECURE,
-        samesite="lax",
+        samesite=settings.cookie_samesite,
         max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 86400,
     )
     return RefreshResponse(access_token=token)
@@ -189,6 +200,8 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
 
 @router.post("/logout", response_model=LogoutResponse)
 def logout(response: Response, current_user: User = Depends(get_current_user), request: Request = None, db: Session = Depends(get_db)):
+    if request is not None:
+        validate_csrf_request(request)
     token = request.cookies.get("access_token") if request else None
     sid = None
     if token:
@@ -198,10 +211,13 @@ def logout(response: Response, current_user: User = Depends(get_current_user), r
         revoke_session(db, uuid.UUID(sid))
 
     response.delete_cookie(
-        key="access_token", httponly=True, secure=settings.COOKIE_SECURE, samesite="lax"
+        key="access_token", httponly=settings.COOKIE_HTTPONLY, secure=settings.COOKIE_SECURE, samesite=settings.cookie_samesite
     )
     response.delete_cookie(
-        key="refresh_token", httponly=True, secure=settings.COOKIE_SECURE, samesite="lax"
+        key="refresh_token", httponly=settings.COOKIE_HTTPONLY, secure=settings.COOKIE_SECURE, samesite=settings.cookie_samesite
+    )
+    response.delete_cookie(
+        key=CSRF_COOKIE_NAME, httponly=False, secure=settings.COOKIE_SECURE, samesite=settings.cookie_samesite
     )
     set_log_context(user_id=str(current_user.id))
     return LogoutResponse()

--- a/backend/app/config/__init__.py
+++ b/backend/app/config/__init__.py
@@ -1,0 +1,1 @@
+"""Application startup configuration validation package."""

--- a/backend/app/config/validation.py
+++ b/backend/app/config/validation.py
@@ -1,0 +1,26 @@
+"""Startup configuration validation helpers."""
+
+from __future__ import annotations
+
+from app.core.config import Settings
+
+
+def validate_startup_config(settings: Settings) -> None:
+    """Fail fast on unsafe production session/cookie configuration."""
+    settings.validate_production_invariants()
+
+    if not settings.is_prod:
+        return
+
+    errors: list[str] = []
+    if settings.cookie_samesite not in {"lax", "none"}:
+        errors.append("cookie SameSite policy must resolve to 'lax' or 'none'")
+
+    if settings.cookie_samesite == "none" and not settings.COOKIE_SECURE:
+        errors.append("SameSite=None cookies require COOKIE_SECURE=true")
+
+    if not settings.COOKIE_HTTPONLY:
+        errors.append("COOKIE_HTTPONLY must be true for production session cookies")
+
+    if errors:
+        raise ValueError(f"Invalid prod configuration: {'; '.join(errors)}")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -89,7 +89,9 @@ class Settings(BaseSettings):
 
     # CORS / Cookies
     FRONTEND_ORIGIN: str = "http://localhost:3000"
+    COOKIE_HTTPONLY: bool = True
     COOKIE_SECURE: bool = False
+    COOKIE_DEPLOYMENT_TOPOLOGY: str = "same_site"
 
     # Vault (filesystem)
     STORAGE_BACKEND: str = "s3"
@@ -139,6 +141,11 @@ class Settings(BaseSettings):
         )
 
     @property
+    def cookie_samesite(self) -> str:
+        """Return the SameSite policy implied by deployment topology."""
+        return "none" if self.COOKIE_DEPLOYMENT_TOPOLOGY == "cross_site" else "lax"
+
+    @property
     def is_prod(self) -> bool:
         return self.APP_ENV == "prod"
 
@@ -164,8 +171,14 @@ class Settings(BaseSettings):
             if normalized == insecure_defaults[key]:
                 errors.append(f"{key} cannot use development default in prod")
 
+        if not self.COOKIE_HTTPONLY:
+            errors.append("COOKIE_HTTPONLY must be true in prod")
+
         if not self.COOKIE_SECURE:
             errors.append("COOKIE_SECURE must be true in prod")
+
+        if self.COOKIE_DEPLOYMENT_TOPOLOGY == "cross_site" and not self.COOKIE_SECURE:
+            errors.append("cross_site cookies require COOKIE_SECURE=true")
 
         for key, value in (
             ("FRONTEND_ORIGIN", self.FRONTEND_ORIGIN),
@@ -196,6 +209,10 @@ class Settings(BaseSettings):
         self.SECRET_PROVIDER = self.SECRET_PROVIDER.strip().lower()
         if self.SECRET_PROVIDER not in {"env", "aws_secrets_manager"}:
             raise ValueError("SECRET_PROVIDER must be one of: env, aws_secrets_manager")
+
+        self.COOKIE_DEPLOYMENT_TOPOLOGY = self.COOKIE_DEPLOYMENT_TOPOLOGY.strip().lower()
+        if self.COOKIE_DEPLOYMENT_TOPOLOGY not in {"same_site", "cross_site"}:
+            raise ValueError("COOKIE_DEPLOYMENT_TOPOLOGY must be one of: same_site, cross_site")
 
         if not 60 <= self.EXPORT_DOWNLOAD_URL_EXPIRES_SECONDS <= 900:
             raise ValueError(

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -12,6 +12,7 @@ from app.db.models import Driver, User
 from app.db.repo.drivers import get_driver_by_id
 from app.db.repo.users import get_user_by_id, get_user_org_ids
 from app.db.session import get_db
+from app.security.csrf import validate_csrf_request
 from app.security.permissions import Capability, get_user_capabilities, normalize_role
 from app.security.session import validate_session
 
@@ -57,6 +58,7 @@ def get_current_user(
     db: Session = Depends(get_db),
 ) -> User:
     """Decode a user JWT and return the active User row."""
+    validate_csrf_request(request)
     token = _read_access_token(request, creds)
 
     payload = decode_access_token(token)
@@ -89,6 +91,7 @@ def get_current_driver(
     db: Session = Depends(get_db),
 ) -> Driver:
     """Decode a driver-scoped JWT and return the active Driver row."""
+    validate_csrf_request(request)
     token = _read_access_token(request, creds)
 
     payload = decode_access_token(token)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from app.api.routes.routes_driver_report import router as driver_report_router
 from app.api.routes_admin import router as admin_router
 from app.api.routes_twilio import router as twilio_router
 from app.core.config import settings
+from app.config.validation import validate_startup_config
 from app.core.logging import RequestContextMiddleware, setup_logging
 
 app = FastAPI(title="ADC MVP", version="0.1.0", debug=settings.DEBUG)
@@ -47,7 +48,7 @@ async def health_check():
 
 
 @app.on_event("startup")
-async def validate_startup_config() -> None:
+async def validate_startup_configuration() -> None:
     """Fail fast if environment invariants are broken."""
 
-    settings.validate_production_invariants()
+    validate_startup_config(settings)

--- a/backend/app/security/csrf.py
+++ b/backend/app/security/csrf.py
@@ -1,0 +1,48 @@
+"""CSRF protection helpers for cookie-authenticated flows."""
+
+from __future__ import annotations
+
+import secrets
+
+from fastapi import HTTPException, Request, status
+
+CSRF_COOKIE_NAME = "csrf_token"
+CSRF_HEADER_NAME = "x-csrf-token"
+_MUTATING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+
+
+def issue_csrf_token() -> str:
+    """Create a new CSRF token value for double-submit protection."""
+    return secrets.token_urlsafe(32)
+
+
+def requires_csrf_validation(request: Request) -> bool:
+    """Return True when request is cookie-authenticated and mutating."""
+    if request.method.upper() not in _MUTATING_METHODS:
+        return False
+
+    authorization = request.headers.get("authorization", "")
+    if authorization.lower().startswith("bearer "):
+        return False
+
+    return bool(request.cookies.get("access_token") or request.cookies.get("refresh_token"))
+
+
+def validate_csrf_request(request: Request) -> None:
+    """Validate double-submit CSRF token for cookie-authenticated requests."""
+    if not requires_csrf_validation(request):
+        return
+
+    cookie_token = request.cookies.get(CSRF_COOKIE_NAME)
+    header_token = request.headers.get(CSRF_HEADER_NAME)
+    if not cookie_token or not header_token:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="CSRF token missing",
+        )
+
+    if not secrets.compare_digest(cookie_token, header_token):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="CSRF token invalid",
+        )

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -264,3 +264,47 @@ class TestLoginCookie:
         assert resp.status_code == 200
         cookies = resp.cookies
         assert "access_token" in cookies
+        assert "csrf_token" in cookies
+        set_cookie_header = ",".join(resp.headers.get_list("set-cookie"))
+        assert "HttpOnly" in set_cookie_header
+        assert "SameSite=lax" in set_cookie_header
+
+
+class TestCsrfProtection:
+    def test_cookie_authenticated_refresh_requires_csrf_header(self, client):
+        client.post(
+            "/auth/register",
+            json={"email": "csrf-refresh@example.com", "password": "secret"},
+        )
+        login = client.post(
+            "/auth/login",
+            json={"email": "csrf-refresh@example.com", "password": "secret"},
+        )
+        assert login.status_code == 200
+
+        refresh_without_csrf = client.post("/auth/refresh")
+        assert refresh_without_csrf.status_code == 403
+
+        refresh_with_invalid_csrf = client.post(
+            "/auth/refresh",
+            headers={"x-csrf-token": "invalid-token"},
+        )
+        assert refresh_with_invalid_csrf.status_code == 403
+
+    def test_cookie_authenticated_logout_requires_csrf_header(self, client):
+        client.post(
+            "/auth/register",
+            json={"email": "csrf-logout@example.com", "password": "secret"},
+        )
+        login = client.post(
+            "/auth/login",
+            json={"email": "csrf-logout@example.com", "password": "secret"},
+        )
+        assert login.status_code == 200
+
+        logout_without_csrf = client.post("/auth/logout")
+        assert logout_without_csrf.status_code == 403
+
+        csrf_token = client.cookies.get("csrf_token")
+        logout_with_csrf = client.post("/auth/logout", headers={"x-csrf-token": csrf_token})
+        assert logout_with_csrf.status_code == 200

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -50,6 +50,26 @@ class TestSettingsValidation:
             Settings(SECRET_PROVIDER="vault")
 
 
+    def test_invalid_cookie_topology_fails(self):
+        with pytest.raises(ValueError, match="COOKIE_DEPLOYMENT_TOPOLOGY"):
+            Settings(COOKIE_DEPLOYMENT_TOPOLOGY="hybrid")
+
+    def test_prod_cross_site_requires_secure_cookie(self):
+        settings = Settings(
+            APP_ENV="prod",
+            JWT_SECRET_KEY="super-secret",
+            OTP_HASH_PEPPER="pepper-secret",
+            DATABASE_URL="postgresql://db.example.com/adc",
+            COOKIE_HTTPONLY=True,
+            COOKIE_SECURE=False,
+            COOKIE_DEPLOYMENT_TOPOLOGY="cross_site",
+            FRONTEND_ORIGIN="https://app.example.com",
+            PUBLIC_APP_BASE_URL="https://app.example.com",
+        )
+
+        with pytest.raises(ValueError, match="cross_site cookies require COOKIE_SECURE=true"):
+            settings.validate_production_invariants()
+
 class TestAwsSecretsManagerSource:
     def test_loads_runtime_settings_from_aws_secrets_manager(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
### Motivation
- Prevent CSRF on cookie-authenticated mutating endpoints by requiring a double-submit token when cookies are used for auth.
- Harden cookie defaults in production by making `HttpOnly` explicit, enforcing `Secure` for cross-site cookies, and deriving an explicit `SameSite` policy from deployment topology.
- Fail fast at startup when session/cookie settings are unsafe for production to avoid insecure deployments.

### Description
- Added `backend/app/security/csrf.py` with `issue_csrf_token()`, `requires_csrf_validation()` and `validate_csrf_request()` to implement double-submit CSRF protection for cookie-authenticated mutating requests.
- Enforced CSRF validation by calling `validate_csrf_request()` from authentication dependencies (`get_current_user`, `get_current_driver`) and from `POST /auth/refresh` and `POST /auth/logout` flows, and issued a readable `csrf_token` cookie on login.
- Hardened cookie configuration in `backend/app/core/config.py` by introducing `COOKIE_HTTPONLY`, `COOKIE_DEPLOYMENT_TOPOLOGY` and a derived `cookie_samesite` property, and updated cookie set/delete calls in auth routes to use these settings.
- Added startup validation helpers in `backend/app/config/validation.py` and wired them into app startup in `backend/app/main.py` to fail-fast on unsafe production cookie/session invariants.
- Added and updated tests to cover CSRF behavior and cookie topology validation, and updated affected auth tests to assert the new cookie and header behaviors.

### Testing
- Ran linting checks with `python -m ruff check app tests` and the linter returned no errors.
- Ran unit tests for the modified areas with `python -m pytest tests/test_auth.py tests/test_config.py` and all targeted tests passed.
- Ran broader endpoint suite with `python -m pytest tests/test_api_endpoints.py` and those tests passed as well.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4df51ed6c832182783a220b681b86)