### PR TITLE
Add append-only audit_events table, migration, and backend audit service

### DIFF
--- a/backend/app/audit/__init__.py
+++ b/backend/app/audit/__init__.py
@@ -1,0 +1,1 @@
+"""Audit event helpers."""

--- a/backend/app/audit/models.py
+++ b/backend/app/audit/models.py
@@ -1,0 +1,33 @@
+"""Audit event domain models."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(slots=True)
+class AuditEventCreate:
+    """Input payload for writing an immutable audit event."""
+
+    org_id: uuid.UUID
+    actor_type: str
+    actor_id: str
+    action: str
+    event_type: str
+    outcome: str | None = None
+    incident_id: uuid.UUID | None = None
+    export_id: uuid.UUID | None = None
+    artifact_id: uuid.UUID | None = None
+    metadata: dict[str, Any] | None = None
+    occurred_at_utc: datetime | None = None
+
+
+@dataclass(slots=True)
+class AuditEventRetentionUpdate:
+    """Controlled retention-only fields that can be updated later."""
+
+    retention_expires_at_utc: datetime | None = None
+    retention_purged_at_utc: datetime | None = None

--- a/backend/app/audit/queries.py
+++ b/backend/app/audit/queries.py
@@ -1,0 +1,85 @@
+"""Database queries for immutable audit events."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from app.audit.models import AuditEventCreate, AuditEventRetentionUpdate
+from app.db.models import AuditEvent
+
+
+class AuditEventQueryFilters(dict):
+    """Typed mapping helper for querying audit event timelines."""
+
+
+def insert_audit_event(db: Session, payload: AuditEventCreate) -> AuditEvent:
+    """Insert a new append-only audit event."""
+    audit_event = AuditEvent(
+        org_id=payload.org_id,
+        incident_id=payload.incident_id,
+        export_id=payload.export_id,
+        artifact_id=payload.artifact_id,
+        actor_type=payload.actor_type,
+        actor_id=payload.actor_id,
+        action=payload.action,
+        event_type=payload.event_type,
+        outcome=payload.outcome,
+        metadata_json=payload.metadata,
+        occurred_at_utc=payload.occurred_at_utc,
+    )
+    db.add(audit_event)
+    db.commit()
+    db.refresh(audit_event)
+    return audit_event
+
+
+def list_audit_events(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    incident_id: uuid.UUID | None = None,
+    export_id: uuid.UUID | None = None,
+    actor_id: str | None = None,
+    event_type: str | None = None,
+    occurred_after_utc: datetime | None = None,
+    occurred_before_utc: datetime | None = None,
+    limit: int = 500,
+) -> list[AuditEvent]:
+    """List audit events by common indexed filters."""
+    query = db.query(AuditEvent).filter(AuditEvent.org_id == org_id)
+
+    if incident_id is not None:
+        query = query.filter(AuditEvent.incident_id == incident_id)
+    if export_id is not None:
+        query = query.filter(AuditEvent.export_id == export_id)
+    if actor_id is not None:
+        query = query.filter(AuditEvent.actor_id == actor_id)
+    if event_type is not None:
+        query = query.filter(AuditEvent.event_type == event_type)
+    if occurred_after_utc is not None:
+        query = query.filter(AuditEvent.occurred_at_utc >= occurred_after_utc)
+    if occurred_before_utc is not None:
+        query = query.filter(AuditEvent.occurred_at_utc <= occurred_before_utc)
+
+    return query.order_by(AuditEvent.occurred_at_utc.desc()).limit(limit).all()
+
+
+def update_audit_event_retention(
+    db: Session,
+    *,
+    audit_event_id: uuid.UUID,
+    retention: AuditEventRetentionUpdate,
+) -> AuditEvent | None:
+    """Update retention-only fields for an audit event."""
+    audit_event = db.query(AuditEvent).filter(AuditEvent.id == audit_event_id).first()
+    if audit_event is None:
+        return None
+
+    audit_event.retention_expires_at_utc = retention.retention_expires_at_utc
+    audit_event.retention_purged_at_utc = retention.retention_purged_at_utc
+    db.commit()
+    db.refresh(audit_event)
+    return audit_event

--- a/backend/app/audit/service.py
+++ b/backend/app/audit/service.py
@@ -1,0 +1,65 @@
+"""Service interface for audit event storage and retrieval."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from app.audit.models import AuditEventCreate, AuditEventRetentionUpdate
+from app.audit.queries import (
+    insert_audit_event,
+    list_audit_events,
+    update_audit_event_retention,
+)
+from app.db.models import AuditEvent
+
+
+def append_event(db: Session, payload: AuditEventCreate) -> AuditEvent:
+    """Append a new immutable audit event row."""
+    return insert_audit_event(db, payload)
+
+
+def get_events(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    incident_id: uuid.UUID | None = None,
+    export_id: uuid.UUID | None = None,
+    actor_id: str | None = None,
+    event_type: str | None = None,
+    occurred_after_utc: datetime | None = None,
+    occurred_before_utc: datetime | None = None,
+    limit: int = 500,
+) -> list[AuditEvent]:
+    """Read audit events using indexed dimensions and timestamp range filters."""
+    return list_audit_events(
+        db,
+        org_id=org_id,
+        incident_id=incident_id,
+        export_id=export_id,
+        actor_id=actor_id,
+        event_type=event_type,
+        occurred_after_utc=occurred_after_utc,
+        occurred_before_utc=occurred_before_utc,
+        limit=limit,
+    )
+
+
+def set_retention(
+    db: Session,
+    *,
+    audit_event_id: uuid.UUID,
+    retention_expires_at_utc: datetime | None = None,
+    retention_purged_at_utc: datetime | None = None,
+) -> AuditEvent | None:
+    """Set retention-only mutable fields for an existing audit event."""
+    return update_audit_event_retention(
+        db,
+        audit_event_id=audit_event_id,
+        retention=AuditEventRetentionUpdate(
+            retention_expires_at_utc=retention_expires_at_utc,
+            retention_purged_at_utc=retention_purged_at_utc,
+        ),
+    )

--- a/backend/app/db/migrations/versions/0015_add_audit_events_table.py
+++ b/backend/app/db/migrations/versions/0015_add_audit_events_table.py
@@ -1,0 +1,157 @@
+"""add immutable audit_events table
+
+Revision ID: 0015
+Revises: 0014
+Create Date: 2026-04-07
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0015"
+down_revision: Union[str, None] = "0014"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "audit_events",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("incident_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("export_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("artifact_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("actor_type", sa.Text(), nullable=False),
+        sa.Column("actor_id", sa.Text(), nullable=False),
+        sa.Column("action", sa.Text(), nullable=False),
+        sa.Column("event_type", sa.Text(), nullable=False),
+        sa.Column("outcome", sa.Text(), nullable=True),
+        sa.Column("metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "occurred_at_utc",
+            postgresql.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("retention_expires_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("retention_purged_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "created_at_utc",
+            postgresql.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(["artifact_id"], ["artifacts.artifact_id"]),
+        sa.ForeignKeyConstraint(["export_id"], ["exports.export_id"]),
+        sa.ForeignKeyConstraint(["incident_id"], ["incidents.incident_id"]),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_index("ix_audit_events_org_id", "audit_events", ["org_id"], unique=False)
+    op.create_index("ix_audit_events_incident_id", "audit_events", ["incident_id"], unique=False)
+    op.create_index("ix_audit_events_export_id", "audit_events", ["export_id"], unique=False)
+    op.create_index("ix_audit_events_artifact_id", "audit_events", ["artifact_id"], unique=False)
+    op.create_index("ix_audit_events_actor_id", "audit_events", ["actor_id"], unique=False)
+    op.create_index("ix_audit_events_event_type", "audit_events", ["event_type"], unique=False)
+    op.create_index("ix_audit_events_occurred_at_utc", "audit_events", ["occurred_at_utc"], unique=False)
+
+    op.create_index(
+        "ix_audit_events_org_occurred",
+        "audit_events",
+        ["org_id", "occurred_at_utc"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_audit_events_org_incident_occurred",
+        "audit_events",
+        ["org_id", "incident_id", "occurred_at_utc"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_audit_events_org_export_occurred",
+        "audit_events",
+        ["org_id", "export_id", "occurred_at_utc"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_audit_events_org_actor_occurred",
+        "audit_events",
+        ["org_id", "actor_id", "occurred_at_utc"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_audit_events_org_event_type_occurred",
+        "audit_events",
+        ["org_id", "event_type", "occurred_at_utc"],
+        unique=False,
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION prevent_audit_events_mutation()
+        RETURNS trigger AS $$
+        BEGIN
+            IF TG_OP = 'DELETE' THEN
+                RAISE EXCEPTION 'audit_events rows are append-only and cannot be deleted';
+            END IF;
+
+            IF TG_OP = 'UPDATE' THEN
+                IF NEW.org_id IS DISTINCT FROM OLD.org_id
+                    OR NEW.incident_id IS DISTINCT FROM OLD.incident_id
+                    OR NEW.export_id IS DISTINCT FROM OLD.export_id
+                    OR NEW.artifact_id IS DISTINCT FROM OLD.artifact_id
+                    OR NEW.actor_type IS DISTINCT FROM OLD.actor_type
+                    OR NEW.actor_id IS DISTINCT FROM OLD.actor_id
+                    OR NEW.action IS DISTINCT FROM OLD.action
+                    OR NEW.event_type IS DISTINCT FROM OLD.event_type
+                    OR NEW.outcome IS DISTINCT FROM OLD.outcome
+                    OR NEW.metadata_json IS DISTINCT FROM OLD.metadata_json
+                    OR NEW.occurred_at_utc IS DISTINCT FROM OLD.occurred_at_utc
+                    OR NEW.created_at_utc IS DISTINCT FROM OLD.created_at_utc
+                THEN
+                    RAISE EXCEPTION 'audit_events rows are append-only; only retention fields are mutable';
+                END IF;
+            END IF;
+
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER trg_prevent_audit_events_mutation
+        BEFORE UPDATE OR DELETE ON audit_events
+        FOR EACH ROW
+        EXECUTE FUNCTION prevent_audit_events_mutation();
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS trg_prevent_audit_events_mutation ON audit_events")
+    op.execute("DROP FUNCTION IF EXISTS prevent_audit_events_mutation")
+
+    op.drop_index("ix_audit_events_org_event_type_occurred", table_name="audit_events")
+    op.drop_index("ix_audit_events_org_actor_occurred", table_name="audit_events")
+    op.drop_index("ix_audit_events_org_export_occurred", table_name="audit_events")
+    op.drop_index("ix_audit_events_org_incident_occurred", table_name="audit_events")
+    op.drop_index("ix_audit_events_org_occurred", table_name="audit_events")
+
+    op.drop_index("ix_audit_events_occurred_at_utc", table_name="audit_events")
+    op.drop_index("ix_audit_events_event_type", table_name="audit_events")
+    op.drop_index("ix_audit_events_actor_id", table_name="audit_events")
+    op.drop_index("ix_audit_events_artifact_id", table_name="audit_events")
+    op.drop_index("ix_audit_events_export_id", table_name="audit_events")
+    op.drop_index("ix_audit_events_incident_id", table_name="audit_events")
+    op.drop_index("ix_audit_events_org_id", table_name="audit_events")
+
+    op.drop_table("audit_events")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -113,6 +113,55 @@ class Event(Base):
     )
 
 
+class AuditEvent(Base):
+    """Immutable audit trail for actor/org/incident/export/artifact actions."""
+
+    __tablename__ = "audit_events"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True)
+    incident_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("incidents.incident_id"),
+        nullable=True,
+        index=True,
+    )
+    export_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("exports.export_id"),
+        nullable=True,
+        index=True,
+    )
+    artifact_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("artifacts.artifact_id"),
+        nullable=True,
+        index=True,
+    )
+    actor_type = Column(Text, nullable=False)
+    actor_id = Column(Text, nullable=False, index=True)
+    action = Column(Text, nullable=False)
+    event_type = Column(Text, nullable=False, index=True)
+    outcome = Column(Text, nullable=True)
+    metadata_json = Column(JSONB, nullable=True)
+    occurred_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, index=True, server_default=func.now()
+    )
+    retention_expires_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    retention_purged_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        Index("ix_audit_events_org_occurred", "org_id", "occurred_at_utc"),
+        Index("ix_audit_events_org_incident_occurred", "org_id", "incident_id", "occurred_at_utc"),
+        Index("ix_audit_events_org_export_occurred", "org_id", "export_id", "occurred_at_utc"),
+        Index("ix_audit_events_org_actor_occurred", "org_id", "actor_id", "occurred_at_utc"),
+        Index("ix_audit_events_org_event_type_occurred", "org_id", "event_type", "occurred_at_utc"),
+    )
+
+
 class Incident(Base):
     """Summary pointer for an incident."""
 

--- a/backend/tests/test_audit_service.py
+++ b/backend/tests/test_audit_service.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.audit.models import AuditEventCreate
+from app.audit.service import append_event, get_events, set_retention
+from app.db.models import Base, Org
+
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    test_session = sessionmaker(bind=engine)
+    session = test_session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_append_and_query_audit_events(db_session) -> None:
+    org = Org(name="Audit Org")
+    db_session.add(org)
+    db_session.commit()
+    db_session.refresh(org)
+
+    now = datetime.now(timezone.utc)
+    append_event(
+        db_session,
+        AuditEventCreate(
+            org_id=org.id,
+            actor_type="user",
+            actor_id="user-1",
+            action="export.download",
+            event_type="export_downloaded",
+            outcome="success",
+            metadata={"ip": "127.0.0.1"},
+            occurred_at_utc=now,
+        ),
+    )
+
+    events = get_events(
+        db_session,
+        org_id=org.id,
+        actor_id="user-1",
+        event_type="export_downloaded",
+        occurred_after_utc=now - timedelta(minutes=1),
+        occurred_before_utc=now + timedelta(minutes=1),
+    )
+
+    assert len(events) == 1
+    assert events[0].action == "export.download"
+    assert events[0].outcome == "success"
+
+
+def test_retention_fields_can_be_updated(db_session) -> None:
+    org = Org(name="Retention Org")
+    db_session.add(org)
+    db_session.commit()
+    db_session.refresh(org)
+
+    event = append_event(
+        db_session,
+        AuditEventCreate(
+            org_id=org.id,
+            actor_type="system",
+            actor_id="scheduler",
+            action="retention.mark",
+            event_type="retention_marked",
+        ),
+    )
+
+    retention_until = datetime.now(timezone.utc) + timedelta(days=365)
+    updated = set_retention(
+        db_session,
+        audit_event_id=event.id,
+        retention_expires_at_utc=retention_until,
+    )
+
+    assert updated is not None
+    assert updated.retention_expires_at_utc == retention_until.replace(tzinfo=None)


### PR DESCRIPTION
### Motivation

- Capture a structured, append-only audit trail with the required event shape (org/actor/incident/export/artifact/action/outcome/metadata) for compliance and operational queries.
- Enforce immutability at the database level while allowing controlled retention-only updates for lifecycle management.
- Provide a small service layer and query helpers to make producing and reading audit events consistent and index-friendly for range/time queries.

### Description

- Add a new SQLAlchemy model `AuditEvent` and corresponding columns for `org_id`, `incident_id`, `export_id`, `artifact_id`, `actor_type`, `actor_id`, `action`, `event_type`, `outcome`, `metadata_json`, `occurred_at_utc`, retention timestamps, and `created_at_utc` in `backend/app/db/models.py`.
- Add Alembic migration `0015_add_audit_events_table.py` that creates the `audit_events` table, adds indexes for `org`, `incident`, `export`, `artifact`, `actor`, `event_type`, and `occurred_at_utc` (including composite org+dimension+occurred indexes), and installs a trigger/function that prevents `DELETE` and disallows `UPDATE` to non-retention fields (allowing only retention fields to be mutated).
- Implement `app.audit` module with `models.py` (typed dataclasses), `queries.py` (insert/list/update-retention functions), and `service.py` (`append_event`, `get_events`, `set_retention`) to encapsulate append-only semantics and query patterns.
- Add unit tests `backend/tests/test_audit_service.py` to validate append/query behavior and retention-field updates, and register the new module with an `__init__.py`.

### Testing

- Ran formatter/linter checks with `ruff check app/audit app/db/models.py app/db/migrations/versions/0015_add_audit_events_table.py tests/test_audit_service.py` which passed.
- Ran unit tests with `pytest -q tests/test_audit_service.py tests/test_migration_integrity.py` and all tests passed (3 passed).
- Migration integrity check `tests/test_migration_integrity.py` was executed as part of the test run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4e3abd9148321bba873f82c37caa4)