### PR TITLE
Add persistent job execution tracking, retry policy, and admin ops endpoints

### DIFF
--- a/backend/app/api/routes_admin.py
+++ b/backend/app/api/routes_admin.py
@@ -15,6 +15,8 @@ from app.api.schemas import (
     DriverInstructionStep,
     DriverProtocolSettingsRequest,
     DriverProtocolSettingsResponse,
+    JobExecutionMetaItem,
+    JobExecutionMetaSummary,
     QrPayloadResponse,
     RotateQrResponse,
 )
@@ -34,6 +36,10 @@ from app.db.models import (
 )
 from app.db.session import get_db
 from app.domain.system_event_types import SystemEventType
+from app.db.repo.job_execution_meta import (
+    list_ops_jobs_with_db,
+    summarize_ops_jobs_with_db,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -171,7 +177,9 @@ def get_driver_protocol_settings(
     context = build_user_auth_context(db, admin)
     _require_admin_policy(
         db,
-        allowed=can_access_admin_org(context, context.org_ids[0], Capability.DRIVER_PROTOCOL_WRITE),
+        allowed=can_access_admin_org(
+            context, context.org_ids[0], Capability.DRIVER_PROTOCOL_WRITE
+        ),
         actor_id=admin.id,
         org_id=context.org_ids[0],
         action="driver_protocol.settings.read",
@@ -198,7 +206,9 @@ def update_driver_protocol_settings(
     context = build_user_auth_context(db, admin)
     _require_admin_policy(
         db,
-        allowed=can_access_admin_org(context, context.org_ids[0], Capability.DRIVER_PROTOCOL_WRITE),
+        allowed=can_access_admin_org(
+            context, context.org_ids[0], Capability.DRIVER_PROTOCOL_WRITE
+        ),
         actor_id=admin.id,
         org_id=context.org_ids[0],
         action="driver_protocol.settings.update",
@@ -247,7 +257,9 @@ def get_driver_protocol_instructions(
     context = build_user_auth_context(db, admin)
     _require_admin_policy(
         db,
-        allowed=can_access_admin_org(context, context.org_ids[0], Capability.DRIVER_PROTOCOL_READ),
+        allowed=can_access_admin_org(
+            context, context.org_ids[0], Capability.DRIVER_PROTOCOL_READ
+        ),
         actor_id=admin.id,
         org_id=context.org_ids[0],
         action="driver_protocol.instructions.read",
@@ -286,7 +298,9 @@ def update_driver_protocol_instructions(
     context = build_user_auth_context(db, admin)
     _require_admin_policy(
         db,
-        allowed=can_access_admin_org(context, context.org_ids[0], Capability.DRIVER_PROTOCOL_WRITE),
+        allowed=can_access_admin_org(
+            context, context.org_ids[0], Capability.DRIVER_PROTOCOL_WRITE
+        ),
         actor_id=admin.id,
         org_id=context.org_ids[0],
         action="driver_protocol.instructions.update",
@@ -339,7 +353,9 @@ def reset_driver_protocol_instructions(
     context = build_user_auth_context(db, admin)
     _require_admin_policy(
         db,
-        allowed=can_access_admin_org(context, context.org_ids[0], Capability.DRIVER_PROTOCOL_WRITE),
+        allowed=can_access_admin_org(
+            context, context.org_ids[0], Capability.DRIVER_PROTOCOL_WRITE
+        ),
         actor_id=admin.id,
         org_id=context.org_ids[0],
         action="driver_protocol.instructions.reset",
@@ -378,7 +394,9 @@ def list_admin_vehicles(
     context = build_user_auth_context(db, admin)
     _require_admin_policy(
         db,
-        allowed=can_access_admin_org(context, context.org_ids[0], Capability.VEHICLE_QR_READ),
+        allowed=can_access_admin_org(
+            context, context.org_ids[0], Capability.VEHICLE_QR_READ
+        ),
         actor_id=admin.id,
         org_id=context.org_ids[0],
         action="admin.vehicles.list",
@@ -400,7 +418,9 @@ def rotate_qr(
     context = build_user_auth_context(db, admin)
     _require_admin_policy(
         db,
-        allowed=can_access_admin_org(context, context.org_ids[0], Capability.VEHICLE_QR_WRITE),
+        allowed=can_access_admin_org(
+            context, context.org_ids[0], Capability.VEHICLE_QR_WRITE
+        ),
         actor_id=admin.id,
         org_id=context.org_ids[0],
         action="admin.vehicle_qr.rotate",
@@ -479,7 +499,9 @@ def get_qr_payload(
     context = build_user_auth_context(db, admin)
     _require_admin_policy(
         db,
-        allowed=can_access_admin_org(context, context.org_ids[0], Capability.VEHICLE_QR_READ),
+        allowed=can_access_admin_org(
+            context, context.org_ids[0], Capability.VEHICLE_QR_READ
+        ),
         actor_id=admin.id,
         org_id=context.org_ids[0],
         action="admin.vehicle_qr.read",
@@ -487,3 +509,67 @@ def get_qr_payload(
     scheme = settings.DRIVER_APP_DEEPLINK_SCHEME
     deep_link = f"{scheme}://vehicle/{vehicle_id}"
     return QrPayloadResponse(deep_link=deep_link)
+
+
+@router.get("/ops/jobs/summary", response_model=JobExecutionMetaSummary)
+def get_ops_jobs_summary(
+    stale_after_minutes: int = 15,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, admin)
+    _require_admin_policy(
+        db,
+        allowed=can_access_admin_org(
+            context, context.org_ids[0], Capability.EXPORT_READ
+        ),
+        actor_id=admin.id,
+        org_id=context.org_ids[0],
+        action="admin.ops.jobs.summary",
+    )
+    return JobExecutionMetaSummary(
+        **summarize_ops_jobs_with_db(db=db, stale_after_minutes=stale_after_minutes)
+    )
+
+
+@router.get("/ops/jobs", response_model=list[JobExecutionMetaItem])
+def list_ops_job_failures(
+    stale_after_minutes: int = 15,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, admin)
+    _require_admin_policy(
+        db,
+        allowed=can_access_admin_org(
+            context, context.org_ids[0], Capability.EXPORT_READ
+        ),
+        actor_id=admin.id,
+        org_id=context.org_ids[0],
+        action="admin.ops.jobs.list",
+    )
+    rows = list_ops_jobs_with_db(
+        db=db,
+        statuses={"failed", "retrying", "running", "queued"},
+        stale_after_minutes=stale_after_minutes,
+    )
+    return [
+        JobExecutionMetaItem(
+            celery_task_id=row.celery_task_id,
+            task_name=row.task_name,
+            task_type=row.task_type,
+            status=row.status,
+            retry_count=row.retry_count,
+            max_retries=row.max_retries,
+            retry_category=row.retry_category,
+            should_retry=row.should_retry,
+            next_retry_at_utc=row.next_retry_at_utc,
+            started_at_utc=row.started_at_utc,
+            finished_at_utc=row.finished_at_utc,
+            last_heartbeat_at_utc=row.last_heartbeat_at_utc,
+            last_error=row.last_error,
+            created_at_utc=row.created_at_utc,
+            updated_at_utc=row.updated_at_utc,
+        )
+        for row in rows
+    ]

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -80,13 +80,43 @@ InstructionScope = Literal["default", "company", "insurer"]
 IncidentSeverity = Literal["minor", "serious", "critical"]
 IncidentStatus = Literal["open", "evidence_capturing", "closed"]
 ArtifactStatus = Literal["pending", "captured", "unavailable"]
-ExportType = Literal["court_defense", "insurer_packet", "internal_review", "compliance_audit"]
-ExportStatus = Literal["requested", "queued", "processing", "ready", "failed", "expired"]
-ExportProgressStage = Literal["request_accepted", "gathering_incident_data", "assembling_documents", "packaging_evidence", "uploading_export", "ready_for_download"]
+ExportType = Literal[
+    "court_defense", "insurer_packet", "internal_review", "compliance_audit"
+]
+ExportStatus = Literal[
+    "requested", "queued", "processing", "ready", "failed", "expired"
+]
+ExportProgressStage = Literal[
+    "request_accepted",
+    "gathering_incident_data",
+    "assembling_documents",
+    "packaging_evidence",
+    "uploading_export",
+    "ready_for_download",
+]
 
-assert set(EXPORT_TYPES) == {"court_defense", "insurer_packet", "internal_review", "compliance_audit"}
-assert set(EXPORT_STATUSES) == {"requested", "queued", "processing", "ready", "failed", "expired"}
-assert set(EXPORT_PROGRESS_STAGES) == {"request_accepted", "gathering_incident_data", "assembling_documents", "packaging_evidence", "uploading_export", "ready_for_download"}
+assert set(EXPORT_TYPES) == {
+    "court_defense",
+    "insurer_packet",
+    "internal_review",
+    "compliance_audit",
+}
+assert set(EXPORT_STATUSES) == {
+    "requested",
+    "queued",
+    "processing",
+    "ready",
+    "failed",
+    "expired",
+}
+assert set(EXPORT_PROGRESS_STAGES) == {
+    "request_accepted",
+    "gathering_incident_data",
+    "assembling_documents",
+    "packaging_evidence",
+    "uploading_export",
+    "ready_for_download",
+}
 VehicleStrategy = Literal["qr", "last_assigned"]
 CaptureState = Literal[
     "failed", "complete", "in_progress", "requested", "lockdown", "closed", "pending"
@@ -286,19 +316,27 @@ class CreateExportRequest(BaseModel):
         }
         unknown_keys = set(options.keys()) - allowed_keys
         if unknown_keys:
-            raise ValueError("options_json contains unsupported fields for packet profile exports")
+            raise ValueError(
+                "options_json contains unsupported fields for packet profile exports"
+            )
 
         defaults = profile.default_options()
         self.options_json = {
             **defaults,
-            "include_media": bool(options.get("include_media", defaults["include_media"])),
+            "include_media": bool(
+                options.get("include_media", defaults["include_media"])
+            ),
             "include_raw_telemetry": bool(
                 options.get("include_raw_telemetry", defaults["include_raw_telemetry"])
             ),
             "include_driver_statement": bool(
-                options.get("include_driver_statement", defaults["include_driver_statement"])
+                options.get(
+                    "include_driver_statement", defaults["include_driver_statement"]
+                )
             ),
-            "inventory_mode": str(options.get("inventory_mode", defaults["inventory_mode"])),
+            "inventory_mode": str(
+                options.get("inventory_mode", defaults["inventory_mode"])
+            ),
             "profile_id": requested_profile_id,
         }
         return self
@@ -322,9 +360,13 @@ class RetryExportRequest(BaseModel):
             return self
         target_export_type = self.export_type
         if target_export_type is None and self.options_json:
-            requested_profile_id = self.options_json.get("profile_id") or self.options_json.get("profile")
+            requested_profile_id = self.options_json.get(
+                "profile_id"
+            ) or self.options_json.get("profile")
             if requested_profile_id:
-                target_export_type = get_packet_profile(str(requested_profile_id)).export_type
+                target_export_type = get_packet_profile(
+                    str(requested_profile_id)
+                ).export_type
         if target_export_type is None:
             return self
 
@@ -343,14 +385,20 @@ class RetryExportRequest(BaseModel):
         self.options_json = {
             **defaults,
             "profile_id": requested_profile_id,
-            "include_media": bool(options.get("include_media", defaults["include_media"])),
+            "include_media": bool(
+                options.get("include_media", defaults["include_media"])
+            ),
             "include_raw_telemetry": bool(
                 options.get("include_raw_telemetry", defaults["include_raw_telemetry"])
             ),
             "include_driver_statement": bool(
-                options.get("include_driver_statement", defaults["include_driver_statement"])
+                options.get(
+                    "include_driver_statement", defaults["include_driver_statement"]
+                )
             ),
-            "inventory_mode": str(options.get("inventory_mode", defaults["inventory_mode"])),
+            "inventory_mode": str(
+                options.get("inventory_mode", defaults["inventory_mode"])
+            ),
         }
         return self
 
@@ -472,9 +520,9 @@ class DriverArtifactUploadUrlResponse(BaseModel):
 class DriverArtifactCompleteRequest(BaseModel):
     artifact_id: uuid.UUID
     byte_size: int = Field(gt=0)
-    sha256: Optional[Annotated[str, StringConstraints(min_length=16, max_length=128)]] = (
-        None
-    )
+    sha256: Optional[
+        Annotated[str, StringConstraints(min_length=16, max_length=128)]
+    ] = None
 
 
 class DriverArtifactCompleteResponse(BaseModel):
@@ -626,3 +674,27 @@ class RotateQrResponse(BaseModel):
 
 class QrPayloadResponse(BaseModel):
     deep_link: Annotated[str, StringConstraints(min_length=1, max_length=4096)]
+
+
+class JobExecutionMetaSummary(BaseModel):
+    failed: int = 0
+    retrying: int = 0
+    stuck: int = 0
+
+
+class JobExecutionMetaItem(BaseModel):
+    celery_task_id: str
+    task_name: str
+    task_type: str
+    status: Literal["queued", "running", "retrying", "failed", "succeeded", "stuck"]
+    retry_count: int = 0
+    max_retries: int | None = None
+    retry_category: str | None = None
+    should_retry: bool | None = None
+    next_retry_at_utc: datetime | None = None
+    started_at_utc: datetime | None = None
+    finished_at_utc: datetime | None = None
+    last_heartbeat_at_utc: datetime | None = None
+    last_error: str | None = None
+    created_at_utc: datetime | None = None
+    updated_at_utc: datetime | None = None

--- a/backend/app/db/migrations/versions/0016_add_job_execution_meta.py
+++ b/backend/app/db/migrations/versions/0016_add_job_execution_meta.py
@@ -1,0 +1,139 @@
+"""add job execution metadata table
+
+Revision ID: 0016
+Revises: 0015
+Create Date: 2026-04-08
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0016"
+down_revision: Union[str, None] = "0015"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    job_execution_status = sa.Enum(
+        "queued",
+        "running",
+        "retrying",
+        "failed",
+        "succeeded",
+        "stuck",
+        name="job_execution_status",
+    )
+    job_execution_status.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "job_execution_meta",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("celery_task_id", sa.Text(), nullable=False),
+        sa.Column("task_name", sa.Text(), nullable=False),
+        sa.Column("task_type", sa.Text(), nullable=False),
+        sa.Column(
+            "status",
+            job_execution_status,
+            nullable=False,
+            server_default="queued",
+        ),
+        sa.Column("retry_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("max_retries", sa.Integer(), nullable=True),
+        sa.Column("retry_category", sa.Text(), nullable=True),
+        sa.Column("should_retry", sa.Boolean(), nullable=True),
+        sa.Column(
+            "next_retry_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True
+        ),
+        sa.Column("started_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "finished_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True
+        ),
+        sa.Column(
+            "last_heartbeat_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True
+        ),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column(
+            "args_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "kwargs_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at_utc",
+            postgresql.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at_utc",
+            postgresql.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("celery_task_id"),
+    )
+
+    op.create_index(
+        "ix_job_execution_meta_celery_task_id",
+        "job_execution_meta",
+        ["celery_task_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_job_execution_meta_task_name",
+        "job_execution_meta",
+        ["task_name"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_job_execution_meta_task_type",
+        "job_execution_meta",
+        ["task_type"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_job_execution_meta_status", "job_execution_meta", ["status"], unique=False
+    )
+    op.create_index(
+        "ix_job_execution_meta_retry_category",
+        "job_execution_meta",
+        ["retry_category"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_job_execution_meta_retry_category", table_name="job_execution_meta"
+    )
+    op.drop_index("ix_job_execution_meta_status", table_name="job_execution_meta")
+    op.drop_index("ix_job_execution_meta_task_type", table_name="job_execution_meta")
+    op.drop_index("ix_job_execution_meta_task_name", table_name="job_execution_meta")
+    op.drop_index(
+        "ix_job_execution_meta_celery_task_id", table_name="job_execution_meta"
+    )
+    op.drop_table("job_execution_meta")
+
+    job_execution_status = sa.Enum(
+        "queued",
+        "running",
+        "retrying",
+        "failed",
+        "succeeded",
+        "stuck",
+        name="job_execution_status",
+    )
+    job_execution_status.drop(op.get_bind(), checkfirst=True)

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -119,7 +119,9 @@ class AuditEvent(Base):
     __tablename__ = "audit_events"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    org_id = Column(UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
     incident_id = Column(
         UUID(as_uuid=True),
         ForeignKey("incidents.incident_id"),
@@ -155,10 +157,30 @@ class AuditEvent(Base):
 
     __table_args__ = (
         Index("ix_audit_events_org_occurred", "org_id", "occurred_at_utc"),
-        Index("ix_audit_events_org_incident_occurred", "org_id", "incident_id", "occurred_at_utc"),
-        Index("ix_audit_events_org_export_occurred", "org_id", "export_id", "occurred_at_utc"),
-        Index("ix_audit_events_org_actor_occurred", "org_id", "actor_id", "occurred_at_utc"),
-        Index("ix_audit_events_org_event_type_occurred", "org_id", "event_type", "occurred_at_utc"),
+        Index(
+            "ix_audit_events_org_incident_occurred",
+            "org_id",
+            "incident_id",
+            "occurred_at_utc",
+        ),
+        Index(
+            "ix_audit_events_org_export_occurred",
+            "org_id",
+            "export_id",
+            "occurred_at_utc",
+        ),
+        Index(
+            "ix_audit_events_org_actor_occurred",
+            "org_id",
+            "actor_id",
+            "occurred_at_utc",
+        ),
+        Index(
+            "ix_audit_events_org_event_type_occurred",
+            "org_id",
+            "event_type",
+            "occurred_at_utc",
+        ),
     )
 
 
@@ -246,8 +268,15 @@ class Export(Base):
         default="court_defense",
         server_default="court_defense",
     )
-    profile_id = Column(Text, nullable=False, default="court_defense_v1", server_default="court_defense_v1")
-    requested_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    profile_id = Column(
+        Text,
+        nullable=False,
+        default="court_defense_v1",
+        server_default="court_defense_v1",
+    )
+    requested_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
     retry_parent_export_id = Column(
         UUID(as_uuid=True),
         ForeignKey("exports.export_id"),
@@ -271,7 +300,9 @@ class Export(Base):
     package_sha256 = Column(Text, nullable=True)
     byte_size = Column(BigInteger, nullable=True)
     artifact_count = Column(Integer, nullable=False, default=0, server_default="0")
-    timeline_event_count = Column(Integer, nullable=False, default=0, server_default="0")
+    timeline_event_count = Column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
     requested_at_utc = Column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
     )
@@ -284,7 +315,10 @@ class Export(Base):
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
     )
     updated_at_utc = Column(
-        TIMESTAMP(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
     )
 
     __table_args__ = (Index("ix_exports_org_incident", "org_id", "incident_id"),)
@@ -296,12 +330,20 @@ class SessionRecord(Base):
     __tablename__ = "sessions"
 
     session_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True, index=True)
-    org_id = Column(UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True)
+    user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True, index=True
+    )
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
+    )
     client_type = Column(Text, nullable=False)
     device_descriptor = Column(Text, nullable=True)
-    created_at = Column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
-    last_seen_at = Column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
+    created_at = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    last_seen_at = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
     revoked_at = Column(TIMESTAMP(timezone=True), nullable=True)
     refresh_family_id = Column(UUID(as_uuid=True), nullable=False, index=True)
 
@@ -312,15 +354,71 @@ class RefreshToken(Base):
     __tablename__ = "refresh_tokens"
 
     token_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    session_id = Column(UUID(as_uuid=True), ForeignKey("sessions.session_id"), nullable=False, index=True)
+    session_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("sessions.session_id"),
+        nullable=False,
+        index=True,
+    )
     refresh_family_id = Column(UUID(as_uuid=True), nullable=False, index=True)
-    parent_token_id = Column(UUID(as_uuid=True), ForeignKey("refresh_tokens.token_id"), nullable=True)
+    parent_token_id = Column(
+        UUID(as_uuid=True), ForeignKey("refresh_tokens.token_id"), nullable=True
+    )
     token_hash = Column(Text, nullable=False, unique=True, index=True)
-    issued_at = Column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
+    issued_at = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
     consumed_at = Column(TIMESTAMP(timezone=True), nullable=True)
     revoked_at = Column(TIMESTAMP(timezone=True), nullable=True)
     expires_at = Column(TIMESTAMP(timezone=True), nullable=False)
 
+
+class JobExecutionMeta(Base):
+    """Persistent per-task execution metadata for operations visibility."""
+
+    __tablename__ = "job_execution_meta"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    celery_task_id = Column(Text, nullable=False, unique=True, index=True)
+    task_name = Column(Text, nullable=False, index=True)
+    task_type = Column(Text, nullable=False, index=True)
+    status = Column(
+        Enum(
+            "queued",
+            "running",
+            "retrying",
+            "failed",
+            "succeeded",
+            "stuck",
+            name="job_execution_status",
+        ),
+        nullable=False,
+        default="queued",
+        server_default="queued",
+        index=True,
+    )
+    retry_count = Column(Integer, nullable=False, default=0, server_default="0")
+    max_retries = Column(Integer, nullable=True)
+    retry_category = Column(Text, nullable=True, index=True)
+    should_retry = Column(Boolean, nullable=True)
+    next_retry_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    started_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    finished_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    last_heartbeat_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    last_error = Column(Text, nullable=True)
+    args_json = Column(JSONB, nullable=False, default=list, server_default=text("'[]'"))
+    kwargs_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
 
 
 # ── Driver protocol models ────────────────────────────────────────────

--- a/backend/app/db/repo/job_execution_meta.py
+++ b/backend/app/db/repo/job_execution_meta.py
@@ -1,0 +1,197 @@
+"""Repository helpers for persistent job execution metadata."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from app.db.models import JobExecutionMeta
+from app.db.session import SessionLocal
+
+
+@contextmanager
+def _session_scope():
+    db = SessionLocal()
+    try:
+        yield db
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+def upsert_job_execution_meta(
+    *,
+    task_id: str,
+    task_name: str,
+    task_type: str,
+    status: str,
+    retry_count: int | None = None,
+    max_retries: int | None = None,
+    retry_category: str | None = None,
+    should_retry: bool | None = None,
+    next_retry_at_utc: datetime | None = None,
+    started_at_utc: datetime | None = None,
+    finished_at_utc: datetime | None = None,
+    last_heartbeat_at_utc: datetime | None = None,
+    last_error: str | None = None,
+    args_json: list[Any] | None = None,
+    kwargs_json: dict[str, Any] | None = None,
+) -> JobExecutionMeta:
+    with _session_scope() as db:
+        return upsert_job_execution_meta_with_db(
+            db=db,
+            task_id=task_id,
+            task_name=task_name,
+            task_type=task_type,
+            status=status,
+            retry_count=retry_count,
+            max_retries=max_retries,
+            retry_category=retry_category,
+            should_retry=should_retry,
+            next_retry_at_utc=next_retry_at_utc,
+            started_at_utc=started_at_utc,
+            finished_at_utc=finished_at_utc,
+            last_heartbeat_at_utc=last_heartbeat_at_utc,
+            last_error=last_error,
+            args_json=args_json,
+            kwargs_json=kwargs_json,
+        )
+
+
+def upsert_job_execution_meta_with_db(
+    *,
+    db,
+    task_id: str,
+    task_name: str,
+    task_type: str,
+    status: str,
+    retry_count: int | None = None,
+    max_retries: int | None = None,
+    retry_category: str | None = None,
+    should_retry: bool | None = None,
+    next_retry_at_utc: datetime | None = None,
+    started_at_utc: datetime | None = None,
+    finished_at_utc: datetime | None = None,
+    last_heartbeat_at_utc: datetime | None = None,
+    last_error: str | None = None,
+    args_json: list[Any] | None = None,
+    kwargs_json: dict[str, Any] | None = None,
+) -> JobExecutionMeta:
+    row = (
+        db.query(JobExecutionMeta)
+        .filter(JobExecutionMeta.celery_task_id == task_id)
+        .with_for_update()
+        .first()
+    )
+    if row is None:
+        row = JobExecutionMeta(
+            celery_task_id=task_id,
+            task_name=task_name,
+            task_type=task_type,
+            status=status,
+            retry_count=retry_count or 0,
+            max_retries=max_retries,
+            retry_category=retry_category,
+            should_retry=bool(should_retry) if should_retry is not None else None,
+            next_retry_at_utc=next_retry_at_utc,
+            started_at_utc=started_at_utc,
+            finished_at_utc=finished_at_utc,
+            last_heartbeat_at_utc=last_heartbeat_at_utc,
+            last_error=last_error,
+            args_json=args_json or [],
+            kwargs_json=kwargs_json or {},
+        )
+        db.add(row)
+        db.flush()
+        db.refresh(row)
+        return row
+
+    row.task_name = task_name
+    row.task_type = task_type
+    row.status = status
+    if retry_count is not None:
+        row.retry_count = retry_count
+    if max_retries is not None:
+        row.max_retries = max_retries
+    if retry_category is not None:
+        row.retry_category = retry_category
+    if should_retry is not None:
+        row.should_retry = should_retry
+    if next_retry_at_utc is not None or status != "retrying":
+        row.next_retry_at_utc = next_retry_at_utc
+    if started_at_utc is not None:
+        row.started_at_utc = started_at_utc
+    if finished_at_utc is not None:
+        row.finished_at_utc = finished_at_utc
+    if last_heartbeat_at_utc is not None:
+        row.last_heartbeat_at_utc = last_heartbeat_at_utc
+    if last_error is not None or status == "succeeded":
+        row.last_error = last_error
+    if args_json is not None:
+        row.args_json = args_json
+    if kwargs_json is not None:
+        row.kwargs_json = kwargs_json
+    db.flush()
+    db.refresh(row)
+    return row
+
+
+def list_ops_jobs(
+    *, statuses: set[str], stale_after_minutes: int = 15
+) -> list[JobExecutionMeta]:
+    with _session_scope() as db:
+        return list_ops_jobs_with_db(
+            db=db, statuses=statuses, stale_after_minutes=stale_after_minutes
+        )
+
+
+def list_ops_jobs_with_db(
+    *, db, statuses: set[str], stale_after_minutes: int = 15
+) -> list[JobExecutionMeta]:
+    rows = (
+        db.query(JobExecutionMeta).filter(JobExecutionMeta.status.in_(statuses)).all()
+    )
+    stale_threshold = datetime.now(timezone.utc) - timedelta(
+        minutes=stale_after_minutes
+    )
+    for row in rows:
+        if (
+            row.status in {"queued", "running", "retrying"}
+            and row.last_heartbeat_at_utc
+        ):
+            heartbeat = row.last_heartbeat_at_utc
+            if heartbeat.tzinfo is None:
+                heartbeat = heartbeat.replace(tzinfo=timezone.utc)
+            if heartbeat < stale_threshold:
+                row.status = "stuck"
+                db.flush()
+    return (
+        db.query(JobExecutionMeta)
+        .filter(JobExecutionMeta.status.in_(statuses | {"stuck"}))
+        .order_by(JobExecutionMeta.updated_at_utc.desc())
+        .all()
+    )
+
+
+def summarize_ops_jobs(*, stale_after_minutes: int = 15) -> dict[str, int]:
+    with _session_scope() as db:
+        return summarize_ops_jobs_with_db(
+            db=db, stale_after_minutes=stale_after_minutes
+        )
+
+
+def summarize_ops_jobs_with_db(*, db, stale_after_minutes: int = 15) -> dict[str, int]:
+    rows = list_ops_jobs_with_db(
+        db=db,
+        statuses={"failed", "retrying", "running", "queued"},
+        stale_after_minutes=stale_after_minutes,
+    )
+    summary = {"failed": 0, "retrying": 0, "stuck": 0}
+    for row in rows:
+        if row.status in summary:
+            summary[row.status] += 1
+    return summary

--- a/backend/app/jobs/__init__.py
+++ b/backend/app/jobs/__init__.py
@@ -1,0 +1,1 @@
+"""Job tracking and retry policy package."""

--- a/backend/app/jobs/retry_policy.py
+++ b/backend/app/jobs/retry_policy.py
@@ -1,0 +1,87 @@
+"""Retry classification and policy decisions for Celery jobs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import httpx
+
+RetryCategory = Literal[
+    "transient_dependency",
+    "internal_processing_error",
+    "optional_artifact_inclusion_failure",
+]
+TaskType = Literal["export_tasks", "evidence_tasks", "notification_tasks", "unknown"]
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """Policy controls for a job task class."""
+
+    max_retries: int
+    retryable_categories: frozenset[RetryCategory]
+
+
+TASK_TYPE_POLICY: dict[TaskType, RetryPolicy] = {
+    "export_tasks": RetryPolicy(
+        max_retries=3,
+        retryable_categories=frozenset(
+            {"transient_dependency", "internal_processing_error"}
+        ),
+    ),
+    "evidence_tasks": RetryPolicy(
+        max_retries=3,
+        retryable_categories=frozenset(
+            {"transient_dependency", "internal_processing_error"}
+        ),
+    ),
+    "notification_tasks": RetryPolicy(
+        max_retries=2,
+        retryable_categories=frozenset({"transient_dependency"}),
+    ),
+    "unknown": RetryPolicy(
+        max_retries=0,
+        retryable_categories=frozenset(),
+    ),
+}
+
+
+def resolve_task_type(task_name: str) -> TaskType:
+    """Map a fully qualified Celery task name to a tracked task class."""
+    if ".export_tasks." in task_name:
+        return "export_tasks"
+    if ".evidence_tasks." in task_name:
+        return "evidence_tasks"
+    if ".notification_tasks." in task_name or ".notify_tasks." in task_name:
+        return "notification_tasks"
+    return "unknown"
+
+
+def classify_retry_exception(exc: BaseException) -> RetryCategory:
+    """Classify task exception into an operational retry category."""
+    message = str(exc).lower()
+
+    if isinstance(exc, (httpx.HTTPError, TimeoutError, ConnectionError, OSError)):
+        return "transient_dependency"
+
+    optional_markers = (
+        "optional artifact",
+        "artifact_missing_from_s3",
+        "extension_not_allowed",
+        "artifact skipped",
+    )
+    if any(marker in message for marker in optional_markers):
+        return "optional_artifact_inclusion_failure"
+
+    return "internal_processing_error"
+
+
+def should_retry(
+    task_type: TaskType, category: RetryCategory, retry_count: int
+) -> bool:
+    """Return whether the policy allows an additional retry attempt."""
+    policy = TASK_TYPE_POLICY.get(task_type, TASK_TYPE_POLICY["unknown"])
+    if category not in policy.retryable_categories:
+        return False
+    return retry_count < policy.max_retries

--- a/backend/app/jobs/tracking.py
+++ b/backend/app/jobs/tracking.py
@@ -1,0 +1,114 @@
+"""Persistent Celery job execution metadata tracking."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from app.db.repo.job_execution_meta import upsert_job_execution_meta
+from app.jobs.retry_policy import (
+    classify_retry_exception,
+    resolve_task_type,
+    should_retry,
+)
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def record_task_queued(
+    *,
+    task_name: str,
+    task_id: str,
+    args: list[Any] | None,
+    kwargs: dict[str, Any] | None,
+) -> None:
+    upsert_job_execution_meta(
+        task_id=task_id,
+        task_name=task_name,
+        task_type=resolve_task_type(task_name),
+        status="queued",
+        args_json=args or [],
+        kwargs_json=kwargs or {},
+        last_heartbeat_at_utc=utc_now(),
+    )
+
+
+def record_task_started(*, task_name: str, task_id: str, max_retries: int) -> None:
+    upsert_job_execution_meta(
+        task_id=task_id,
+        task_name=task_name,
+        task_type=resolve_task_type(task_name),
+        status="running",
+        max_retries=max_retries,
+        started_at_utc=utc_now(),
+        last_heartbeat_at_utc=utc_now(),
+    )
+
+
+def record_task_retrying(
+    *,
+    task_name: str,
+    task_id: str,
+    retry_count: int,
+    max_retries: int,
+    exception: BaseException,
+) -> None:
+    task_type = resolve_task_type(task_name)
+    category = classify_retry_exception(exception)
+    will_retry = should_retry(task_type, category, retry_count)
+    status = "retrying" if will_retry else "failed"
+    next_retry = utc_now() + timedelta(seconds=30) if will_retry else None
+    upsert_job_execution_meta(
+        task_id=task_id,
+        task_name=task_name,
+        task_type=task_type,
+        status=status,
+        retry_count=retry_count,
+        max_retries=max_retries,
+        retry_category=category,
+        should_retry=will_retry,
+        next_retry_at_utc=next_retry,
+        last_error=str(exception),
+        last_heartbeat_at_utc=utc_now(),
+        finished_at_utc=utc_now() if not will_retry else None,
+    )
+
+
+def record_task_failed(
+    *,
+    task_name: str,
+    task_id: str,
+    retry_count: int,
+    max_retries: int,
+    exception: BaseException,
+) -> None:
+    task_type = resolve_task_type(task_name)
+    category = classify_retry_exception(exception)
+    upsert_job_execution_meta(
+        task_id=task_id,
+        task_name=task_name,
+        task_type=task_type,
+        status="failed",
+        retry_count=retry_count,
+        max_retries=max_retries,
+        retry_category=category,
+        should_retry=False,
+        last_error=str(exception),
+        finished_at_utc=utc_now(),
+        last_heartbeat_at_utc=utc_now(),
+    )
+
+
+def record_task_succeeded(*, task_name: str, task_id: str) -> None:
+    upsert_job_execution_meta(
+        task_id=task_id,
+        task_name=task_name,
+        task_type=resolve_task_type(task_name),
+        status="succeeded",
+        should_retry=False,
+        finished_at_utc=utc_now(),
+        last_heartbeat_at_utc=utc_now(),
+        last_error=None,
+    )

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -3,7 +3,14 @@
 import logging
 
 from celery import Celery
-from celery.signals import before_task_publish, task_failure, task_postrun, task_prerun, worker_process_init
+from celery.signals import (
+    before_task_publish,
+    task_failure,
+    task_postrun,
+    task_prerun,
+    task_retry,
+    worker_process_init,
+)
 
 from app.core.config import settings
 from app.observability.alerts import init_sentry
@@ -16,6 +23,13 @@ from app.observability.tracing import (
     inject_correlation_headers,
     set_actor_context,
     set_correlation_id,
+)
+from app.jobs.tracking import (
+    record_task_failed,
+    record_task_queued,
+    record_task_retrying,
+    record_task_started,
+    record_task_succeeded,
 )
 
 logger = logging.getLogger(__name__)
@@ -89,6 +103,10 @@ def _on_before_task_publish(headers=None, **_kwargs):
     if headers is None:
         return
     headers.update(inject_correlation_headers(headers))
+    task_name = headers.get("task")
+    task_id = headers.get("id")
+    if task_name and task_id:
+        record_task_queued(task_name=task_name, task_id=task_id, args=None, kwargs=None)
 
 
 @task_prerun.connect
@@ -100,6 +118,12 @@ def _on_task_prerun(*_, task=None, **__):
         user_id=extracted.get(USER_ID_HEADER) or None,
         org_id=extracted.get(ORG_ID_HEADER) or None,
     )
+    if task is not None:
+        record_task_started(
+            task_name=task.name,
+            task_id=task.request.id,
+            max_retries=getattr(task, "max_retries", 0) or 0,
+        )
     increment(MetricNames.CELERY_TASK_STARTED)
 
 
@@ -108,9 +132,54 @@ def _on_task_failure(*_, **__):
     increment(MetricNames.CELERY_TASK_FAILURES)
 
 
+@task_retry.connect
+def _on_task_retry(request=None, reason=None, sender=None, **_kwargs):
+    if sender is None or request is None or not request.id:
+        return
+    record_task_retrying(
+        task_name=sender.name,
+        task_id=request.id,
+        retry_count=getattr(request, "retries", 0) or 0,
+        max_retries=getattr(sender, "max_retries", 0) or 0,
+        exception=reason
+        if isinstance(reason, BaseException)
+        else RuntimeError(str(reason)),
+    )
+
+
 @task_postrun.connect
 def _on_task_postrun(*_, **__):
     clear_context()
+
+
+@task_failure.connect
+def persist_terminal_failure(
+    sender=None,
+    task_id=None,
+    exception=None,
+    **_kwargs,
+):
+    if sender is None or not task_id or exception is None:
+        return
+    max_retries = getattr(sender, "max_retries", 0) or 0
+    current_retries = getattr(getattr(sender, "request", None), "retries", 0) or 0
+    if current_retries < max_retries:
+        return
+    record_task_failed(
+        task_name=sender.name,
+        task_id=task_id,
+        retry_count=current_retries,
+        max_retries=max_retries,
+        exception=exception,
+    )
+
+
+@task_postrun.connect
+def persist_task_success(sender=None, task_id=None, state=None, **_kwargs):
+    if sender is None or not task_id:
+        return
+    if state == "SUCCESS":
+        record_task_succeeded(task_name=sender.name, task_id=task_id)
 
 
 @celery_app.task

--- a/backend/tests/test_driver_admin_endpoints.py
+++ b/backend/tests/test_driver_admin_endpoints.py
@@ -1,6 +1,7 @@
 """Tests for driver and admin endpoints."""
 
 import hashlib
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -18,6 +19,7 @@ from app.db.models import (
     DriverVehicleAssignment,
     Event,
     Incident,
+    JobExecutionMeta,
     Org,
     User,
     UserOrg,
@@ -394,12 +396,8 @@ class TestDriverInitiate:
         incident = db_session.query(Incident).first()
         assert incident is not None
         assert incident.adc_vehicle_id == "veh-100"
-        mock_dash.delay.assert_called_once_with(
-            str(incident.incident_id), None, None
-        )
-        mock_tele.delay.assert_called_once_with(
-            str(incident.incident_id), None, None
-        )
+        mock_dash.delay.assert_called_once_with(str(incident.incident_id), None, None)
+        mock_tele.delay.assert_called_once_with(str(incident.incident_id), None, None)
         mock_notify_manager.delay.assert_called_once_with(str(incident.incident_id))
 
         events = (
@@ -437,12 +435,8 @@ class TestDriverInitiate:
         assert resp.status_code == 200
         incident = db_session.query(Incident).first()
         assert incident.adc_vehicle_id == "veh-200"
-        mock_dash.delay.assert_called_once_with(
-            str(incident.incident_id), None, None
-        )
-        mock_tele.delay.assert_called_once_with(
-            str(incident.incident_id), None, None
-        )
+        mock_dash.delay.assert_called_once_with(str(incident.incident_id), None, None)
+        mock_tele.delay.assert_called_once_with(str(incident.incident_id), None, None)
         mock_notify_manager.delay.assert_called_once_with(str(incident.incident_id))
 
     @patch("app.api.routes_driver.notify_safety_manager")
@@ -531,8 +525,6 @@ class TestDriverInitiate:
         assert resp.status_code == 200
         assert resp.json()["incident_id"] == str(existing.incident_id)
         assert db_session.query(Incident).count() == 1
-
-
 
 
 # ── GET /driver/instructions/active ─────────────────────────────────
@@ -805,7 +797,6 @@ class TestDriverActiveIncidentAndStatus:
         assert resp.status_code == 404
 
 
-
 # ── GET /admin/vehicles/{vehicle_id}/qr ─────────────────────────────
 
 
@@ -864,7 +855,11 @@ class TestDriverProtocolSettings:
         db_session.refresh(test_org)
         assert test_org.instruction_source == "company"
         assert test_org.require_driver_ack is True
-        audit = db_session.query(AuditEvent).filter(AuditEvent.event_type == "config_updated").first()
+        audit = (
+            db_session.query(AuditEvent)
+            .filter(AuditEvent.event_type == "config_updated")
+            .first()
+        )
         assert audit is not None
         assert audit.outcome == "success"
 
@@ -938,3 +933,56 @@ class TestAdminVehiclesList:
         assert resp.status_code == 200
         data = resp.json()
         assert any(vehicle["adc_vehicle_id"] == "veh-101" for vehicle in data)
+
+
+class TestAdminOpsJobs:
+    def test_ops_jobs_summary_and_list(self, client, admin_headers, db_session):
+        retrying = JobExecutionMeta(
+            celery_task_id="task-retrying",
+            task_name="app.tasks.export_tasks.build_export",
+            task_type="export_tasks",
+            status="retrying",
+            retry_count=1,
+            max_retries=3,
+            retry_category="transient_dependency",
+            should_retry=True,
+            last_heartbeat_at_utc=datetime.now(timezone.utc),
+        )
+        failed = JobExecutionMeta(
+            celery_task_id="task-failed",
+            task_name="app.tasks.notification_tasks.notify_safety_manager",
+            task_type="notification_tasks",
+            status="failed",
+            retry_count=2,
+            max_retries=2,
+            retry_category="internal_processing_error",
+            should_retry=False,
+            last_error="Twilio timeout",
+            last_heartbeat_at_utc=datetime.now(timezone.utc),
+        )
+        stale = JobExecutionMeta(
+            celery_task_id="task-stale",
+            task_name="app.tasks.evidence_tasks.capture_dashcam",
+            task_type="evidence_tasks",
+            status="running",
+            retry_count=0,
+            max_retries=3,
+            last_heartbeat_at_utc=datetime.now(timezone.utc) - timedelta(minutes=90),
+        )
+        db_session.add_all([retrying, failed, stale])
+        db_session.commit()
+
+        summary_resp = client.get("/admin/ops/jobs/summary", headers=admin_headers)
+        assert summary_resp.status_code == 200
+        summary = summary_resp.json()
+        assert summary["failed"] == 1
+        assert summary["retrying"] == 1
+        assert summary["stuck"] == 1
+
+        list_resp = client.get("/admin/ops/jobs", headers=admin_headers)
+        assert list_resp.status_code == 200
+        payload = list_resp.json()
+        statuses = {item["status"] for item in payload}
+        assert "failed" in statuses
+        assert "retrying" in statuses
+        assert "stuck" in statuses

--- a/backend/tests/test_job_retry_policy.py
+++ b/backend/tests/test_job_retry_policy.py
@@ -1,0 +1,41 @@
+"""Tests for job retry categorization and policy behavior."""
+
+import httpx
+
+from app.jobs.retry_policy import (
+    classify_retry_exception,
+    resolve_task_type,
+    should_retry,
+)
+
+
+def test_resolve_task_type_from_name() -> None:
+    assert resolve_task_type("app.tasks.export_tasks.build_export") == "export_tasks"
+    assert (
+        resolve_task_type("app.tasks.evidence_tasks.capture_dashcam")
+        == "evidence_tasks"
+    )
+    assert (
+        resolve_task_type("app.tasks.notification_tasks.notify_safety_manager")
+        == "notification_tasks"
+    )
+
+
+def test_classify_retry_exception_transient_dependency() -> None:
+    exc = httpx.ReadTimeout("provider timed out")
+    assert classify_retry_exception(exc) == "transient_dependency"
+
+
+def test_classify_retry_exception_optional_artifact_failure() -> None:
+    exc = RuntimeError("Optional artifact skipped due to extension_not_allowed")
+    assert classify_retry_exception(exc) == "optional_artifact_inclusion_failure"
+
+
+def test_should_retry_policy_enforced_per_task_type() -> None:
+    assert should_retry("notification_tasks", "transient_dependency", retry_count=1)
+    assert not should_retry(
+        "notification_tasks", "internal_processing_error", retry_count=1
+    )
+    assert not should_retry(
+        "export_tasks", "optional_artifact_inclusion_failure", retry_count=0
+    )


### PR DESCRIPTION
### Motivation

- Provide durable visibility into Celery job state and failures for the operations console by persisting per-task execution metadata. 
- Classify retries to avoid blind autoretry for non-retryable conditions and to apply different policies per task class (exports, evidence, notifications). 
- Surface failed/retrying/stuck work to the admin frontend so ops can inspect and act on in-flight or terminal failures.

### Description

- Added a new SQLAlchemy model `JobExecutionMeta` and Alembic migration `0016` to store per-task lifecycle state, retry metadata, heartbeat timestamps, errors, args/kwargs JSON, and created/updated timestamps (`backend/app/db/models.py`, `backend/app/db/migrations/versions/0016_add_job_execution_meta.py`).
- Implemented a retry classification and policy module (`backend/app/jobs/retry_policy.py`) that classifies exceptions into `transient_dependency`, `internal_processing_error`, and `optional_artifact_inclusion_failure` and applies a per-task-type `RetryPolicy` for `export_tasks`, `evidence_tasks`, and `notification_tasks`.
- Implemented persistent lifecycle tracking helpers (`backend/app/jobs/tracking.py`) and repository helpers (`backend/app/db/repo/job_execution_meta.py`) with an upsert flow and heartbeat-based stale detection that promotes old running/queued/retrying rows to `stuck`.
- Wired tracking into Celery lifecycle via signal handlers in `backend/app/tasks/celery_app.py` to record queued/started/retrying/failed/succeeded transitions and to persist terminal failures when retries are exhausted.
- Exposed two admin ops API endpoints with authz and Pydantic schemas: `GET /admin/ops/jobs/summary` and `GET /admin/ops/jobs` to return counts and detailed rows for failed/retrying/stuck jobs (`backend/app/api/routes_admin.py`, `backend/app/api/schemas.py`).
- Added tests covering retry classification/policy and the admin ops endpoints (`backend/tests/test_job_retry_policy.py`, extended `backend/tests/test_driver_admin_endpoints.py`).

### Testing

- Ran linter/format checks with `cd backend && ruff check ...` and `ruff format` as part of development; linter checks passed for the modified files. 
- Ran unit tests: `cd backend && pytest tests/test_job_retry_policy.py tests/test_driver_admin_endpoints.py -q` and all tests passed locally (42 passed, 3 warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5b6df85808321843482386c62942b)