### PR TITLE
Harden S3 object key privacy and short-lived presign behavior

### DIFF
--- a/backend/app/services/s3_key_builder.py
+++ b/backend/app/services/s3_key_builder.py
@@ -1,15 +1,31 @@
-"""Deterministic S3 key builder for court-friendly artifact paths.
+"""Private, deterministic S3 key builder for artifact storage.
 
-Produces predictable, human-readable keys:
+All object keys are constrained to:
 
-  org/{org_id}/incidents/{incident_id}/telematics/{artifact_type}/{artifact_id}.json
-  org/{org_id}/incidents/{incident_id}/telematics/{artifact_type}/{artifact_id}.csv
-  org/{org_id}/incidents/{incident_id}/telematics/{artifact_type}/{artifact_id}.pdf
-  org/{org_id}/incidents/{incident_id}/dashcam/{camera_view}/{artifact_id}.mp4
-  org/{org_id}/incidents/{incident_id}/exports/{export_id}/ADC_Court_Package.zip
+  orgs/{org_id}/incidents/{incident_id}/artifacts/{artifact_id}[.{extension}]
+
+This intentionally avoids embedding sensitive details (artifact type, camera view,
+or export package naming) directly in object paths.
 """
 
 from __future__ import annotations
+
+import re
+
+_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _safe_segment(name: str, value: str) -> str:
+    if not value or not _SEGMENT_PATTERN.fullmatch(value):
+        raise ValueError(f"{name} contains unsupported characters")
+    return value
+
+
+def _artifact_root(org_id: str, incident_id: str, artifact_id: str) -> str:
+    org = _safe_segment("org_id", org_id)
+    incident = _safe_segment("incident_id", incident_id)
+    artifact = _safe_segment("artifact_id", artifact_id)
+    return f"orgs/{org}/incidents/{incident}/artifacts/{artifact}"
 
 
 def telematics_key(
@@ -21,14 +37,14 @@ def telematics_key(
 ) -> str:
     """Build an S3 key for a telematics artifact.
 
+    Note: artifact_type is intentionally ignored for key privacy.
+
     >>> telematics_key("org-1", "inc-1", "eld_log", "art-1", "json")
-    'org/org-1/incidents/inc-1/telematics/eld_log/art-1.json'
+    'orgs/org-1/incidents/inc-1/artifacts/art-1.json'
     """
-    ext = extension.lstrip(".")
-    return (
-        f"org/{org_id}/incidents/{incident_id}/telematics/"
-        f"{artifact_type}/{artifact_id}.{ext}"
-    )
+    _ = artifact_type
+    ext = _safe_segment("extension", extension.lstrip("."))
+    return f"{_artifact_root(org_id, incident_id, artifact_id)}.{ext}"
 
 
 def dashcam_key(
@@ -39,12 +55,13 @@ def dashcam_key(
 ) -> str:
     """Build an S3 key for a dashcam artifact.
 
+    Note: camera_view is intentionally ignored for key privacy.
+
     >>> dashcam_key("org-1", "inc-1", "road_facing", "art-1")
-    'org/org-1/incidents/inc-1/dashcam/road_facing/art-1.mp4'
+    'orgs/org-1/incidents/inc-1/artifacts/art-1.mp4'
     """
-    return (
-        f"org/{org_id}/incidents/{incident_id}/dashcam/{camera_view}/{artifact_id}.mp4"
-    )
+    _ = camera_view
+    return f"{_artifact_root(org_id, incident_id, artifact_id)}.mp4"
 
 
 def export_key(
@@ -55,6 +72,6 @@ def export_key(
     """Build an S3 key for a court-package export.
 
     >>> export_key("org-1", "inc-1", "exp-1")
-    'org/org-1/incidents/inc-1/exports/exp-1/ADC_Court_Package.zip'
+    'orgs/org-1/incidents/inc-1/artifacts/exp-1.zip'
     """
-    return f"org/{org_id}/incidents/{incident_id}/exports/{export_id}/ADC_Court_Package.zip"
+    return f"{_artifact_root(org_id, incident_id, export_id)}.zip"

--- a/backend/app/services/vault_s3.py
+++ b/backend/app/services/vault_s3.py
@@ -1,8 +1,21 @@
 """Vault / S3 storage service."""
 
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
 import logging
+import re
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_PRESIGN_TTL_SECONDS = 300
+MAX_PRESIGN_TTL_SECONDS = 300
+_PRIVATE_KEY_PATTERN = re.compile(
+    r"^orgs/[A-Za-z0-9._-]+/incidents/[A-Za-z0-9._-]+/artifacts/[A-Za-z0-9._-]+(?:\.[A-Za-z0-9]+)?$"
+)
+_SHA256_PATTERN = re.compile(r"^[a-f0-9]{64}$")
 
 
 class S3PresignConfigurationError(ValueError):
@@ -13,6 +26,71 @@ class S3PresignGenerationError(RuntimeError):
     """Raised when generating an S3 presigned URL fails."""
 
 
+class S3ObjectKeyValidationError(ValueError):
+    """Raised when an S3 object key does not follow private key conventions."""
+
+
+@dataclass(frozen=True)
+class ArtifactObjectMetadata:
+    """Integrity-critical metadata stored alongside an artifact blob."""
+
+    sha256: str
+    byte_size: int
+    content_type: str
+    captured_at_utc: datetime
+    uploaded_at_utc: datetime
+
+    @classmethod
+    def from_blob(
+        cls,
+        *,
+        data: bytes,
+        content_type: str,
+        captured_at_utc: datetime,
+        uploaded_at_utc: datetime | None = None,
+    ) -> "ArtifactObjectMetadata":
+        """Build validated metadata from raw bytes."""
+        return cls(
+            sha256=hashlib.sha256(data).hexdigest(),
+            byte_size=len(data),
+            content_type=content_type,
+            captured_at_utc=captured_at_utc,
+            uploaded_at_utc=uploaded_at_utc or datetime.now(timezone.utc),
+        )
+
+    def validate(self) -> None:
+        """Validate metadata fields for audit/integrity usage."""
+        if not _SHA256_PATTERN.fullmatch(self.sha256):
+            raise ValueError("Artifact metadata sha256 must be a lowercase hex SHA-256 digest")
+        if self.byte_size < 0:
+            raise ValueError("Artifact metadata byte_size must be non-negative")
+        if not self.content_type or "/" not in self.content_type:
+            raise ValueError("Artifact metadata content_type is invalid")
+        if self.captured_at_utc.tzinfo is None or self.uploaded_at_utc.tzinfo is None:
+            raise ValueError("Artifact metadata timestamps must be timezone-aware")
+        if self.uploaded_at_utc < self.captured_at_utc:
+            raise ValueError("Artifact upload timestamp cannot be before capture timestamp")
+
+    def validate_against_data(self, data: bytes) -> None:
+        """Validate metadata plus byte-level integrity against provided bytes."""
+        self.validate()
+        if self.byte_size != len(data):
+            raise ValueError("Artifact metadata byte_size does not match payload size")
+        if self.sha256 != hashlib.sha256(data).hexdigest():
+            raise ValueError("Artifact metadata sha256 does not match payload")
+
+    def to_s3_metadata(self) -> dict[str, str]:
+        """Convert validated metadata to S3-compatible metadata map."""
+        self.validate()
+        return {
+            "adc-sha256": self.sha256,
+            "adc-byte-size": str(self.byte_size),
+            "adc-content-type": self.content_type,
+            "adc-captured-at-utc": self.captured_at_utc.isoformat(),
+            "adc-uploaded-at-utc": self.uploaded_at_utc.isoformat(),
+        }
+
+
 class VaultS3:
     """Handles storing and retrieving artifacts from S3."""
 
@@ -20,8 +98,16 @@ class VaultS3:
         self.bucket = bucket
         self.region = region
 
-    def put_bytes(self, key: str, data: bytes) -> str:
+    def put_bytes(
+        self,
+        key: str,
+        data: bytes,
+        metadata: ArtifactObjectMetadata | None = None,
+    ) -> str:
         """Upload data to S3 and return the storage path."""
+        _validate_private_object_key(key)
+        if metadata is not None:
+            metadata.validate_against_data(data)
         path = f"s3://{self.bucket}/{key}"
         logger.info("Uploading to %s", path)
         # Placeholder: integrate boto3
@@ -29,11 +115,16 @@ class VaultS3:
 
     def get_bytes(self, key: str) -> bytes:
         """Download data from S3."""
+        _validate_private_object_key(key)
         logger.info("Downloading s3://%s/%s", self.bucket, key)
         # Placeholder: integrate boto3
         return b""
 
-    def presign_download(self, key: str, expires_in: int = 3600) -> str:
+    def presign_download(
+        self,
+        key: str,
+        expires_in: int = DEFAULT_PRESIGN_TTL_SECONDS,
+    ) -> str:
         """Return a presigned URL for downloading the object."""
         return generate_presigned_download_url(
             bucket=self.bucket,
@@ -51,18 +142,34 @@ class VaultS3:
         return self.get_bytes(key)
 
 
+def _validate_private_object_key(key: str) -> None:
+    if not key:
+        raise S3ObjectKeyValidationError("S3 object key is required")
+    if not _PRIVATE_KEY_PATTERN.fullmatch(key):
+        raise S3ObjectKeyValidationError(
+            "S3 object key must match orgs/{org_id}/incidents/{incident_id}/artifacts/{artifact_id}"
+        )
+
+
+def _enforce_short_presign_ttl(expires_in: int) -> int:
+    if expires_in <= 0:
+        raise S3PresignConfigurationError("Export download URL TTL must be positive")
+    return min(expires_in, MAX_PRESIGN_TTL_SECONDS)
+
+
 def generate_presigned_download_url(
     *,
     bucket: str,
     key: str,
     region: str,
-    expires_in: int = 3600,
+    expires_in: int = DEFAULT_PRESIGN_TTL_SECONDS,
 ) -> str:
     """Generate a presigned S3 download URL using boto3."""
     if not bucket:
         raise S3PresignConfigurationError("Export download bucket is not configured")
-    if not key:
-        raise S3PresignConfigurationError("Export download object key is not configured")
+
+    _validate_private_object_key(key)
+    ttl = _enforce_short_presign_ttl(expires_in)
 
     try:
         import boto3
@@ -72,7 +179,7 @@ def generate_presigned_download_url(
         return client.generate_presigned_url(
             ClientMethod="get_object",
             Params={"Bucket": bucket, "Key": key},
-            ExpiresIn=expires_in,
+            ExpiresIn=ttl,
         )
     except ImportError as exc:
         logger.exception("boto3 is required to generate S3 presigned URLs")

--- a/backend/tests/test_s3_key_builder.py
+++ b/backend/tests/test_s3_key_builder.py
@@ -2,65 +2,72 @@
 
 import uuid
 
+import pytest
+
 from app.services.s3_key_builder import dashcam_key, export_key, telematics_key
 
 
 class TestTelematicsKey:
     def test_json_extension(self):
         key = telematics_key("org-1", "inc-1", "eld_log", "art-1", "json")
-        assert key == "org/org-1/incidents/inc-1/telematics/eld_log/art-1.json"
+        assert key == "orgs/org-1/incidents/inc-1/artifacts/art-1.json"
 
     def test_csv_extension(self):
         key = telematics_key("org-1", "inc-1", "gps_trail", "art-2", "csv")
-        assert key == "org/org-1/incidents/inc-1/telematics/gps_trail/art-2.csv"
+        assert key == "orgs/org-1/incidents/inc-1/artifacts/art-2.csv"
 
     def test_pdf_extension(self):
         key = telematics_key("org-1", "inc-1", "safety_event", "art-3", "pdf")
-        assert key == "org/org-1/incidents/inc-1/telematics/safety_event/art-3.pdf"
+        assert key == "orgs/org-1/incidents/inc-1/artifacts/art-3.pdf"
 
     def test_strips_leading_dot_from_extension(self):
         key = telematics_key("org-1", "inc-1", "eld_log", "art-1", ".json")
-        assert key == "org/org-1/incidents/inc-1/telematics/eld_log/art-1.json"
+        assert key == "orgs/org-1/incidents/inc-1/artifacts/art-1.json"
 
     def test_with_real_uuids(self):
         org = str(uuid.uuid4())
         inc = str(uuid.uuid4())
         art = str(uuid.uuid4())
         key = telematics_key(org, inc, "vehicle_state", art, "json")
-        assert key == f"org/{org}/incidents/{inc}/telematics/vehicle_state/{art}.json"
+        assert key == f"orgs/{org}/incidents/{inc}/artifacts/{art}.json"
 
 
 class TestDashcamKey:
     def test_road_facing(self):
         key = dashcam_key("org-1", "inc-1", "road_facing", "art-1")
-        assert key == "org/org-1/incidents/inc-1/dashcam/road_facing/art-1.mp4"
+        assert key == "orgs/org-1/incidents/inc-1/artifacts/art-1.mp4"
 
     def test_driver_facing(self):
         key = dashcam_key("org-1", "inc-1", "driver_facing", "art-2")
-        assert key == "org/org-1/incidents/inc-1/dashcam/driver_facing/art-2.mp4"
+        assert key == "orgs/org-1/incidents/inc-1/artifacts/art-2.mp4"
 
     def test_with_real_uuids(self):
         org = str(uuid.uuid4())
         inc = str(uuid.uuid4())
         art = str(uuid.uuid4())
         key = dashcam_key(org, inc, "road_facing", art)
-        assert key == f"org/{org}/incidents/{inc}/dashcam/road_facing/{art}.mp4"
+        assert key == f"orgs/{org}/incidents/{inc}/artifacts/{art}.mp4"
 
 
 class TestExportKey:
     def test_basic(self):
         key = export_key("org-1", "inc-1", "exp-1")
-        assert key == "org/org-1/incidents/inc-1/exports/exp-1/ADC_Court_Package.zip"
+        assert key == "orgs/org-1/incidents/inc-1/artifacts/exp-1.zip"
 
     def test_with_real_uuids(self):
         org = str(uuid.uuid4())
         inc = str(uuid.uuid4())
         exp = str(uuid.uuid4())
         key = export_key(org, inc, exp)
-        assert key == f"org/{org}/incidents/{inc}/exports/{exp}/ADC_Court_Package.zip"
+        assert key == f"orgs/{org}/incidents/{inc}/artifacts/{exp}.zip"
 
     def test_key_is_deterministic(self):
         """Same inputs always produce the same key."""
         k1 = export_key("org-1", "inc-1", "exp-1")
         k2 = export_key("org-1", "inc-1", "exp-1")
         assert k1 == k2
+
+
+def test_rejects_unsafe_key_segments():
+    with pytest.raises(ValueError):
+        telematics_key("org-1", "inc-1", "eld_log", "../../secret", "json")

--- a/backend/tests/test_vault_s3.py
+++ b/backend/tests/test_vault_s3.py
@@ -1,9 +1,15 @@
 """Tests for S3 presigned URL generation helpers."""
 
+from datetime import datetime, timedelta, timezone
+import hashlib
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 from app.services.vault_s3 import (
+    ArtifactObjectMetadata,
+    S3ObjectKeyValidationError,
     S3PresignConfigurationError,
     S3PresignGenerationError,
     generate_presigned_download_url,
@@ -14,22 +20,28 @@ class _FakeS3Client:
     def generate_presigned_url(self, ClientMethod, Params, ExpiresIn):  # noqa: N803
         assert ClientMethod == "get_object"
         assert Params["Bucket"] == "bucket"
-        assert Params["Key"] == "exports/test.zip"
-        assert ExpiresIn == 900
+        assert Params["Key"] == "orgs/org-1/incidents/inc-1/artifacts/art-1.zip"
+        # caller asked for 900, implementation caps to 300 for short-lived URL issuance
+        assert ExpiresIn == 300
         return "https://signed.example.com/exports/test.zip"
 
 
 def test_generate_presigned_download_url_missing_bucket_raises():
-    try:
+    with pytest.raises(S3PresignConfigurationError, match="Export download bucket is not configured"):
         generate_presigned_download_url(
             bucket="",
-            key="exports/test.zip",
+            key="orgs/org-1/incidents/inc-1/artifacts/art-1.zip",
             region="us-east-1",
         )
-    except S3PresignConfigurationError as exc:
-        assert str(exc) == "Export download bucket is not configured"
-    else:
-        raise AssertionError("Expected S3PresignConfigurationError")
+
+
+def test_generate_presigned_download_url_invalid_key_raises():
+    with pytest.raises(S3ObjectKeyValidationError):
+        generate_presigned_download_url(
+            bucket="bucket",
+            key="org/org-1/incidents/inc-1/exports/test.zip",
+            region="us-east-1",
+        )
 
 
 def test_generate_presigned_download_url_uses_boto3(monkeypatch):
@@ -44,7 +56,7 @@ def test_generate_presigned_download_url_uses_boto3(monkeypatch):
 
     url = generate_presigned_download_url(
         bucket="bucket",
-        key="exports/test.zip",
+        key="orgs/org-1/incidents/inc-1/artifacts/art-1.zip",
         region="us-east-1",
         expires_in=900,
     )
@@ -64,13 +76,44 @@ def test_generate_presigned_download_url_missing_boto3_raises(monkeypatch):
 
     monkeypatch.setattr("builtins.__import__", _raising_import)
 
-    try:
+    with pytest.raises(S3PresignGenerationError, match="Failed to generate download URL"):
         generate_presigned_download_url(
             bucket="bucket",
-            key="exports/test.zip",
+            key="orgs/org-1/incidents/inc-1/artifacts/art-1.zip",
             region="us-east-1",
         )
-    except S3PresignGenerationError as exc:
-        assert str(exc) == "Failed to generate download URL"
-    else:
-        raise AssertionError("Expected S3PresignGenerationError")
+
+
+def test_artifact_metadata_round_trip_and_s3_projection():
+    data = b"artifact-bytes"
+    captured_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    uploaded_at = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+    metadata = ArtifactObjectMetadata.from_blob(
+        data=data,
+        content_type="application/pdf",
+        captured_at_utc=captured_at,
+        uploaded_at_utc=uploaded_at,
+    )
+
+    metadata.validate_against_data(data)
+    headers = metadata.to_s3_metadata()
+
+    assert headers["adc-sha256"] == hashlib.sha256(data).hexdigest()
+    assert headers["adc-byte-size"] == str(len(data))
+    assert headers["adc-content-type"] == "application/pdf"
+    assert headers["adc-captured-at-utc"] == captured_at.isoformat()
+    assert headers["adc-uploaded-at-utc"] == uploaded_at.isoformat()
+
+
+def test_artifact_metadata_rejects_timestamp_inversion():
+    metadata = ArtifactObjectMetadata(
+        sha256="a" * 64,
+        byte_size=1,
+        content_type="video/mp4",
+        captured_at_utc=datetime.now(timezone.utc),
+        uploaded_at_utc=datetime.now(timezone.utc) - timedelta(seconds=1),
+    )
+
+    with pytest.raises(ValueError, match="before capture"):
+        metadata.validate()


### PR DESCRIPTION
### Motivation
- Prevent leakage of sensitive naming in S3 object keys by enforcing a private, predictable key shape and disallowing arbitrary path segments.
- Reduce risk of long-lived presigned download URLs by issuing short TTLs for exported artifacts.
- Ensure integrity of critical artifacts by capturing and validating SHA-256, byte size, content type, and timestamps before/when storing objects.

### Description
- Enforce private object-key format `orgs/{org_id}/incidents/{incident_id}/artifacts/{artifact_id}` (optional extension) and validate keys on upload, download, and presign operations in `backend/app/services/vault_s3.py`.
- Add `ArtifactObjectMetadata` dataclass to store/validate `sha256`, `byte_size`, `content_type`, `captured_at_utc`, and `uploaded_at_utc`, including payload-integrity checks and `to_s3_metadata()` projection.
- Cap presigned download URL TTL to a short default/maximum of 300 seconds and validate TTL parameters in the presign helper in `backend/app/services/vault_s3.py`.
- Replace prior verbose key format with privacy-preserving builders in `backend/app/services/s3_key_builder.py` so generated keys no longer contain artifact type, camera view, or export package names.
- Update unit tests to cover key-shape enforcement, TTL capping, metadata round-trip and validation, and unsafe-segment rejection (`backend/tests/test_vault_s3.py`, `backend/tests/test_s3_key_builder.py`).

### Testing
- Ran style/lint and unit checks with `cd backend && ruff check app/services/vault_s3.py app/services/s3_key_builder.py tests/test_vault_s3.py tests/test_s3_key_builder.py` and then executed `cd backend && pytest -q tests/test_vault_s3.py tests/test_s3_key_builder.py`.
- All targeted tests passed: `18 passed` (tests covering presign behavior, metadata validation, and key-builder behavior succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5bbe222548321a470ff0a9758be45)