### PR TITLE
Standardize API errors with safe messaging, codes, and correlation IDs

### DIFF
--- a/backend/app/api/error_responses.py
+++ b/backend/app/api/error_responses.py
@@ -1,0 +1,26 @@
+"""Helpers for standardized user-safe API error responses."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+from app.api.schemas import ApiErrorDetail, ApiErrorCode
+from app.core.logging import get_request_id
+
+
+def raise_api_error(
+    *,
+    status_code: int,
+    message: str,
+    code: ApiErrorCode,
+    retry_hint: str | None = None,
+) -> None:
+    raise HTTPException(
+        status_code=status_code,
+        detail=ApiErrorDetail(
+            message=message,
+            code=code,
+            retry_hint=retry_hint,
+            correlation_id=get_request_id(),
+        ).model_dump(exclude_none=True),
+    )

--- a/backend/app/api/routes_exports.py
+++ b/backend/app/api/routes_exports.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qs, urlparse
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
+from app.api.error_responses import raise_api_error
 from app.api.schemas import (
     CreateExportEnqueueResponse,
     CreateExportRequest,
@@ -76,7 +77,11 @@ def create_export_endpoint(
     incident = get_incident(db, body.incident_id)
     if incident is None:
         increment(MetricNames.EXPORT_REQUEST_FAILURES)
-        raise HTTPException(status_code=404, detail="Incident not found")
+        raise_api_error(
+            status_code=404,
+            message="Incident not found",
+            code="RESOURCE_NOT_FOUND",
+        )
     allowed = can_request_export(context, incident)
     if not allowed:
         emit_audit_event(
@@ -165,10 +170,12 @@ def create_export_endpoint(
     except Exception as exc:
         increment(MetricNames.EXPORT_REQUEST_FAILURES)
         logger.exception("Failed to enqueue export task")
-        raise HTTPException(
+        raise_api_error(
             status_code=502,
-            detail="Unable to enqueue export generation",
-        ) from exc
+            message="Export processing is temporarily degraded.",
+            code="THIRD_PARTY_DEGRADED",
+            retry_hint="Please retry export generation in a few minutes.",
+        )
 
     export = update_export(db, export.export_id, status="queued", transition_actor="api_user") or export
     task_id = getattr(task_result, "id", None)
@@ -208,7 +215,12 @@ def retry_export_endpoint(
     context = build_user_auth_context(db, current_user)
     failed_export = _resolve_authorized_export(db, export_id, list(context.org_ids), context=context)
     if failed_export.status != "failed":
-        raise HTTPException(status_code=409, detail="Only failed exports can be retried")
+        raise_api_error(
+            status_code=409,
+            message="Only failed exports can be retried.",
+            code="EXPORT_RETRY_ALLOWED",
+            retry_hint="Wait for the export to fail, then retry.",
+        )
 
     new_export = create_export(
         db,
@@ -271,10 +283,12 @@ def retry_export_endpoint(
         )
     except Exception as exc:
         logger.exception("Failed to enqueue retry export task")
-        raise HTTPException(
+        raise_api_error(
             status_code=502,
-            detail="Unable to enqueue export generation",
-        ) from exc
+            message="Export processing is temporarily degraded.",
+            code="THIRD_PARTY_DEGRADED",
+            retry_hint="Please retry export generation in a few minutes.",
+        )
     new_export = update_export(db, new_export.export_id, status="queued", transition_actor="api_user") or new_export
     task_id = getattr(task_result, "id", None)
     create_event(
@@ -350,7 +364,11 @@ def _resolve_authorized_export(
 ):
     export = get_export(db, export_id)
     if not export:
-        raise HTTPException(status_code=404, detail="Export not found")
+        raise_api_error(
+            status_code=404,
+            message="Export not found",
+            code="RESOURCE_NOT_FOUND",
+        )
 
     export_org_id = _get_export_owner_org_id(db, export)
     if context is not None:
@@ -369,7 +387,11 @@ def _resolve_authorized_export(
             )
             require_policy(False)
     elif export_org_id is None or export_org_id not in org_ids:
-        raise HTTPException(status_code=403, detail="Forbidden")
+        raise_api_error(
+            status_code=403,
+            message="You do not have access to this export.",
+            code="ACCESS_DENIED",
+        )
     return export
 
 
@@ -612,7 +634,11 @@ def download_export_endpoint(
         export = get_export(db, export_id)
     if not export:
         increment(MetricNames.EXPORT_DOWNLOAD_FAILURES)
-        raise HTTPException(status_code=404, detail="Export not found")
+        raise_api_error(
+            status_code=404,
+            message="Export not found",
+            code="RESOURCE_NOT_FOUND",
+        )
 
     export_org_id = _get_export_owner_org_id(db, export)
     if not can_download_export(context, export, export_org_id=export_org_id):
@@ -629,18 +655,32 @@ def download_export_endpoint(
             export_id=export.export_id,
             metadata={"should_log": True, "resource": "export_download"},
         )
-        raise HTTPException(status_code=403, detail="Forbidden")
+        raise_api_error(
+            status_code=403,
+            message="You do not have access to this export.",
+            code="ACCESS_DENIED",
+        )
 
     if export.status != "ready":
         increment(MetricNames.EXPORT_DOWNLOAD_FAILURES)
-        raise HTTPException(status_code=409, detail="Export is not ready")
+        raise_api_error(
+            status_code=409,
+            message="Export is still processing.",
+            code="EXPORT_DELAYED",
+            retry_hint="Try downloading again in 30-60 seconds.",
+        )
     now = datetime.now(timezone.utc)
     expires_at = export.expires_at_utc
     if expires_at and expires_at.tzinfo is None:
         expires_at = expires_at.replace(tzinfo=timezone.utc)
     if expires_at and expires_at <= now:
         increment(MetricNames.EXPORT_DOWNLOAD_FAILURES)
-        raise HTTPException(status_code=410, detail="Export is expired")
+        raise_api_error(
+            status_code=410,
+            message="This export link has expired.",
+            code="EXPORT_EXPIRED",
+            retry_hint="Generate a new export package and retry download.",
+        )
 
     bucket = export.s3_bucket or settings.S3_BUCKET
     key = export.s3_key or f"exports/{export.export_id}.zip"
@@ -655,16 +695,29 @@ def download_export_endpoint(
         )
     except S3PresignConfigurationError as exc:
         increment(MetricNames.EXPORT_DOWNLOAD_FAILURES)
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        logger.warning("Presign configuration invalid", extra={"error": str(exc)})
+        raise_api_error(
+            status_code=422,
+            message="Export download is temporarily unavailable.",
+            code="THIRD_PARTY_DEGRADED",
+            retry_hint="Please retry shortly or contact support with the correlation ID.",
+        )
     except S3PresignGenerationError as exc:
         increment(MetricNames.EXPORT_DOWNLOAD_FAILURES)
-        raise HTTPException(
+        raise_api_error(
             status_code=502,
-            detail="Unable to generate export download URL",
-        ) from exc
+            message="Unable to prepare export download right now.",
+            code="THIRD_PARTY_DEGRADED",
+            retry_hint="Please retry in a few minutes.",
+        )
     if not _is_presigned_https_url(presigned_url):
         increment(MetricNames.EXPORT_DOWNLOAD_FAILURES)
-        raise HTTPException(status_code=502, detail="Invalid presigned download URL")
+        raise_api_error(
+            status_code=502,
+            message="Unable to prepare export download right now.",
+            code="THIRD_PARTY_DEGRADED",
+            retry_hint="Please retry in a few minutes.",
+        )
 
     create_event(
         db,

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -127,6 +127,32 @@ ArtifactUploadContentType = Literal[
     "image/png",
     "video/mp4",
 ]
+
+
+ApiErrorCode = Literal[
+    "EXPORT_DELAYED",
+    "EXPORT_NOT_READY",
+    "EXPORT_EXPIRED",
+    "EXPORT_RETRY_ALLOWED",
+    "UPLOAD_RETRY_RECOMMENDED",
+    "THIRD_PARTY_DEGRADED",
+    "RESOURCE_NOT_FOUND",
+    "ACCESS_DENIED",
+    "RATE_LIMITED",
+    "REQUEST_INVALID",
+    "INTERNAL_ERROR",
+]
+
+
+class ApiErrorDetail(BaseModel):
+    message: Annotated[str, StringConstraints(min_length=1, max_length=300)]
+    code: ApiErrorCode
+    retry_hint: Annotated[str, StringConstraints(min_length=1, max_length=300)] | None = None
+    correlation_id: Annotated[str, StringConstraints(min_length=8, max_length=128)] | None = None
+
+
+class ApiErrorResponse(BaseModel):
+    detail: ApiErrorDetail
 DriverTimelineEventName = Literal[
     "driver_protocol_launch_confirmed",
     "driver_safety_gate_viewed",

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -859,7 +859,10 @@ class TestDownloadExport:
 
         resp = client.get(f"/exports/{exp.export_id}/download", headers=auth_headers)
         assert resp.status_code == 422
-        assert resp.json()["detail"] == "Export download bucket is not configured"
+        detail = resp.json()["detail"]
+        assert detail["code"] == "THIRD_PARTY_DEGRADED"
+        assert detail["message"] == "Export download is temporarily unavailable."
+        assert detail.get("correlation_id")
 
     @patch("app.api.routes_exports.generate_presigned_download_url")
     def test_download_export_presign_failure_returns_502(
@@ -889,7 +892,10 @@ class TestDownloadExport:
 
         resp = client.get(f"/exports/{exp.export_id}/download", headers=auth_headers)
         assert resp.status_code == 502
-        assert resp.json()["detail"] == "Unable to generate export download URL"
+        detail = resp.json()["detail"]
+        assert detail["code"] == "THIRD_PARTY_DEGRADED"
+        assert detail["message"] == "Unable to prepare export download right now."
+        assert detail.get("correlation_id")
 
     def test_download_export_forbidden_when_legacy_null_org_export_has_no_org_incident(
         self, client, db_session, auth_headers
@@ -935,7 +941,10 @@ class TestDownloadExport:
 
         resp = client.get(f"/exports/{exp.export_id}/download", headers=auth_headers)
         assert resp.status_code == 410
-        assert resp.json()["detail"] == "Export is expired"
+        detail = resp.json()["detail"]
+        assert detail["code"] == "EXPORT_EXPIRED"
+        assert detail["message"] == "This export link has expired."
+        assert detail.get("correlation_id")
 
     @pytest.mark.parametrize("status", ["requested", "queued", "processing", "failed"])
     def test_download_export_not_ready_statuses_return_409(
@@ -980,7 +989,10 @@ class TestDownloadExport:
 
         resp = client.get(f"/exports/{exp.export_id}/download", headers=auth_headers)
         assert resp.status_code == 502
-        assert resp.json()["detail"] == "Invalid presigned download URL"
+        detail = resp.json()["detail"]
+        assert detail["code"] == "THIRD_PARTY_DEGRADED"
+        assert detail["message"] == "Unable to prepare export download right now."
+        assert detail.get("correlation_id")
 
 
 # ── GET /exports/{export_id} ───────────────────────────────────────

--- a/frontend/app/exports/page.tsx
+++ b/frontend/app/exports/page.tsx
@@ -16,6 +16,7 @@ import {
   type ExportDownloadAuditResponse,
   type ExportStatus,
   type ExportType,
+  toUserErrorMessage,
 } from "@/lib/api";
 import { getExportStatusBadgeClass, getExportStatusLabel } from "@/lib/exportStatus";
 
@@ -81,7 +82,7 @@ export default function ExportsPage() {
   useEffect(() => {
     listExports()
       .then(setExports)
-      .catch((err) => setError(err.message))
+      .catch((err) => setError(toUserErrorMessage(err, "Failed to load exports")))
       .finally(() => setLoading(false));
   }, []);
 
@@ -98,7 +99,7 @@ export default function ExportsPage() {
         setAudit(exportAudit);
       })
       .catch((err: unknown) => {
-        setError(err instanceof Error ? err.message : "Failed to load export detail");
+        setError(toUserErrorMessage(err, "Failed to load export detail"));
       })
       .finally(() => setDetailLoading(false));
   }, [selectedExportId]);
@@ -144,7 +145,7 @@ export default function ExportsPage() {
       const result = await downloadExport(exportId);
       window.open(result.url, "_blank");
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Download failed");
+      setError(toUserErrorMessage(err, "Download failed"));
     }
   }
 

--- a/frontend/app/incidents/[id]/IncidentDetailClient.tsx
+++ b/frontend/app/incidents/[id]/IncidentDetailClient.tsx
@@ -9,6 +9,7 @@ import {
   type IncidentDetail,
   type DriverProtocolSummary,
   type DriverResponseSummary,
+  toUserErrorMessage,
 } from "@/lib/api";
 import { useAuth } from "@/lib/useAuth";
 import EvidenceTable, { EVIDENCE_TYPES } from "@/components/EvidenceTable";
@@ -98,7 +99,7 @@ export default function IncidentDetailClient() {
     if (!user) return;
     getIncident(id)
       .then(setIncident)
-      .catch((err) => setError(err.message))
+      .catch((err) => setError(toUserErrorMessage(err, "Failed to load incident")))
       .finally(() => setLoading(false));
   }, [id, user]);
 

--- a/frontend/components/IncidentDetailExportPanel.tsx
+++ b/frontend/components/IncidentDetailExportPanel.tsx
@@ -11,6 +11,7 @@ import {
   type ExportStatus,
   type ExportSummary,
   type ExportType,
+  toUserErrorMessage,
 } from "@/lib/api";
 import { getExportStatusBadgeClass, getExportStatusLabel } from "@/lib/exportStatus";
 import GenerateExportModal from "@/components/GenerateExportModal";
@@ -88,7 +89,7 @@ export default function IncidentDetailExportPanel({
           window.clearInterval(timer);
         }
       } catch (err: unknown) {
-        setErrorMessage(err instanceof Error ? err.message : "Unable to poll export status");
+        setErrorMessage(toUserErrorMessage(err, "Unable to poll export status"));
       }
     }, 2500);
 
@@ -119,15 +120,19 @@ export default function IncidentDetailExportPanel({
       setShowModal(false);
       await onExportsChanged();
     } catch (err: unknown) {
-      setErrorMessage(err instanceof Error ? err.message : "Failed to create export");
+      setErrorMessage(toUserErrorMessage(err, "Failed to create export"));
     } finally {
       setSubmitting(false);
     }
   }
 
   async function handleDownload(exportId: string) {
-    const result = await downloadExport(exportId);
-    window.open(result.url, "_blank");
+    try {
+      const result = await downloadExport(exportId);
+      window.open(result.url, "_blank");
+    } catch (err: unknown) {
+      setErrorMessage(toUserErrorMessage(err, "Failed to download export"));
+    }
   }
 
   async function handleRetry(exportId: string) {
@@ -141,7 +146,7 @@ export default function IncidentDetailExportPanel({
       setReadyExport(null);
       await onExportsChanged();
     } catch (err: unknown) {
-      setErrorMessage(err instanceof Error ? err.message : "Failed to retry export");
+      setErrorMessage(toUserErrorMessage(err, "Failed to retry export"));
     } finally {
       setSubmitting(false);
     }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -7,6 +7,72 @@ const API_BASE =
       "http://localhost:8000"
     : process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
 
+type ApiErrorDetail = {
+  message?: string;
+  code?: string;
+  retry_hint?: string;
+  correlation_id?: string;
+};
+
+type ApiErrorPayload = {
+  detail?: string | ApiErrorDetail;
+};
+
+export class ApiRequestError extends Error {
+  status: number;
+  code?: string;
+  retryHint?: string;
+  correlationId?: string;
+
+  constructor(
+    message: string,
+    status: number,
+    options: { code?: string; retryHint?: string; correlationId?: string } = {}
+  ) {
+    super(message);
+    this.name = "ApiRequestError";
+    this.status = status;
+    this.code = options.code;
+    this.retryHint = options.retryHint;
+    this.correlationId = options.correlationId;
+  }
+}
+
+function parseApiErrorPayload(payload: ApiErrorPayload | null | undefined) {
+  const detail = payload?.detail;
+  if (typeof detail === "string") {
+    return { message: detail };
+  }
+  return {
+    message: detail?.message,
+    code: detail?.code,
+    retryHint: detail?.retry_hint,
+    correlationId: detail?.correlation_id,
+  };
+}
+
+export function toUserErrorMessage(error: unknown, fallback = "Request failed"): string {
+  if (!(error instanceof ApiRequestError)) {
+    if (error instanceof Error && error.message) return error.message;
+    return fallback;
+  }
+
+  const guidanceByCode: Record<string, string> = {
+    EXPORT_DELAYED: "Export generation is taking longer than usual. Wait a minute, then try download again.",
+    EXPORT_NOT_READY: "Export is still processing. Please check again shortly.",
+    EXPORT_EXPIRED: "This export has expired. Generate a new export package to continue.",
+    EXPORT_RETRY_ALLOWED: "Only failed exports can be retried. Wait for processing to complete first.",
+    UPLOAD_RETRY_RECOMMENDED: "Upload processing is delayed. Retry the upload in a few moments.",
+    THIRD_PARTY_DEGRADED: "A connected provider is degraded right now. Retry shortly.",
+  };
+
+  const guidance = error.code ? guidanceByCode[error.code] : undefined;
+  const hint = error.retryHint ? ` ${error.retryHint}` : "";
+  const correlation = error.correlationId ? ` (Ref: ${error.correlationId})` : "";
+
+  return `${guidance ?? error.message ?? fallback}${hint}${correlation}`.trim();
+}
+
 async function request<T>(
   path: string,
   init?: RequestInit
@@ -27,12 +93,13 @@ async function request<T>(
     if (typeof window !== "undefined" && !isAuthMutation) {
       window.location.href = "/login";
     }
-    throw new Error("Unauthorized");
+    throw new ApiRequestError("Unauthorized", 401);
   }
 
   if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error(body.detail ?? res.statusText);
+    const body = (await res.json().catch(() => ({}))) as ApiErrorPayload;
+    const parsed = parseApiErrorPayload(body);
+    throw new ApiRequestError(parsed.message ?? res.statusText, res.status, parsed);
   }
 
   if (res.status === 204) {


### PR DESCRIPTION
### Motivation
- Provide a consistent, user-safe error contract from the backend that carries a machine-readable code and optional retry guidance while avoiding leakage of internal errors.
- Surface operator diagnostics via non-sensitive correlation IDs so support/debugging can reference server logs without exposing stack traces to users.
- Make the frontend consume the structured contract and present actionable guidance (delayed exports, retry uploads, third-party degradation) instead of raw internals.

### Description
- Added an API error contract to backend schemas: `ApiErrorDetail` and `ApiErrorResponse` with `message`, `code`, optional `retry_hint`, and `correlation_id`. (backend/app/api/schemas.py)
- Introduced `raise_api_error` helper to emit structured, user-safe HTTP errors including the current correlation ID. (backend/app/api/error_responses.py)
- Updated export routes to use the structured error helper for common failure cases (not found, access denied, export delayed/not-ready, expired export, presign/config failures, task enqueue failures) to return safe messages and codes. (backend/app/api/routes_exports.py)
- Updated backend tests to assert the new structured error shape (`detail.code`, `detail.message`, `detail.correlation_id`) for export download failure scenarios. (backend/tests/test_api_endpoints.py)
- Frontend: enhanced `frontend/lib/api.ts` to parse structured error payloads into a richer `ApiRequestError`, expose `toUserErrorMessage` which maps known error codes to user guidance and surfaces correlation IDs.
- Frontend pages/components that interact with exports and incident detail now use `toUserErrorMessage` to show contextual guidance for delayed exports, retrying uploads/exports, and third-party degradation. (frontend/components/IncidentDetailExportPanel.tsx, frontend/app/exports/page.tsx, frontend/app/incidents/[id]/IncidentDetailClient.tsx)

### Testing
- Ran backend export download contract tests: `pytest backend/tests/test_api_endpoints.py::TestDownloadExport -q` and then the backend contract suite `pytest backend/tests/test_frontend_contracts.py -q`; all assertions updated and passed (backend tests passed).
- Frontend unit tests: `cd frontend && npm test -- --runInBand` passed (all tests OK).
- Frontend linter: `cd frontend && npm run lint` completed with a pre-existing single warning in `frontend/components/marketing/Hero.tsx` (no new lint errors).
- All modified automated tests ran successfully after updates; structured-error expectations are validated by the test changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c42eff50832188bf3d48f2bb77eb)