### PR TITLE
Add Ops dashboard and audit-search endpoints and frontend pages with role gating and audit logging

### DIFF
--- a/backend/app/api/routes_admin.py
+++ b/backend/app/api/routes_admin.py
@@ -4,19 +4,28 @@ import hashlib
 import logging
 import secrets
 import uuid
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
 from app.api.schemas import (
+    AuditSearchResponseItem,
     AdminVehicleSummary,
     DriverInstructionSetRequest,
     DriverInstructionSetResponse,
     DriverInstructionStep,
     DriverProtocolSettingsRequest,
     DriverProtocolSettingsResponse,
+    IntegrationHealthItem,
     JobExecutionMetaItem,
     JobExecutionMetaSummary,
+    OpsAnomalyItem,
+    OpsDashboardResponse,
+    OpsFailedExportItem,
+    OpsFailedNotificationItem,
+    OpsIncidentItem,
     QrPayloadResponse,
     RotateQrResponse,
 )
@@ -27,9 +36,14 @@ from app.security.permissions import Capability
 from app.security.authn import build_user_auth_context
 from app.security.authz import can_access_admin_org, require_policy
 from app.db.models import (
+    Artifact,
+    AuditEvent,
     DriverInstructionSet,
     DriverInstructionStep as DriverInstructionStepModel,
     Event,
+    Export,
+    Incident,
+    JobExecutionMeta,
     Org,
     User,
     VehicleQrToken,
@@ -46,6 +60,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 INSTRUCTION_SCOPES = {"default", "company", "insurer"}
+OPS_ALLOWED_ROLES = {"system_admin", "org_admin", "admin"}
 
 DEFAULT_DRIVER_PROTOCOL_STEPS = [
     {
@@ -113,6 +128,10 @@ def _require_admin_policy(
         metadata={"should_log": True, **(metadata or {})},
     )
     require_policy(False)
+
+
+def _can_access_ops_views(context) -> bool:
+    return context.user.role in OPS_ALLOWED_ROLES and bool(context.org_ids)
 
 
 def _get_or_create_instruction_set(
@@ -570,6 +589,290 @@ def list_ops_job_failures(
             last_error=row.last_error,
             created_at_utc=row.created_at_utc,
             updated_at_utc=row.updated_at_utc,
+        )
+        for row in rows
+    ]
+
+
+@router.get("/ops/dashboard", response_model=OpsDashboardResponse)
+def get_ops_dashboard(
+    stale_after_minutes: int = 15,
+    lookback_hours: int = 24,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, admin)
+    _require_admin_policy(
+        db,
+        allowed=_can_access_ops_views(context),
+        actor_id=admin.id,
+        org_id=context.org_ids[0] if context.org_ids else None,
+        action="admin.ops.dashboard.read",
+        metadata={"required_roles": sorted(OPS_ALLOWED_ROLES)},
+    )
+    org_id = context.org_ids[0]
+    now = datetime.now(timezone.utc)
+    stale_cutoff = now - timedelta(minutes=max(1, stale_after_minutes))
+    lookback_cutoff = now - timedelta(hours=max(1, lookback_hours))
+
+    stuck_incidents = (
+        db.query(Incident)
+        .filter(
+            Incident.org_id == org_id,
+            Incident.status == "evidence_capturing",
+            Incident.created_at_utc <= stale_cutoff,
+        )
+        .order_by(Incident.created_at_utc.asc())
+        .limit(50)
+        .all()
+    )
+
+    missing_evidence_rows = (
+        db.query(Incident, func.count(Artifact.artifact_id).label("missing_count"))
+        .outerjoin(
+            Artifact,
+            Artifact.incident_id == Incident.incident_id,
+        )
+        .filter(
+            Incident.org_id == org_id,
+            Incident.status != "closed",
+            or_(Artifact.artifact_id.is_(None), Artifact.status != "captured"),
+        )
+        .group_by(Incident.incident_id)
+        .order_by(Incident.created_at_utc.asc())
+        .limit(50)
+        .all()
+    )
+
+    failed_notifications = (
+        db.query(JobExecutionMeta)
+        .filter(
+            JobExecutionMeta.task_type == "notification_tasks",
+            JobExecutionMeta.status.in_(("failed", "retrying")),
+        )
+        .order_by(JobExecutionMeta.updated_at_utc.desc())
+        .limit(50)
+        .all()
+    )
+
+    failed_exports = (
+        db.query(Export)
+        .filter(Export.org_id == org_id, Export.status == "failed")
+        .order_by(Export.updated_at_utc.desc())
+        .limit(50)
+        .all()
+    )
+
+    integration_rows = (
+        db.query(
+            JobExecutionMeta.task_type,
+            func.count(JobExecutionMeta.id).label("failure_count"),
+            func.max(JobExecutionMeta.updated_at_utc).label("last_failure_at_utc"),
+        )
+        .filter(JobExecutionMeta.status.in_(("failed", "retrying")))
+        .group_by(JobExecutionMeta.task_type)
+        .all()
+    )
+    known_integration_keys = {"evidence_tasks", "notification_tasks", "export_tasks"}
+    integration_health: list[IntegrationHealthItem] = []
+    for key in ("evidence_tasks", "notification_tasks", "export_tasks"):
+        row = next((item for item in integration_rows if item.task_type == key), None)
+        if row is None:
+            integration_health.append(
+                IntegrationHealthItem(
+                    integration_key=key,
+                    status="healthy",
+                    failure_count=0,
+                )
+            )
+            continue
+        integration_health.append(
+            IntegrationHealthItem(
+                integration_key=key,
+                status="degraded",
+                failure_count=int(row.failure_count or 0),
+                last_failure_at_utc=row.last_failure_at_utc,
+                details="Recent failed or retrying job executions detected.",
+            )
+        )
+    for row in integration_rows:
+        if row.task_type in known_integration_keys:
+            continue
+        integration_health.append(
+            IntegrationHealthItem(
+                integration_key=row.task_type,
+                status="degraded",
+                failure_count=int(row.failure_count or 0),
+                last_failure_at_utc=row.last_failure_at_utc,
+                details="Recent failed or retrying job executions detected.",
+            )
+        )
+
+    anomaly_events = (
+        db.query(AuditEvent)
+        .filter(
+            AuditEvent.org_id == org_id,
+            AuditEvent.occurred_at_utc >= lookback_cutoff,
+            or_(
+                AuditEvent.event_type == "authorization_failed",
+                AuditEvent.outcome == "failure",
+                AuditEvent.action.ilike("%security%"),
+            ),
+        )
+        .order_by(AuditEvent.occurred_at_utc.desc())
+        .limit(100)
+        .all()
+    )
+    emit_audit_event(
+        db,
+        org_id=org_id,
+        actor_type="user",
+        actor_id=str(admin.id),
+        action="admin.ops.dashboard.read",
+        event_type="ops_dashboard_viewed",
+        outcome="success",
+        metadata={
+            "stuck_incident_count": len(stuck_incidents),
+            "missing_evidence_count": len(missing_evidence_rows),
+            "failed_notification_count": len(failed_notifications),
+            "failed_export_count": len(failed_exports),
+            "anomaly_count": len(anomaly_events),
+        },
+    )
+    return OpsDashboardResponse(
+        stuck_incidents=[
+            OpsIncidentItem(
+                incident_id=row.incident_id,
+                status=row.status,
+                created_at_utc=row.created_at_utc,
+                adc_vehicle_id=row.adc_vehicle_id,
+                adc_driver_id=row.adc_driver_id,
+                reason="Evidence capture has exceeded stale threshold.",
+            )
+            for row in stuck_incidents
+        ],
+        missing_evidence_incidents=[
+            OpsIncidentItem(
+                incident_id=incident.incident_id,
+                status=incident.status,
+                created_at_utc=incident.created_at_utc,
+                adc_vehicle_id=incident.adc_vehicle_id,
+                adc_driver_id=incident.adc_driver_id,
+                reason=f"{missing_count} evidence artifacts not captured.",
+            )
+            for incident, missing_count in missing_evidence_rows
+        ],
+        failed_notifications=[
+            OpsFailedNotificationItem(
+                celery_task_id=row.celery_task_id,
+                status=row.status,
+                retry_count=row.retry_count,
+                max_retries=row.max_retries,
+                last_error=row.last_error,
+                updated_at_utc=row.updated_at_utc,
+            )
+            for row in failed_notifications
+        ],
+        failed_exports=[
+            OpsFailedExportItem(
+                export_id=row.export_id,
+                incident_id=row.incident_id,
+                export_type=row.export_type,
+                status=row.status,
+                error_message=row.error_message,
+                updated_at_utc=row.updated_at_utc,
+            )
+            for row in failed_exports
+        ],
+        integration_health=integration_health,
+        recent_anomalies=[
+            OpsAnomalyItem(
+                audit_event_id=row.id,
+                occurred_at_utc=row.occurred_at_utc,
+                action=row.action,
+                event_type=row.event_type,
+                outcome=row.outcome,
+                actor_id=row.actor_id,
+                metadata=row.metadata_json or {},
+            )
+            for row in anomaly_events
+        ],
+    )
+
+
+@router.get("/ops/audit-search", response_model=list[AuditSearchResponseItem])
+def audit_search(
+    q: str | None = None,
+    action: str | None = None,
+    event_type: str | None = None,
+    outcome: str | None = None,
+    actor_id: str | None = None,
+    lookback_hours: int = 168,
+    limit: int = 100,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, admin)
+    _require_admin_policy(
+        db,
+        allowed=_can_access_ops_views(context),
+        actor_id=admin.id,
+        org_id=context.org_ids[0] if context.org_ids else None,
+        action="admin.ops.audit.search",
+        metadata={"required_roles": sorted(OPS_ALLOWED_ROLES)},
+    )
+    org_id = context.org_ids[0]
+    lookback_cutoff = datetime.now(timezone.utc) - timedelta(hours=max(1, lookback_hours))
+    query = db.query(AuditEvent).filter(
+        AuditEvent.org_id == org_id,
+        AuditEvent.occurred_at_utc >= lookback_cutoff,
+    )
+    if action:
+        query = query.filter(AuditEvent.action.ilike(f"%{action}%"))
+    if event_type:
+        query = query.filter(AuditEvent.event_type.ilike(f"%{event_type}%"))
+    if outcome:
+        query = query.filter(AuditEvent.outcome == outcome)
+    if actor_id:
+        query = query.filter(AuditEvent.actor_id.ilike(f"%{actor_id}%"))
+    if q:
+        query = query.filter(
+            or_(
+                AuditEvent.action.ilike(f"%{q}%"),
+                AuditEvent.event_type.ilike(f"%{q}%"),
+                AuditEvent.actor_id.ilike(f"%{q}%"),
+            )
+        )
+    rows = query.order_by(AuditEvent.occurred_at_utc.desc()).limit(max(1, min(limit, 250))).all()
+    emit_audit_event(
+        db,
+        org_id=org_id,
+        actor_type="user",
+        actor_id=str(admin.id),
+        action="admin.ops.audit.search",
+        event_type="ops_audit_search_performed",
+        outcome="success",
+        metadata={
+            "query_text": q,
+            "action_filter": action,
+            "event_type_filter": event_type,
+            "outcome_filter": outcome,
+            "result_count": len(rows),
+        },
+    )
+    return [
+        AuditSearchResponseItem(
+            audit_event_id=row.id,
+            org_id=row.org_id,
+            incident_id=row.incident_id,
+            export_id=row.export_id,
+            actor_type=row.actor_type,
+            actor_id=row.actor_id,
+            action=row.action,
+            event_type=row.event_type,
+            outcome=row.outcome,
+            occurred_at_utc=row.occurred_at_utc,
+            metadata=row.metadata_json or {},
         )
         for row in rows
     ]

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -698,3 +698,71 @@ class JobExecutionMetaItem(BaseModel):
     last_error: str | None = None
     created_at_utc: datetime | None = None
     updated_at_utc: datetime | None = None
+
+
+class OpsIncidentItem(BaseModel):
+    incident_id: uuid.UUID
+    status: str
+    created_at_utc: datetime | None = None
+    adc_vehicle_id: str | None = None
+    adc_driver_id: str | None = None
+    reason: str
+
+
+class OpsFailedNotificationItem(BaseModel):
+    celery_task_id: str
+    status: str
+    retry_count: int = 0
+    max_retries: int | None = None
+    last_error: str | None = None
+    updated_at_utc: datetime | None = None
+
+
+class OpsFailedExportItem(BaseModel):
+    export_id: uuid.UUID
+    incident_id: uuid.UUID
+    export_type: ExportType
+    status: ExportStatus
+    error_message: str | None = None
+    updated_at_utc: datetime | None = None
+
+
+class IntegrationHealthItem(BaseModel):
+    integration_key: str
+    status: Literal["healthy", "degraded"]
+    failure_count: int = 0
+    last_failure_at_utc: datetime | None = None
+    details: str | None = None
+
+
+class OpsAnomalyItem(BaseModel):
+    audit_event_id: uuid.UUID
+    occurred_at_utc: datetime
+    action: str
+    event_type: str
+    outcome: str | None = None
+    actor_id: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class OpsDashboardResponse(BaseModel):
+    stuck_incidents: list[OpsIncidentItem] = Field(default_factory=list)
+    missing_evidence_incidents: list[OpsIncidentItem] = Field(default_factory=list)
+    failed_notifications: list[OpsFailedNotificationItem] = Field(default_factory=list)
+    failed_exports: list[OpsFailedExportItem] = Field(default_factory=list)
+    integration_health: list[IntegrationHealthItem] = Field(default_factory=list)
+    recent_anomalies: list[OpsAnomalyItem] = Field(default_factory=list)
+
+
+class AuditSearchResponseItem(BaseModel):
+    audit_event_id: uuid.UUID
+    org_id: uuid.UUID
+    incident_id: uuid.UUID | None = None
+    export_id: uuid.UUID | None = None
+    actor_type: str
+    actor_id: str
+    action: str
+    event_type: str
+    outcome: str | None = None
+    occurred_at_utc: datetime
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/backend/tests/test_driver_admin_endpoints.py
+++ b/backend/tests/test_driver_admin_endpoints.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from app.db.models import (
+    Artifact,
     AuditEvent,
     Base,
     Driver,
@@ -18,6 +19,7 @@ from app.db.models import (
     DriverInstructionStep,
     DriverVehicleAssignment,
     Event,
+    Export,
     Incident,
     JobExecutionMeta,
     Org,
@@ -986,3 +988,110 @@ class TestAdminOpsJobs:
         assert "failed" in statuses
         assert "retrying" in statuses
         assert "stuck" in statuses
+
+
+class TestAdminOpsDashboardAndAudit:
+    def test_ops_dashboard_exposes_operational_risks(
+        self, client, admin_headers, db_session, test_org
+    ):
+        stale_incident = Incident(
+            org_id=test_org.id,
+            adc_vehicle_id="veh-stale",
+            adc_driver_id="drv-stale",
+            status="evidence_capturing",
+            created_at_utc=datetime.now(timezone.utc) - timedelta(hours=4),
+        )
+        missing_evidence_incident = Incident(
+            org_id=test_org.id,
+            adc_vehicle_id="veh-missing",
+            adc_driver_id="drv-missing",
+            status="open",
+        )
+        db_session.add_all([stale_incident, missing_evidence_incident])
+        db_session.commit()
+        db_session.add(
+            Artifact(
+                org_id=test_org.id,
+                incident_id=missing_evidence_incident.incident_id,
+                artifact_type="dashcam",
+                status="pending",
+            )
+        )
+        db_session.add(
+            Export(
+                org_id=test_org.id,
+                incident_id=missing_evidence_incident.incident_id,
+                export_type="court_defense",
+                status="failed",
+                error_message="zip build failed",
+            )
+        )
+        db_session.add(
+            JobExecutionMeta(
+                celery_task_id="notify-failed-1",
+                task_name="app.tasks.notification_tasks.notify_safety_manager",
+                task_type="notification_tasks",
+                status="failed",
+                last_error="sms provider unavailable",
+            )
+        )
+        db_session.add(
+            AuditEvent(
+                org_id=test_org.id,
+                actor_type="user",
+                actor_id="user-x",
+                action="security.session.invalid_refresh",
+                event_type="authorization_failed",
+                outcome="failure",
+            )
+        )
+        db_session.commit()
+
+        resp = client.get("/admin/ops/dashboard", headers=admin_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["stuck_incidents"]) >= 1
+        assert len(data["missing_evidence_incidents"]) >= 1
+        assert len(data["failed_notifications"]) >= 1
+        assert len(data["failed_exports"]) >= 1
+        assert len(data["integration_health"]) >= 1
+        assert len(data["recent_anomalies"]) >= 1
+
+        audit = (
+            db_session.query(AuditEvent)
+            .filter(AuditEvent.event_type == "ops_dashboard_viewed")
+            .first()
+        )
+        assert audit is not None
+        assert audit.outcome == "success"
+
+    def test_audit_search_is_restricted_and_logged(
+        self, client, admin_headers, non_admin_headers, db_session, test_org
+    ):
+        db_session.add(
+            AuditEvent(
+                org_id=test_org.id,
+                actor_type="user",
+                actor_id="ops-user",
+                action="admin.ops.jobs.list",
+                event_type="ops_event",
+                outcome="success",
+            )
+        )
+        db_session.commit()
+
+        denied = client.get("/admin/ops/audit-search", headers=non_admin_headers)
+        assert denied.status_code == 403
+
+        allowed = client.get(
+            "/admin/ops/audit-search?q=ops-user",
+            headers=admin_headers,
+        )
+        assert allowed.status_code == 200
+        assert len(allowed.json()) >= 1
+        log = (
+            db_session.query(AuditEvent)
+            .filter(AuditEvent.event_type == "ops_audit_search_performed")
+            .first()
+        )
+        assert log is not None

--- a/frontend/app/admin/ops/audit/page.tsx
+++ b/frontend/app/admin/ops/audit/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import AdminLayout from "@/components/AdminLayout";
+import { searchOpsAudit, type AuditSearchResponseItem } from "@/lib/api";
+
+export default function AuditSearchPage() {
+  const [q, setQ] = useState("");
+  const [rows, setRows] = useState<AuditSearchResponseItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const runSearch = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const results = await searchOpsAudit({ q, limit: 100, lookback_hours: 168 });
+      setRows(results);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to search audit events");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AdminLayout title="Audit Search">
+      <div className="space-y-4">
+        <div className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <label className="block text-xs font-medium uppercase text-gray-400">Search</label>
+          <div className="mt-2 flex gap-2">
+            <input
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              placeholder="actor_id, event_type, action"
+              className="w-full rounded-md border px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-900"
+            />
+            <button
+              onClick={runSearch}
+              disabled={loading}
+              className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+            >
+              {loading ? "Searching…" : "Search"}
+            </button>
+          </div>
+          {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+        </div>
+
+        <div className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <table className="w-full text-left text-xs">
+            <thead className="text-gray-500">
+              <tr>
+                <th className="py-2">When</th>
+                <th className="py-2">Actor</th>
+                <th className="py-2">Event</th>
+                <th className="py-2">Action</th>
+                <th className="py-2">Outcome</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y dark:divide-gray-700">
+              {rows.map((row) => (
+                <tr key={row.audit_event_id}>
+                  <td className="py-2">{new Date(row.occurred_at_utc).toLocaleString()}</td>
+                  <td className="py-2 font-mono">{row.actor_id}</td>
+                  <td className="py-2">{row.event_type}</td>
+                  <td className="py-2">{row.action}</td>
+                  <td className="py-2">{row.outcome ?? "—"}</td>
+                </tr>
+              ))}
+              {rows.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="py-4 text-gray-500">No results yet.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </AdminLayout>
+  );
+}

--- a/frontend/app/admin/ops/page.tsx
+++ b/frontend/app/admin/ops/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import AdminLayout from "@/components/AdminLayout";
+import {
+  FailedJobsTable,
+  IntegrationHealthPanel,
+  SecurityAnomaliesPanel,
+} from "@/components/ops";
+import { getOpsDashboard, type OpsDashboardResponse } from "@/lib/api";
+
+export default function OpsDashboardPage() {
+  const [data, setData] = useState<OpsDashboardResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    getOpsDashboard()
+      .then(setData)
+      .catch((err) => setError(err instanceof Error ? err.message : "Failed to load ops dashboard"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <AdminLayout title="Ops Dashboard">
+      {loading && <p className="text-sm text-gray-500">Loading…</p>}
+      {error && <p className="mb-4 text-sm text-red-600">{error}</p>}
+
+      {data && (
+        <div className="space-y-6">
+          <section className="grid gap-4 sm:grid-cols-2">
+            <div className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              <h2 className="text-sm font-semibold text-gray-800 dark:text-gray-100">Stuck Incidents</h2>
+              <ul className="mt-2 space-y-2 text-xs text-gray-600 dark:text-gray-300">
+                {data.stuck_incidents.map((item) => (
+                  <li key={item.incident_id} className="rounded border p-2 dark:border-gray-700">
+                    <p className="font-mono">{item.incident_id}</p>
+                    <p>{item.reason}</p>
+                  </li>
+                ))}
+                {data.stuck_incidents.length === 0 && <li>None found.</li>}
+              </ul>
+            </div>
+
+            <div className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              <h2 className="text-sm font-semibold text-gray-800 dark:text-gray-100">Missing Evidence</h2>
+              <ul className="mt-2 space-y-2 text-xs text-gray-600 dark:text-gray-300">
+                {data.missing_evidence_incidents.map((item) => (
+                  <li key={item.incident_id} className="rounded border p-2 dark:border-gray-700">
+                    <p className="font-mono">{item.incident_id}</p>
+                    <p>{item.reason}</p>
+                  </li>
+                ))}
+                {data.missing_evidence_incidents.length === 0 && <li>None found.</li>}
+              </ul>
+            </div>
+          </section>
+
+          <FailedJobsTable rows={data.failed_notifications} />
+
+          <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-sm font-semibold text-gray-800 dark:text-gray-100">Failed Exports</h2>
+              <Link href="/exports" className="text-xs text-blue-600 hover:underline">Open exports</Link>
+            </div>
+            <ul className="space-y-2 text-xs text-gray-600 dark:text-gray-300">
+              {data.failed_exports.map((exp) => (
+                <li key={exp.export_id} className="rounded border p-2 dark:border-gray-700">
+                  <p>
+                    Export <span className="font-mono">{exp.export_id}</span> · Incident <span className="font-mono">{exp.incident_id}</span>
+                  </p>
+                  <p className="text-red-600">{exp.error_message ?? "Unknown export error"}</p>
+                </li>
+              ))}
+              {data.failed_exports.length === 0 && <li>No failed exports.</li>}
+            </ul>
+          </section>
+
+          <IntegrationHealthPanel items={data.integration_health} />
+          <SecurityAnomaliesPanel items={data.recent_anomalies} />
+        </div>
+      )}
+    </AdminLayout>
+  );
+}

--- a/frontend/components/AdminLayout.tsx
+++ b/frontend/components/AdminLayout.tsx
@@ -10,7 +10,17 @@ const NAV_ITEMS = [
   { href: "/admin/driver-protocol", label: "Driver Protocol" },
   { href: "/admin/driver-protocol/instructions", label: "Instructions" },
   { href: "/admin/vehicles", label: "Vehicles" },
+  { href: "/admin/ops", label: "Ops Dashboard" },
+  { href: "/admin/ops/audit", label: "Audit Search" },
 ];
+
+const AUTHORIZED_OPS_ROLES = new Set([
+  "admin",
+  "org_admin",
+  "system_admin",
+  "support_admin",
+  "support_agent",
+]);
 
 type AdminLayoutProps = {
   title: string;
@@ -25,7 +35,7 @@ export default function AdminLayout({ title, children }: AdminLayoutProps) {
     return <div className="p-6 text-gray-500">Loading…</div>;
   }
 
-  if (!user || user.role !== "admin") {
+  if (!user || !AUTHORIZED_OPS_ROLES.has(user.role)) {
     return (
       <div className="p-6 text-sm text-gray-500">
         Admin access required.

--- a/frontend/components/ops.tsx
+++ b/frontend/components/ops.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import Link from "next/link";
+import type {
+  IntegrationHealthItem,
+  OpsAnomalyItem,
+  OpsFailedNotificationItem,
+} from "@/lib/api";
+
+function formatDate(value?: string | null) {
+  if (!value) return "—";
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? "—" : d.toLocaleString();
+}
+
+export function FailedJobsTable({
+  rows,
+}: {
+  rows: OpsFailedNotificationItem[];
+}) {
+  return (
+    <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <h2 className="text-sm font-semibold text-gray-800 dark:text-gray-100">
+        Failed Notifications
+      </h2>
+      <div className="mt-3 overflow-x-auto">
+        <table className="w-full text-left text-xs">
+          <thead className="text-gray-500">
+            <tr>
+              <th className="py-2">Task</th>
+              <th className="py-2">Status</th>
+              <th className="py-2">Retries</th>
+              <th className="py-2">Updated</th>
+              <th className="py-2">Error</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y dark:divide-gray-700">
+            {rows.map((item) => (
+              <tr key={item.celery_task_id}>
+                <td className="py-2 font-mono text-[11px]">{item.celery_task_id}</td>
+                <td className="py-2">{item.status}</td>
+                <td className="py-2">
+                  {item.retry_count}/{item.max_retries ?? "—"}
+                </td>
+                <td className="py-2">{formatDate(item.updated_at_utc)}</td>
+                <td className="py-2 text-red-600">{item.last_error ?? "—"}</td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td className="py-4 text-gray-500" colSpan={5}>
+                  No failed notifications.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+export function IntegrationHealthPanel({
+  items,
+}: {
+  items: IntegrationHealthItem[];
+}) {
+  return (
+    <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <h2 className="text-sm font-semibold text-gray-800 dark:text-gray-100">
+        Integration Health
+      </h2>
+      <ul className="mt-3 space-y-2 text-sm">
+        {items.map((item) => (
+          <li key={item.integration_key} className="rounded border p-3 dark:border-gray-700">
+            <div className="flex items-center justify-between">
+              <p className="font-medium text-gray-800 dark:text-gray-100">
+                {item.integration_key}
+              </p>
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs ${
+                  item.status === "healthy"
+                    ? "bg-green-100 text-green-700"
+                    : "bg-yellow-100 text-yellow-700"
+                }`}
+              >
+                {item.status}
+              </span>
+            </div>
+            <p className="text-xs text-gray-500">
+              Failures: {item.failure_count} · Last failure: {formatDate(item.last_failure_at_utc)}
+            </p>
+            {item.details ? <p className="text-xs text-gray-500">{item.details}</p> : null}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export function SecurityAnomaliesPanel({
+  items,
+}: {
+  items: OpsAnomalyItem[];
+}) {
+  return (
+    <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-gray-800 dark:text-gray-100">
+          Recent Audit / Security Anomalies
+        </h2>
+        <Link href="/admin/ops/audit" className="text-xs text-blue-600 hover:underline">
+          Open audit search
+        </Link>
+      </div>
+      <ul className="mt-3 space-y-2 text-xs text-gray-600 dark:text-gray-300">
+        {items.map((item) => (
+          <li key={item.audit_event_id} className="rounded border p-3 dark:border-gray-700">
+            <p>
+              <span className="font-semibold">{item.event_type}</span> · {item.action}
+            </p>
+            <p>
+              Actor {item.actor_id} · Outcome {item.outcome ?? "n/a"} · {formatDate(item.occurred_at_utc)}
+            </p>
+          </li>
+        ))}
+        {items.length === 0 && <li>No anomalies in lookback window.</li>}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -441,3 +441,107 @@ export function rotateVehicleQr(vehicleId: string) {
 export function getVehicleQrPayload(vehicleId: string) {
   return request<{ deep_link: string }>(`/admin/vehicles/${vehicleId}/qr`);
 }
+
+export interface OpsIncidentItem {
+  incident_id: string;
+  status: string;
+  created_at_utc?: string | null;
+  adc_vehicle_id?: string | null;
+  adc_driver_id?: string | null;
+  reason: string;
+}
+
+export interface OpsFailedNotificationItem {
+  celery_task_id: string;
+  status: string;
+  retry_count: number;
+  max_retries?: number | null;
+  last_error?: string | null;
+  updated_at_utc?: string | null;
+}
+
+export interface OpsFailedExportItem {
+  export_id: string;
+  incident_id: string;
+  export_type: ExportType;
+  status: ExportStatus;
+  error_message?: string | null;
+  updated_at_utc?: string | null;
+}
+
+export interface IntegrationHealthItem {
+  integration_key: string;
+  status: "healthy" | "degraded";
+  failure_count: number;
+  last_failure_at_utc?: string | null;
+  details?: string | null;
+}
+
+export interface OpsAnomalyItem {
+  audit_event_id: string;
+  occurred_at_utc: string;
+  action: string;
+  event_type: string;
+  outcome?: string | null;
+  actor_id: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface OpsDashboardResponse {
+  stuck_incidents: OpsIncidentItem[];
+  missing_evidence_incidents: OpsIncidentItem[];
+  failed_notifications: OpsFailedNotificationItem[];
+  failed_exports: OpsFailedExportItem[];
+  integration_health: IntegrationHealthItem[];
+  recent_anomalies: OpsAnomalyItem[];
+}
+
+export interface AuditSearchResponseItem {
+  audit_event_id: string;
+  org_id: string;
+  incident_id?: string | null;
+  export_id?: string | null;
+  actor_type: string;
+  actor_id: string;
+  action: string;
+  event_type: string;
+  outcome?: string | null;
+  occurred_at_utc: string;
+  metadata: Record<string, unknown>;
+}
+
+export function getOpsDashboard(params?: {
+  stale_after_minutes?: number;
+  lookback_hours?: number;
+}) {
+  const query = new URLSearchParams();
+  if (params?.stale_after_minutes) {
+    query.set("stale_after_minutes", String(params.stale_after_minutes));
+  }
+  if (params?.lookback_hours) {
+    query.set("lookback_hours", String(params.lookback_hours));
+  }
+  const suffix = query.toString() ? `?${query.toString()}` : "";
+  return request<OpsDashboardResponse>(`/admin/ops/dashboard${suffix}`);
+}
+
+export function searchOpsAudit(params?: {
+  q?: string;
+  action?: string;
+  event_type?: string;
+  outcome?: string;
+  actor_id?: string;
+  lookback_hours?: number;
+  limit?: number;
+}) {
+  const query = new URLSearchParams();
+  if (params?.q) query.set("q", params.q);
+  if (params?.action) query.set("action", params.action);
+  if (params?.event_type) query.set("event_type", params.event_type);
+  if (params?.outcome) query.set("outcome", params.outcome);
+  if (params?.actor_id) query.set("actor_id", params.actor_id);
+  if (params?.lookback_hours) query.set("lookback_hours", String(params.lookback_hours));
+  if (params?.limit) query.set("limit", String(params.limit));
+  const suffix = query.toString() ? `?${query.toString()}` : "";
+  return request<AuditSearchResponseItem[]>(`/admin/ops/audit-search${suffix}`);
+}


### PR DESCRIPTION
### Motivation
- Provide operational visibility for stuck incidents, missing evidence, failed notifications, failed exports, integration health, and recent audit/security anomalies. 
- Surface these signals in a role-restricted ops UI and ensure every access is recorded in the audit trail for compliance and investigation.

### Description
- Added API schemas (`OpsDashboardResponse`, `OpsIncidentItem`, `OpsFailedNotificationItem`, `OpsFailedExportItem`, `IntegrationHealthItem`, `OpsAnomalyItem`, `AuditSearchResponseItem`) in `backend/app/api/schemas.py` to model ops payloads.
- Implemented new backend endpoints in `backend/app/api/routes_admin.py`: `GET /admin/ops/dashboard` (aggregates incidents, artifacts, jobs, exports and audit anomalies) and `GET /admin/ops/audit-search` (filterable audit event search), with queries against `Incident`, `Artifact`, `JobExecutionMeta`, `Export`, and `AuditEvent` and structured responses.
- Enforced role-restrictions for ops views using `OPS_ALLOWED_ROLES` + `_can_access_ops_views` and kept explicit authorization-failure audit emission via `_require_admin_policy`; added success-path audit events (`ops_dashboard_viewed`, `ops_audit_search_performed`).
- Extended the frontend client `frontend/lib/api.ts` with typed models and helper functions `getOpsDashboard` and `searchOpsAudit`.
- Added UI components and pages: `FailedJobsTable`, `IntegrationHealthPanel`, `SecurityAnomaliesPanel` (`frontend/components/ops.tsx`), `OpsDashboardPage` (`/admin/ops`), and `AuditSearchPage` (`/admin/ops/audit`).
- Updated `AdminLayout` navigation and role gating (`frontend/components/AdminLayout.tsx`) to surface ops links and allow authorized support/admin roles.
- Added backend tests exercising the new endpoints, role restrictions, and audit logging in `backend/tests/test_driver_admin_endpoints.py`.

### Testing
- Ran backend unit tests with `python -m pytest backend/tests/test_driver_admin_endpoints.py -q` and observed `40 passed` (no failures).
- Ran backend linter with `ruff check app tests` which completed with no new issues.
- Ran frontend lint with `npm run lint` which completed; one pre-existing warning remains in `frontend/components/marketing/Hero.tsx` and is unrelated to these changes.
- Ran frontend typecheck and unit tests with `npm run typecheck` and `npm test`, and all frontend tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c42cd8f48321ad53c3b6a7c4dc6f)