### PR TITLE
Add backup/DR docs and infra manifests for automated Postgres backups and object storage policies

### DIFF
--- a/docs/operations/backup-dr/README.md
+++ b/docs/operations/backup-dr/README.md
@@ -1,0 +1,54 @@
+# Backup & Disaster Recovery (DR) Operations
+
+## Scope
+
+This package defines production backup automation requirements, disaster recovery objectives, and operator playbooks for:
+
+- PostgreSQL backup and point-in-time restore.
+- Object storage versioning/lifecycle controls.
+- Secrets/configuration recovery.
+- DNS/ingress recovery.
+- Third-party/key dependency outage response.
+
+Use this directory with `infra/production/postgres-backup-cronjob.yaml` and `infra/production/object-storage-policies.yaml`.
+
+## Explicit service targets (RPO/RTO)
+
+| System | RPO target | RTO target | Owner |
+| --- | --- | --- | --- |
+| PostgreSQL (primary transactional DB) | <= 15 minutes | <= 60 minutes | Backend + Platform on-call |
+| Artifact object storage | <= 15 minutes | <= 120 minutes | Platform on-call |
+| Runtime secrets/configuration | <= 60 minutes | <= 45 minutes | Security + Platform on-call |
+| DNS + ingress routing | N/A (control-plane) | <= 30 minutes | Platform on-call |
+
+### Target interpretation
+
+- **RPO** is measured by the age of last recoverable write.
+- **RTO** is measured from incident declaration to first successful customer write/read in production.
+- Missing an RPO/RTO target requires a Sev-1 escalation and retrospective corrective action within 30 days.
+
+## Backup retention policy
+
+- **PostgreSQL full backups:** daily, retain 35 days.
+- **PostgreSQL weekly checkpoints:** retain 12 weeks.
+- **PostgreSQL monthly checkpoints:** retain 12 months.
+- **WAL archive segments:** retain 35 days minimum (to support PITR across full backup windows).
+- **Object storage current versions:** retained per product/legal policy.
+- **Object storage non-current versions:** retain 90 days minimum.
+- **Object storage deleted-marker cleanup:** purge after 30 days to limit orphaned version metadata.
+
+## Non-production restore validation drills
+
+- Run restore drills at least **quarterly** in non-production.
+- Use the restore checklist in `restore-validation-checklist.md`.
+- Persist drill evidence (timestamps, query outputs, object checksum samples, screenshots/log excerpts) in the incident knowledge base.
+- Track: achieved RPO, achieved RTO, gaps, and owner/due-date for corrective actions.
+
+## Playbook index
+
+- [PostgreSQL restore playbook](./playbook-db-restore.md)
+- [Secrets recovery playbook](./playbook-secrets-recovery.md)
+- [Object storage assumptions + recovery playbook](./playbook-storage-recovery.md)
+- [DNS/Ingress recovery playbook](./playbook-dns-ingress-recovery.md)
+- [Key dependency outage playbook](./playbook-dependency-outages.md)
+- [Restore validation checklist (non-prod drills)](./restore-validation-checklist.md)

--- a/docs/operations/backup-dr/playbook-db-restore.md
+++ b/docs/operations/backup-dr/playbook-db-restore.md
@@ -1,0 +1,37 @@
+# Playbook: PostgreSQL Restore
+
+## Trigger conditions
+
+- Database corruption.
+- Accidental destructive write.
+- Region/instance outage.
+- Sustained replication failure with data divergence risk.
+
+## Preconditions
+
+- Incident declared and IC assigned.
+- Write freeze approved (application maintenance mode or write-block controls).
+- Target recovery timestamp selected.
+
+## Procedure
+
+1. Confirm latest healthy full backup and WAL archive continuity.
+2. Provision restore database from full backup.
+3. Apply WAL to target recovery timestamp (PITR).
+4. Run schema integrity check (`alembic current`) and critical query smoke tests.
+5. Point staging/test clients at restored DB for confidence checks.
+6. Promote restored DB to primary.
+7. Update `DATABASE_URL` secret stage/reference and restart backend + workers.
+8. Observe error rates, migration state, and background task behavior for 30 minutes.
+
+## Validation
+
+- API read/write smoke tests pass.
+- Job queue throughput returns to baseline.
+- No migration drift.
+- RPO <= 15 minutes and RTO <= 60 minutes.
+
+## Rollback strategy
+
+- If restored primary is unhealthy, revert `DATABASE_URL` reference to prior stable primary.
+- Keep restored instance online for forensic comparison.

--- a/docs/operations/backup-dr/playbook-dependency-outages.md
+++ b/docs/operations/backup-dr/playbook-dependency-outages.md
@@ -1,0 +1,33 @@
+# Playbook: Key Dependency Outages
+
+## Dependencies covered
+
+- Secrets manager.
+- Object storage provider.
+- DNS provider.
+- OTP/SMS provider.
+- Payment/identity or other customer-facing upstreams (as applicable).
+
+## Triage matrix
+
+| Dependency | Degradation symptom | Immediate mitigation |
+| --- | --- | --- |
+| Secrets manager | Pod restart loops / missing secrets | Pin to cached version; recover secret version stage; reduce restarts |
+| Object storage | Upload/download failures | Queue writes, switch to replicated region, disable non-essential exports |
+| DNS provider | Domain unreachable | Fail over via secondary DNS or static fallback records |
+| OTP provider | Login/verification failures | Use backup channel/provider; temporary grace for active sessions |
+
+## Generic response procedure
+
+1. Declare incident and assign IC.
+2. Confirm upstream status and scope of impact.
+3. Enable feature flags/degraded mode to protect core write paths.
+4. Fail over to redundant provider/region where available.
+5. Communicate customer impact and workaround expectations.
+6. Track elapsed time against dependent service RTO.
+
+## Recovery validation
+
+- Error rates return to baseline for dependency-specific endpoints.
+- Queued/retried jobs drain without manual replay gaps.
+- Follow-up action items include stronger fallback/abstraction coverage.

--- a/docs/operations/backup-dr/playbook-dns-ingress-recovery.md
+++ b/docs/operations/backup-dr/playbook-dns-ingress-recovery.md
@@ -1,0 +1,27 @@
+# Playbook: DNS and Ingress Recovery
+
+## Trigger conditions
+
+- DNS records missing or pointed to invalid target.
+- Ingress controller outage.
+- TLS certificate mismatch/expiration causing service rejection.
+
+## Procedure
+
+1. Verify ingress controller health and service endpoints.
+2. Confirm load balancer/NLB endpoint and ingress class are valid.
+3. Restore DNS records to known-good target and TTL.
+4. Validate TLS certificate and secret references used by ingress.
+5. Run external health probe against production hostname.
+6. Monitor 4xx/5xx and latency for 30 minutes.
+
+## Validation
+
+- External API health endpoint returns success.
+- Authentication and upload paths are reachable externally.
+- RTO <= 30 minutes.
+
+## Notes
+
+- Keep IaC-backed DNS records as source of truth.
+- Keep a one-command rollback for ingress manifest deploys.

--- a/docs/operations/backup-dr/playbook-secrets-recovery.md
+++ b/docs/operations/backup-dr/playbook-secrets-recovery.md
@@ -1,0 +1,37 @@
+# Playbook: Secrets Recovery
+
+## Scope
+
+Recover access to runtime secrets required by backend/worker workloads:
+
+- Database connection string.
+- Redis URL.
+- Object storage bucket identifiers and credentials.
+- JWT/OTP provider credentials.
+
+## Trigger conditions
+
+- Secrets manager outage or region failure.
+- Secret deletion/corruption.
+- Incorrect version stage promoted to production.
+
+## Procedure
+
+1. Identify impacted secret IDs and workloads failing startup or runtime auth.
+2. Recover latest known-good secret versions from replicated region or audit history.
+3. Re-attach correct version stage (for example, `AWSCURRENT`) to known-good payload.
+4. Reconcile mandatory key set against deployment requirements.
+5. Roll backend and worker pods to refresh in-memory credentials.
+6. Validate health endpoints and authentication-dependent flows.
+
+## Validation
+
+- No startup failures due to missing env/secret values.
+- DB/Redis/storage dependent endpoints pass smoke tests.
+- RTO <= 45 minutes.
+
+## Hardening assumptions
+
+- Secret values are recoverable from version history/audit logs.
+- At least one secondary operator has break-glass access.
+- Secret catalog is documented and reviewed quarterly.

--- a/docs/operations/backup-dr/playbook-storage-recovery.md
+++ b/docs/operations/backup-dr/playbook-storage-recovery.md
@@ -1,0 +1,29 @@
+# Playbook: Object Storage Recovery and Assumptions
+
+## Storage assumptions
+
+- Bucket versioning is enabled for artifacts and exports buckets.
+- Lifecycle policy retains non-current versions for at least 90 days.
+- Cross-region replication (or scheduled copy) is configured for critical prefixes.
+- Object integrity metadata (checksum/hash) exists for sampled evidence objects.
+
+## Trigger conditions
+
+- Accidental delete/overwrite.
+- Bucket policy misconfiguration causing object loss/inaccessibility.
+- Regional outage impacting primary object storage endpoint.
+
+## Procedure
+
+1. Determine blast radius: single object, prefix, full bucket, or regional scope.
+2. For overwrite/delete: restore previous object versions.
+3. For widespread corruption: fail over to replicated bucket copy.
+4. Rebuild derived artifacts (exports/previews) where needed.
+5. Confirm IAM/presigned URL behavior and access control correctness.
+
+## Validation
+
+- Authorized user download for sampled restored objects succeeds.
+- Hash/checksum matches object metadata for sampled files.
+- Export pipeline includes restored objects without integrity errors.
+- RPO <= 15 minutes and RTO <= 120 minutes.

--- a/docs/operations/backup-dr/restore-validation-checklist.md
+++ b/docs/operations/backup-dr/restore-validation-checklist.md
@@ -1,0 +1,56 @@
+# Restore Validation Checklist (Non-Prod Drill)
+
+## Drill metadata
+
+- Date/time (UTC):
+- Incident commander:
+- Participants:
+- Simulated scenario:
+- Target system(s):
+- Declared outage start:
+- Service restored timestamp:
+
+## Validation gates
+
+### 1) PostgreSQL restore validation
+
+- [ ] Restore instance created from latest full backup snapshot.
+- [ ] WAL replay / PITR applied to target timestamp.
+- [ ] `alembic current` equals expected head revision.
+- [ ] CRUD smoke test passes for incidents and artifacts tables.
+- [ ] Background worker DB tasks complete with no retry storm.
+- [ ] Measured DB restore RPO <= 15 minutes.
+- [ ] Measured DB restore RTO <= 60 minutes.
+
+### 2) Object storage validation
+
+- [ ] Bucket versioning confirmed enabled.
+- [ ] Lifecycle policy attached and matches retention standard.
+- [ ] Random sample restore from non-current object version succeeds.
+- [ ] Checksums/hash metadata match expected values for sample files.
+- [ ] Export job can include restored objects.
+- [ ] Measured storage RPO <= 15 minutes.
+- [ ] Measured storage RTO <= 120 minutes.
+
+### 3) Secrets/config recovery validation
+
+- [ ] Runtime secret metadata recovered (secret id + current version stage).
+- [ ] App can read required settings after secret recovery.
+- [ ] Roll/redeploy confirms new pods resolve required secrets.
+- [ ] No startup failures from missing secret keys.
+- [ ] Measured secrets RTO <= 45 minutes.
+
+### 4) DNS/ingress validation
+
+- [ ] Ingress controller healthy and serving expected routes.
+- [ ] DNS record set points to active load balancer endpoint.
+- [ ] TLS certificate chain valid for production domains.
+- [ ] External API health check returns successful response.
+- [ ] Measured DNS/ingress RTO <= 30 minutes.
+
+## Closeout
+
+- [ ] Actual RPO/RTO documented for each system.
+- [ ] Deviations from runbooks listed.
+- [ ] Corrective actions created with owner + due date.
+- [ ] Final drill report published and linked.

--- a/docs/reliability-and-incident-response-runbook.md
+++ b/docs/reliability-and-incident-response-runbook.md
@@ -11,6 +11,9 @@ This document defines:
 
 Use this runbook alongside credential/key rotation runbooks in `docs/`.
 
+Use detailed backup/DR artifacts in `docs/operations/backup-dr/` for operational execution checklists and playbooks.
+
+
 ## 1) Service ownership and on-call assignments
 
 | Area | Primary owner | Secondary owner | Escalation manager |

--- a/infra/production/object-storage-policies.yaml
+++ b/infra/production/object-storage-policies.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: adc-object-storage-dr-policy
+  namespace: adc
+data:
+  assumptions.md: |
+    - Artifacts and exports buckets must have versioning enabled.
+    - Replication/copy jobs should keep RPO at or below 15 minutes.
+    - Non-current version retention must be at least 90 days.
+    - Delete markers should expire after 30 days.
+  artifacts-versioning.json: |
+    {
+      "Bucket": "adc-artifacts-prod",
+      "VersioningConfiguration": {
+        "Status": "Enabled"
+      }
+    }
+  exports-versioning.json: |
+    {
+      "Bucket": "adc-exports-prod",
+      "VersioningConfiguration": {
+        "Status": "Enabled"
+      }
+    }
+  artifacts-lifecycle.json: |
+    {
+      "Rules": [
+        {
+          "ID": "adc-artifacts-noncurrent-retention",
+          "Status": "Enabled",
+          "Filter": {"Prefix": ""},
+          "NoncurrentVersionExpiration": {
+            "NoncurrentDays": 90
+          },
+          "Expiration": {
+            "ExpiredObjectDeleteMarker": true
+          },
+          "AbortIncompleteMultipartUpload": {
+            "DaysAfterInitiation": 7
+          }
+        }
+      ]
+    }
+  exports-lifecycle.json: |
+    {
+      "Rules": [
+        {
+          "ID": "adc-exports-noncurrent-retention",
+          "Status": "Enabled",
+          "Filter": {"Prefix": ""},
+          "NoncurrentVersionExpiration": {
+            "NoncurrentDays": 90
+          },
+          "Expiration": {
+            "ExpiredObjectDeleteMarker": true
+          },
+          "AbortIncompleteMultipartUpload": {
+            "DaysAfterInitiation": 7
+          }
+        }
+      ]
+    }

--- a/infra/production/postgres-backup-cronjob.yaml
+++ b/infra/production/postgres-backup-cronjob.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: adc-postgres-backup-policy
+  namespace: adc
+data:
+  retention_days_daily: "35"
+  retention_weeks_weekly: "12"
+  retention_months_monthly: "12"
+  wal_retention_days: "35"
+  backup_schedule_utc: "*/5 * * * *"
+  full_snapshot_schedule_utc: "0 2 * * *"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: adc-postgres-wal-archive
+  namespace: adc
+spec:
+  schedule: "*/5 * * * *"
+  successfulJobsHistoryLimit: 6
+  failedJobsHistoryLimit: 12
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: adc-backend
+          restartPolicy: OnFailure
+          containers:
+            - name: wal-archive
+              image: ghcr.io/your-org/adc-ops:latest
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - >-
+                  ./scripts/backup/run_pg_wal_archive.sh
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: adc-runtime-settings
+                      key: DATABASE_URL
+                - name: PG_BACKUP_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: adc-runtime-settings
+                      key: PG_BACKUP_BUCKET
+                - name: AWS_REGION
+                  value: us-east-1
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: adc-postgres-full-backup
+  namespace: adc
+spec:
+  schedule: "0 2 * * *"
+  successfulJobsHistoryLimit: 14
+  failedJobsHistoryLimit: 14
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: adc-backend
+          restartPolicy: OnFailure
+          containers:
+            - name: pg-full-backup
+              image: ghcr.io/your-org/adc-ops:latest
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - >-
+                  ./scripts/backup/run_pg_full_backup.sh
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: adc-runtime-settings
+                      key: DATABASE_URL
+                - name: PG_BACKUP_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: adc-runtime-settings
+                      key: PG_BACKUP_BUCKET
+                - name: AWS_REGION
+                  value: us-east-1


### PR DESCRIPTION
### Motivation

- Provide operators with explicit backup automation, retention and recovery guidance for PostgreSQL and object storage to meet defined RPO/RTO targets.  
- Give teams concrete non-prod restore drill steps and a validation checklist to exercise restores safely.  
- Capture recovery runbooks for secrets, DNS/ingress, storage assumptions, and key dependency outages so on-call can act consistently.  

### Description

- Added a new operations package at `docs/operations/backup-dr/` containing a README that defines explicit RPO/RTO targets and retention policy.  
- Added a non-prod `restore-validation-checklist.md` and playbooks: `playbook-db-restore.md`, `playbook-secrets-recovery.md`, `playbook-storage-recovery.md`, `playbook-dns-ingress-recovery.md`, and `playbook-dependency-outages.md`.  
- Added production infra manifests: `infra/production/postgres-backup-cronjob.yaml` which includes a ConfigMap of backup retention/schedules and CronJobs for WAL archival (`adc-postgres-wal-archive`) and daily full snapshots (`adc-postgres-full-backup`).  
- Added `infra/production/object-storage-policies.yaml` ConfigMap containing versioning and lifecycle payloads and assumptions for artifacts/exports buckets (non-current version retention and delete-marker handling).  
- Touched `docs/reliability-and-incident-response-runbook.md` to reference the new backup/DR artifacts for operator execution.  

### Testing

- Ran `make lint` and it completed successfully (`ruff` checks and the hardening matrix lint check passed).  
- Ran `make test`; test collection ran and overall suite produced 342 collected tests with 338 passing and 4 failing.  
- The 4 failures are in `backend/tests/test_hardening_matrix_lint.py` and are due to the test harness resolving paths relative to the `backend/` working directory and not finding an expected matrix helper script and `docs/production-hardening/control-matrix.md`; these failures are pre-existing and unrelated to the backup/DR docs and infra manifests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5b9d8db1483219e514f71a8fb6aaa)