### PR TITLE
Add dependency-aware health endpoints and Kubernetes probe checks

### DIFF
--- a/backend/app/health/checks.py
+++ b/backend/app/health/checks.py
@@ -1,0 +1,74 @@
+"""Dependency checks used by health endpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import redis
+from sqlalchemy import text
+
+from app.api.routes_driver_auth import _get_redis_client
+from app.core.config import settings
+from app.db.session import engine
+
+
+@dataclass(slots=True)
+class CheckResult:
+    """Normalized health check result payload."""
+
+    ok: bool
+    detail: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"ok": self.ok, "detail": self.detail}
+
+
+def check_database() -> CheckResult:
+    """Validate that the database can accept simple queries."""
+
+    try:
+        with engine.connect() as connection:
+            connection.execute(text("SELECT 1"))
+        return CheckResult(ok=True, detail="reachable")
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return CheckResult(ok=False, detail=f"{type(exc).__name__}: {exc}")
+
+
+def check_redis() -> CheckResult:
+    """Validate Redis availability used by driver OTP rate limiting."""
+
+    try:
+        client = _get_redis_client()
+        if client.ping():
+            return CheckResult(ok=True, detail="reachable")
+        return CheckResult(ok=False, detail="ping returned false")
+    except (redis.RedisError, OSError) as exc:
+        return CheckResult(ok=False, detail=f"{type(exc).__name__}: {exc}")
+
+
+def check_storage(deep: bool = False) -> CheckResult:
+    """Optional storage deep check for debugging readiness issues."""
+
+    if not deep:
+        return CheckResult(ok=True, detail="skipped")
+
+    backend = settings.STORAGE_BACKEND.strip().lower()
+    if backend == "filesystem":
+        root = Path(settings.VAULT_ROOT)
+        try:
+            root.mkdir(parents=True, exist_ok=True)
+            probe = root / ".healthcheck"
+            probe.write_bytes(b"ok")
+            probe.unlink(missing_ok=True)
+            return CheckResult(ok=True, detail="filesystem writable")
+        except OSError as exc:
+            return CheckResult(ok=False, detail=f"{type(exc).__name__}: {exc}")
+
+    if backend == "s3":
+        if not settings.S3_ARTIFACTS_BUCKET.strip() or not settings.S3_EXPORTS_BUCKET.strip():
+            return CheckResult(ok=False, detail="missing required S3 bucket configuration")
+        return CheckResult(ok=True, detail="s3 buckets configured")
+
+    return CheckResult(ok=False, detail=f"unsupported storage backend: {backend}")

--- a/backend/app/health/routes.py
+++ b/backend/app/health/routes.py
@@ -1,0 +1,47 @@
+"""Health endpoints for liveness/readiness probes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Query, status
+from fastapi.responses import JSONResponse
+
+from app.health.checks import check_database, check_redis, check_storage
+
+router = APIRouter(prefix="/health", tags=["health"])
+
+
+@router.get("")
+async def health_check() -> JSONResponse:
+    """Compatibility health endpoint returning readiness semantics."""
+
+    return await readiness_check()
+
+
+@router.get("/live")
+async def liveness_check() -> dict[str, str]:
+    """Kubernetes liveness probe: process is running."""
+
+    return {"status": "ok"}
+
+
+@router.get("/ready")
+async def readiness_check(
+    deep_storage: bool = Query(False, description="Perform optional storage deep check."),
+) -> JSONResponse:
+    """Kubernetes readiness probe: critical traffic dependencies are healthy."""
+
+    db = check_database()
+    redis = check_redis()
+    storage = check_storage(deep=deep_storage)
+
+    ready = db.ok and redis.ok and storage.ok
+    payload = {
+        "status": "ok" if ready else "fail",
+        "checks": {
+            "database": db.as_dict(),
+            "redis": redis.as_dict(),
+            "storage": storage.as_dict(),
+        },
+    }
+    status_code = status.HTTP_200_OK if ready else status.HTTP_503_SERVICE_UNAVAILABLE
+    return JSONResponse(content=payload, status_code=status_code)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from app.api.routes.routes_driver_artifacts import router as driver_artifacts_ro
 from app.api.routes.routes_driver_report import router as driver_report_router
 from app.api.routes_admin import router as admin_router
 from app.api.routes_twilio import router as twilio_router
+from app.health.routes import router as health_router
 from app.core.config import settings
 from app.config.validation import validate_startup_config
 from app.observability.alerts import init_sentry
@@ -41,11 +42,7 @@ app.include_router(driver_artifacts_router, prefix="/driver", tags=["driver-arti
 app.include_router(driver_report_router, prefix="/driver", tags=["driver-report"])
 app.include_router(admin_router, prefix="/admin", tags=["admin"])
 app.include_router(twilio_router, prefix="/twilio", tags=["twilio"])
-
-
-@app.get("/health")
-async def health_check():
-    return {"status": "ok"}
+app.include_router(health_router)
 
 
 @app.on_event("startup")

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -1359,6 +1359,6 @@ class TestListExports:
 
 class TestHealth:
     def test_health(self, client):
-        resp = client.get("/health")
+        resp = client.get("/health/live")
         assert resp.status_code == 200
         assert resp.json() == {"status": "ok"}

--- a/backend/tests/test_health_routes.py
+++ b/backend/tests/test_health_routes.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_liveness_is_up() -> None:
+    client = TestClient(app)
+
+    response = client.get("/health/live")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_readiness_healthy_dependencies(monkeypatch) -> None:
+    from app.health import routes
+    from app.health.checks import CheckResult
+
+    client = TestClient(app)
+    monkeypatch.setattr(routes, "check_database", lambda: CheckResult(ok=True, detail="reachable"))
+    monkeypatch.setattr(routes, "check_redis", lambda: CheckResult(ok=True, detail="reachable"))
+    monkeypatch.setattr(
+        routes,
+        "check_storage",
+        lambda deep=False: CheckResult(ok=True, detail="skipped" if not deep else "ok"),
+    )
+
+    response = client.get("/health/ready")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["checks"]["database"]["ok"] is True
+    assert body["checks"]["redis"]["ok"] is True
+
+
+def test_readiness_returns_503_when_meaningful_traffic_cannot_be_served(monkeypatch) -> None:
+    from app.health import routes
+    from app.health.checks import CheckResult
+
+    client = TestClient(app)
+    monkeypatch.setattr(
+        routes,
+        "check_database",
+        lambda: CheckResult(ok=False, detail="OperationalError: db unavailable"),
+    )
+    monkeypatch.setattr(routes, "check_redis", lambda: CheckResult(ok=True, detail="reachable"))
+    monkeypatch.setattr(routes, "check_storage", lambda deep=False: CheckResult(ok=True, detail="skipped"))
+
+    response = client.get("/health/ready")
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "fail"
+    assert body["checks"]["database"]["ok"] is False
+
+
+def test_health_root_uses_readiness_semantics(monkeypatch) -> None:
+    from app.health import routes
+    from app.health.checks import CheckResult
+
+    client = TestClient(app)
+    monkeypatch.setattr(routes, "check_database", lambda: CheckResult(ok=True, detail="reachable"))
+    monkeypatch.setattr(routes, "check_redis", lambda: CheckResult(ok=False, detail="redis unavailable"))
+    monkeypatch.setattr(routes, "check_storage", lambda deep=False: CheckResult(ok=True, detail="skipped"))
+
+    response = client.get("/health")
+
+    assert response.status_code == 503
+    assert response.json()["status"] == "fail"
+
+
+def test_readiness_optional_storage_deep_check(monkeypatch) -> None:
+    from app.health import routes
+    from app.health.checks import CheckResult
+
+    client = TestClient(app)
+    monkeypatch.setattr(routes, "check_database", lambda: CheckResult(ok=True, detail="reachable"))
+    monkeypatch.setattr(routes, "check_redis", lambda: CheckResult(ok=True, detail="reachable"))
+
+    observed = {"deep": False}
+
+    def _check_storage(deep: bool = False) -> CheckResult:
+        observed["deep"] = deep
+        return CheckResult(ok=True, detail="ok")
+
+    monkeypatch.setattr(routes, "check_storage", _check_storage)
+
+    response = client.get("/health/ready?deep_storage=true")
+
+    assert response.status_code == 200
+    assert observed["deep"] is True

--- a/backend/tests/test_kubernetes_health_probes.py
+++ b/backend/tests/test_kubernetes_health_probes.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+MANIFEST_PATH = Path(__file__).resolve().parents[2] / "infra/production/backend-deployment.yaml"
+
+
+def _app_deployment_manifest() -> str:
+    content = MANIFEST_PATH.read_text()
+    first_doc = content.split("\n---\n", maxsplit=1)[0]
+    return first_doc
+
+
+def test_kubernetes_liveness_probe_matches_health_live_endpoint() -> None:
+    manifest = _app_deployment_manifest()
+
+    assert "livenessProbe:" in manifest
+    assert "path: /health/live" in manifest
+
+
+def test_kubernetes_readiness_probe_matches_health_ready_endpoint() -> None:
+    manifest = _app_deployment_manifest()
+
+    assert "readinessProbe:" in manifest
+    assert "path: /health/ready" in manifest

--- a/infra/production/backend-deployment.yaml
+++ b/infra/production/backend-deployment.yaml
@@ -19,6 +19,22 @@ spec:
           image: ghcr.io/your-org/adc-backend:latest
           ports:
             - containerPort: 8000
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
           env:
             - name: APP_ENV
               value: prod


### PR DESCRIPTION
### Motivation
- Make the service readiness reflect real trafficability by verifying critical dependencies (DB and Redis) instead of always returning OK.
- Provide an optional deep storage probe for debugging storage-related readiness issues.
- Ensure Kubernetes liveness/readiness probes point at distinct endpoints with clear semantics so k8s behaviour matches application health.

### Description
- Add `backend/app/health/checks.py` with `check_database()`, `check_redis()`, and `check_storage(deep: bool)` and a `CheckResult` payload type.
- Add `backend/app/health/routes.py` exposing `/health/live` (liveness), `/health/ready` (readiness returning `503` when dependencies fail), and make `/health` use readiness semantics.
- Wire the health router into `backend/app/main.py` so the new endpoints are included in the FastAPI app.
- Update `infra/production/backend-deployment.yaml` to add `livenessProbe` -> `/health/live` and `readinessProbe` -> `/health/ready`.
- Add tests: `backend/tests/test_health_routes.py` (healthy/unhealthy dependency paths and optional deep storage), `backend/tests/test_kubernetes_health_probes.py` (manifest probe path alignment), and update the existing API health test to use liveness at `/health/live`.

### Testing
- Ran `cd backend && pytest tests/test_health_routes.py tests/test_kubernetes_health_probes.py tests/test_api_endpoints.py -k health` and all selected tests passed (`8 passed, 55 deselected`).
- Ran linter checks with `cd backend && ruff check app tests` and the lint check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5b9687a408321b0239fc170cfe627)