### PR TITLE
Add operations dashboard specs and monitoring alert policies

### DIFF
--- a/docs/operations/dashboards/api-health.md
+++ b/docs/operations/dashboards/api-health.md
@@ -1,0 +1,39 @@
+# API Health Dashboard Spec
+
+## Purpose
+Track request-path reliability, latency, and saturation for customer-facing API endpoints required by the observability gate (Section 7.4).
+
+## Scope
+- Environment: `prod`
+- Service: `adc-api`
+- Org: `adc`
+- Data sources: HTTP server metrics, ingress metrics, Postgres and Redis dependency health metrics
+
+## Primary panels
+1. **Request rate (RPS)**
+   - Query: `sum(rate(http_server_requests_total{service="adc-api",environment="prod"}[5m]))`
+2. **Error ratio (5xx / total)**
+   - Query: `sum(rate(http_server_requests_total{service="adc-api",environment="prod",status=~"5.."}[5m])) / sum(rate(http_server_requests_total{service="adc-api",environment="prod"}[5m]))`
+3. **p95 latency by route**
+   - Query: `histogram_quantile(0.95, sum by (le, route) (rate(http_server_request_duration_seconds_bucket{service="adc-api",environment="prod"}[5m])))`
+4. **Auth success vs failure ratio**
+   - Query: `sum(rate(auth_attempts_total{service="adc-api",environment="prod",result="success"}[5m])) / sum(rate(auth_attempts_total{service="adc-api",environment="prod"}[5m]))`
+5. **Dependency health rollup**
+   - Queries: DB connection saturation, Redis timeout/error rate, OTP provider error rate
+6. **SLO burn-rate panels (1h and 6h windows)**
+   - Query pair for fast/slow burn on API error budget
+
+## Dashboard-level filters
+- `org`: default `adc`
+- `service`: default `adc-api`
+- `environment`: default `prod`
+- `route`: optional wildcard
+
+## Linked alerts
+- `api_5xx_error_ratio_critical`
+- `api_latency_p95_warning`
+- `api_dependency_failure_critical`
+
+## Runbooks
+- Primary: `docs/reliability-and-incident-response-runbook.md`
+- Secondary: `docs/release-readiness-checklist.md`

--- a/docs/operations/dashboards/evidence-pipeline.md
+++ b/docs/operations/dashboards/evidence-pipeline.md
@@ -1,0 +1,39 @@
+# Evidence Pipeline Dashboard Spec
+
+## Purpose
+Provide end-to-end visibility into evidence ingest, processing, storage, and export reliability for compliance-sensitive workflows.
+
+## Scope
+- Environment: `prod`
+- Service: `adc-evidence-pipeline`
+- Org: `adc`
+- Data sources: ingest API metrics, object-storage metrics, pipeline task metrics, export metrics
+
+## Primary panels
+1. **Evidence ingest success ratio**
+   - Query: `sum(rate(evidence_ingest_requests_total{service="adc-evidence-pipeline",environment="prod",result="success"}[10m])) / sum(rate(evidence_ingest_requests_total{service="adc-evidence-pipeline",environment="prod"}[10m]))`
+2. **Artifact processing latency p95**
+   - Query: `histogram_quantile(0.95, sum by (le, stage) (rate(evidence_stage_duration_seconds_bucket{service="adc-evidence-pipeline",environment="prod"}[10m])))`
+3. **Pipeline stage failure count by stage**
+   - Query: `sum(rate(evidence_stage_failures_total{service="adc-evidence-pipeline",environment="prod"}[10m])) by (stage)`
+4. **Storage write/read error rates**
+   - Query: `sum(rate(evidence_storage_errors_total{service="adc-evidence-pipeline",environment="prod"}[5m])) by (operation)`
+5. **Export package generation success ratio**
+   - Query: `sum(rate(export_package_jobs_total{service="adc-evidence-pipeline",environment="prod",state="SUCCESS"}[15m])) / sum(rate(export_package_jobs_total{service="adc-evidence-pipeline",environment="prod"}[15m]))`
+6. **Backlog of pending evidence artifacts**
+   - Query: `max(evidence_pending_artifacts{service="adc-evidence-pipeline",environment="prod"})`
+
+## Dashboard-level filters
+- `org`: default `adc`
+- `service`: default `adc-evidence-pipeline`
+- `environment`: default `prod`
+- `stage`: optional
+
+## Linked alerts
+- `evidence_ingest_failure_ratio_critical`
+- `evidence_stage_latency_warning`
+- `evidence_export_failures_critical`
+
+## Runbooks
+- Primary: `docs/reliability-and-incident-response-runbook.md`
+- Secondary: `docs/section-23-export-acceptance-checklist.md`

--- a/docs/operations/dashboards/job-processing.md
+++ b/docs/operations/dashboards/job-processing.md
@@ -1,0 +1,39 @@
+# Job Processing Dashboard Spec
+
+## Purpose
+Monitor asynchronous worker throughput, failures, retry patterns, and queue health to maintain Section 7.4 observability requirements and Section 21 post-release verification readiness.
+
+## Scope
+- Environment: `prod`
+- Service: `adc-worker`
+- Org: `adc`
+- Data sources: Celery/queue metrics, worker runtime metrics, Redis queue metrics
+
+## Primary panels
+1. **Jobs started/completed rate**
+   - Query: `sum(rate(celery_tasks_total{service="adc-worker",environment="prod",state=~"STARTED|SUCCESS"}[5m])) by (state)`
+2. **Job failure ratio**
+   - Query: `sum(rate(celery_tasks_total{service="adc-worker",environment="prod",state="FAILURE"}[15m])) / sum(rate(celery_tasks_total{service="adc-worker",environment="prod"}[15m]))`
+3. **Queue depth by queue name**
+   - Query: `max(celery_queue_depth{service="adc-worker",environment="prod"}) by (queue)`
+4. **Oldest message age**
+   - Query: `max(celery_queue_oldest_message_age_seconds{service="adc-worker",environment="prod"}) by (queue)`
+5. **Retry storm detection**
+   - Query: `sum(rate(celery_task_retries_total{service="adc-worker",environment="prod"}[10m])) by (task_name)`
+6. **Worker availability**
+   - Query: `sum(up{service="adc-worker",environment="prod"})`
+
+## Dashboard-level filters
+- `org`: default `adc`
+- `service`: default `adc-worker`
+- `environment`: default `prod`
+- `queue`: optional
+
+## Linked alerts
+- `jobs_failure_ratio_critical`
+- `jobs_queue_depth_warning`
+- `jobs_stuck_message_critical`
+
+## Runbooks
+- Primary: `docs/reliability-and-incident-response-runbook.md`
+- Secondary: `docs/section-23-export-acceptance-checklist.md`

--- a/docs/operations/dashboards/security-audit.md
+++ b/docs/operations/dashboards/security-audit.md
@@ -1,0 +1,39 @@
+# Security & Audit Dashboard Spec
+
+## Purpose
+Track security posture and audit pipeline health, including immutable event generation and ingestion timeliness.
+
+## Scope
+- Environment: `prod`
+- Service: `adc-security-audit`
+- Org: `adc`
+- Data sources: auth/audit logs, SIEM ingestion metrics, admin action audit events
+
+## Primary panels
+1. **Authentication failure ratio by reason**
+   - Query: `sum(rate(auth_failures_total{service="adc-security-audit",environment="prod"}[10m])) by (reason) / sum(rate(auth_attempts_total{service="adc-security-audit",environment="prod"}[10m]))`
+2. **Privileged action count by actor role**
+   - Query: `sum(rate(admin_privileged_actions_total{service="adc-security-audit",environment="prod"}[15m])) by (actor_role, action)`
+3. **Audit event ingestion lag (p95)**
+   - Query: `histogram_quantile(0.95, sum by (le) (rate(audit_ingestion_lag_seconds_bucket{service="adc-security-audit",environment="prod"}[10m])))`
+4. **Audit event drop/parse failures**
+   - Query: `sum(rate(audit_event_failures_total{service="adc-security-audit",environment="prod"}[10m])) by (failure_type)`
+5. **Cross-tenant access-denied attempts**
+   - Query: `sum(rate(authz_cross_tenant_denied_total{service="adc-security-audit",environment="prod"}[10m]))`
+6. **Tamper-evidence validator status**
+   - Query: `max(audit_tamper_validation_pass{service="adc-security-audit",environment="prod"})`
+
+## Dashboard-level filters
+- `org`: default `adc`
+- `service`: default `adc-security-audit`
+- `environment`: default `prod`
+- `actor_role`: optional
+
+## Linked alerts
+- `security_auth_failure_ratio_warning`
+- `audit_ingestion_lag_critical`
+- `audit_pipeline_failure_critical`
+
+## Runbooks
+- Primary: `docs/reliability-and-incident-response-runbook.md`
+- Secondary: `docs/release-readiness-checklist.md`

--- a/infra/monitoring/alert-policies.yaml
+++ b/infra/monitoring/alert-policies.yaml
@@ -1,0 +1,187 @@
+version: 1
+org: adc
+service: adc-platform
+environment: prod
+
+alert_policies:
+  # Section 7.4 - Observability alerts (critical + warning)
+  - id: api_5xx_error_ratio_critical
+    section_ref: "7.4"
+    severity: critical
+    condition: "api 5xx error ratio > 5% for 10m"
+    expression: "sum(rate(http_server_requests_total{service='adc-api',environment='prod',status=~'5..'}[10m])) / sum(rate(http_server_requests_total{service='adc-api',environment='prod'}[10m])) > 0.05"
+    for: 10m
+    routing:
+      pager: primary
+      escalation: sre_manager
+    runbook: docs/reliability-and-incident-response-runbook.md
+    tags:
+      org: adc
+      service: adc-api
+      environment: prod
+
+  - id: api_latency_p95_warning
+    section_ref: "7.4"
+    severity: warning
+    condition: "api p95 latency > 750ms for 15m"
+    expression: "histogram_quantile(0.95, sum by (le) (rate(http_server_request_duration_seconds_bucket{service='adc-api',environment='prod'}[5m]))) > 0.75"
+    for: 15m
+    routing:
+      pager: secondary
+      escalation: service_owner
+    runbook: docs/reliability-and-incident-response-runbook.md
+    tags:
+      org: adc
+      service: adc-api
+      environment: prod
+
+  - id: jobs_failure_ratio_critical
+    section_ref: "7.4"
+    severity: critical
+    condition: "worker failure ratio > 10% for 15m"
+    expression: "sum(rate(celery_tasks_total{service='adc-worker',environment='prod',state='FAILURE'}[15m])) / sum(rate(celery_tasks_total{service='adc-worker',environment='prod'}[15m])) > 0.10"
+    for: 15m
+    routing:
+      pager: primary
+      escalation: backend_oncall
+    runbook: docs/reliability-and-incident-response-runbook.md
+    tags:
+      org: adc
+      service: adc-worker
+      environment: prod
+
+  - id: jobs_queue_depth_warning
+    section_ref: "7.4"
+    severity: warning
+    condition: "queue depth > 1000 for 20m"
+    expression: "max(celery_queue_depth{service='adc-worker',environment='prod'}) > 1000"
+    for: 20m
+    routing:
+      pager: secondary
+      escalation: backend_service_owner
+    runbook: docs/reliability-and-incident-response-runbook.md
+    tags:
+      org: adc
+      service: adc-worker
+      environment: prod
+
+  - id: evidence_ingest_failure_ratio_critical
+    section_ref: "7.4"
+    severity: critical
+    condition: "evidence ingest success ratio < 98% for 10m"
+    expression: "sum(rate(evidence_ingest_requests_total{service='adc-evidence-pipeline',environment='prod',result='success'}[10m])) / sum(rate(evidence_ingest_requests_total{service='adc-evidence-pipeline',environment='prod'}[10m])) < 0.98"
+    for: 10m
+    routing:
+      pager: primary
+      escalation: data_platform_oncall
+    runbook: docs/reliability-and-incident-response-runbook.md
+    tags:
+      org: adc
+      service: adc-evidence-pipeline
+      environment: prod
+
+  - id: evidence_stage_latency_warning
+    section_ref: "7.4"
+    severity: warning
+    condition: "evidence stage p95 latency > 120s for 15m"
+    expression: "histogram_quantile(0.95, sum by (le) (rate(evidence_stage_duration_seconds_bucket{service='adc-evidence-pipeline',environment='prod'}[10m]))) > 120"
+    for: 15m
+    routing:
+      pager: secondary
+      escalation: data_pipeline_owner
+    runbook: docs/section-23-export-acceptance-checklist.md
+    tags:
+      org: adc
+      service: adc-evidence-pipeline
+      environment: prod
+
+  - id: audit_ingestion_lag_critical
+    section_ref: "7.4"
+    severity: critical
+    condition: "audit ingestion lag p95 > 300s for 10m"
+    expression: "histogram_quantile(0.95, sum by (le) (rate(audit_ingestion_lag_seconds_bucket{service='adc-security-audit',environment='prod'}[10m]))) > 300"
+    for: 10m
+    routing:
+      pager: primary
+      escalation: security_oncall
+    runbook: docs/reliability-and-incident-response-runbook.md
+    tags:
+      org: adc
+      service: adc-security-audit
+      environment: prod
+
+  - id: security_auth_failure_ratio_warning
+    section_ref: "7.4"
+    severity: warning
+    condition: "auth failure ratio > 20% for 10m"
+    expression: "sum(rate(auth_failures_total{service='adc-security-audit',environment='prod'}[10m])) / sum(rate(auth_attempts_total{service='adc-security-audit',environment='prod'}[10m])) > 0.20"
+    for: 10m
+    routing:
+      pager: secondary
+      escalation: security_service_owner
+    runbook: docs/reliability-and-incident-response-runbook.md
+    tags:
+      org: adc
+      service: adc-security-audit
+      environment: prod
+
+  # Section 21 - Change management and post-release verification
+  - id: post_release_slo_regression_critical
+    section_ref: "21"
+    severity: critical
+    condition: "post-release api error budget burn rate > 4x for 30m"
+    expression: "slo_error_budget_burn_rate{service='adc-api',environment='prod',window='30m'} > 4"
+    for: 30m
+    routing:
+      pager: primary
+      escalation: incident_commander
+    runbook: docs/release-readiness-checklist.md
+    tags:
+      org: adc
+      service: adc-api
+      environment: prod
+
+  - id: post_release_job_regression_warning
+    section_ref: "21"
+    severity: warning
+    condition: "job failure ratio > 5% for 30m within 24h of deploy"
+    expression: "sum(rate(celery_tasks_total{service='adc-worker',environment='prod',state='FAILURE',release_window='post_release'}[30m])) / sum(rate(celery_tasks_total{service='adc-worker',environment='prod',release_window='post_release'}[30m])) > 0.05"
+    for: 30m
+    routing:
+      pager: secondary
+      escalation: release_manager
+    runbook: docs/release-readiness-checklist.md
+    tags:
+      org: adc
+      service: adc-worker
+      environment: prod
+
+  - id: post_release_audit_gap_critical
+    section_ref: "21"
+    severity: critical
+    condition: "audit event coverage < 99% for 15m post deploy"
+    expression: "audit_coverage_ratio{service='adc-security-audit',environment='prod',release_window='post_release'} < 0.99"
+    for: 15m
+    routing:
+      pager: primary
+      escalation: compliance_lead
+    runbook: docs/reliability-and-incident-response-runbook.md
+    tags:
+      org: adc
+      service: adc-security-audit
+      environment: prod
+
+  - id: post_release_smoke_test_fail_warning
+    section_ref: "21"
+    severity: warning
+    condition: "any mandatory smoke test fails in post-release checks"
+    expression: "max(release_smoke_test_failure{service='adc-api',environment='prod',required='true'}) > 0"
+    for: 5m
+    routing:
+      pager: secondary
+      escalation: release_manager
+    runbook: docs/release-readiness-checklist.md
+    tags:
+      org: adc
+      service: adc-api
+      environment: prod


### PR DESCRIPTION
### Motivation
- Improve observability and post-release verification by adding dashboard specs and alert definitions that implement the observability gate (Section 7.4) and change-management/post-release checks (Section 21).
- Provide clear paging/routing metadata and runbook links so alerts map to the correct org/service/environment and on-call path.

### Description
- Added four dashboard specification documents under `docs/operations/dashboards/`: `api-health.md`, `job-processing.md`, `evidence-pipeline.md`, and `security-audit.md`, each including purpose, scope, primary panels/queries, filters, linked alerts, and runbooks.
- Added `infra/monitoring/alert-policies.yaml` defining critical and warning alert policies (mapped to section refs `7.4` and `21`) for API, workers, evidence pipeline, and audit pipelines.
- Every alert entry includes a `runbook` link and `tags` containing `org`, `service`, and `environment` to support accurate paging and routing.
- Included default routing metadata (`pager`/`escalation`) for each alert to indicate intended paging targets.

### Testing
- Ran `make lint` and the repository lint checks passed (`make lint` ✅).
- Ran `make test` and the test suite failed with 4 failing hardening-matrix lint tests (see failures below), which are unrelated to the monitoring docs: the test failures surface a `FileNotFoundError` for `backend/scripts/check_hardening_matrix_updates.py` and a missing matrix-file assertion for `docs/production-hardening/control-matrix.md`; these failures caused `make test` to exit non-zero (4 failed, 333 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5b5b6332c8321bc227fab31bda871)