### PR TITLE
Add log redaction and suspicious activity detection

### DIFF
--- a/backend/app/audit/emitter.py
+++ b/backend/app/audit/emitter.py
@@ -10,6 +10,8 @@ from sqlalchemy.orm import Session
 
 from app.audit.models import AuditEventCreate
 from app.audit.service import append_event
+from app.observability.detection import audit_activity_detector
+from app.observability.redaction import redact_log_data
 
 logger = logging.getLogger(__name__)
 
@@ -47,14 +49,35 @@ def emit_audit_event(
                 metadata=metadata or {},
             ),
         )
+        alerts = audit_activity_detector.evaluate(
+            org_id=str(org_id),
+            actor_type=actor_type,
+            actor_id=actor_id,
+            action=action,
+            event_type=event_type,
+            outcome=outcome,
+            metadata=metadata or {},
+        )
+        for alert in alerts:
+            logger.warning(
+                alert.message,
+                extra=redact_log_data(
+                    {
+                        "alert": alert.rule,
+                        "severity": alert.severity,
+                        **alert.context,
+                    }
+                ),
+            )
     except Exception:
         logger.exception(
             "Failed to append audit event",
-            extra={
+            extra=redact_log_data({
                 "org_id": str(org_id),
                 "actor_type": actor_type,
                 "actor_id": actor_id,
                 "action": action,
                 "event_type": event_type,
-            },
+                "metadata": metadata or {},
+            }),
         )

--- a/backend/app/observability/alerts.py
+++ b/backend/app/observability/alerts.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 
 from app.core.config import settings
+from app.observability.redaction import redact_log_data
 
 logger = logging.getLogger(__name__)
 _sentry_ready = False
@@ -46,27 +47,28 @@ def init_sentry(*, service: str) -> None:
 
 
 def capture_exception(exc: Exception, *, context: dict[str, Any] | None = None) -> None:
-    logger.exception("Unhandled exception", exc_info=exc, extra={"alert": "exception"})
+    logger.exception("Unhandled exception", exc_info=exc, extra=redact_log_data({"alert": "exception", "context": context or {}}))
     if not _sentry_ready:
         return
 
     import sentry_sdk
 
     with sentry_sdk.push_scope() as scope:
-        for key, value in (context or {}).items():
+        for key, value in redact_log_data(context or {}).items():
             scope.set_extra(key, value)
         sentry_sdk.capture_exception(exc)
 
 
 def capture_message(message: str, *, level: str = "warning", **context: Any) -> None:
     log_level = getattr(logging, level.upper(), logging.WARNING)
-    logger.log(log_level, message, extra={"alert": "message"})
+    safe_context = redact_log_data(context)
+    logger.log(log_level, redact_log_data(message), extra={"alert": "message", "context": safe_context})
     if not _sentry_ready:
         return
 
     import sentry_sdk
 
     with sentry_sdk.push_scope() as scope:
-        for key, value in context.items():
+        for key, value in safe_context.items():
             scope.set_extra(key, value)
-        sentry_sdk.capture_message(message, level=level)
+        sentry_sdk.capture_message(redact_log_data(message), level=level)

--- a/backend/app/observability/detection.py
+++ b/backend/app/observability/detection.py
@@ -1,0 +1,130 @@
+"""In-process suspicious activity detectors for high-signal audit events."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from threading import Lock
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DetectionAlert:
+    rule: str
+    severity: str
+    message: str
+    context: dict[str, Any]
+
+
+class _SlidingWindowCounter:
+    def __init__(self) -> None:
+        self._events: dict[str, deque[datetime]] = defaultdict(deque)
+
+    def increment_and_count(self, key: str, now: datetime, window: timedelta) -> int:
+        bucket = self._events[key]
+        bucket.append(now)
+        cutoff = now - window
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        return len(bucket)
+
+
+class AuditActivityDetector:
+    """Applies threshold-based rules over recent audit events."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._auth_failures = _SlidingWindowCounter()
+        self._admin_actions = _SlidingWindowCounter()
+        self._downloads = _SlidingWindowCounter()
+
+    def evaluate(
+        self,
+        *,
+        org_id: str,
+        actor_type: str,
+        actor_id: str,
+        action: str,
+        event_type: str,
+        outcome: str | None,
+        metadata: dict[str, Any] | None = None,
+        now: datetime | None = None,
+    ) -> list[DetectionAlert]:
+        when = now or datetime.now(timezone.utc)
+        details = metadata or {}
+        alerts: list[DetectionAlert] = []
+
+        with self._lock:
+            if event_type == "auth_login_failed" or (action == "auth.login" and outcome == "failure"):
+                count = self._auth_failures.increment_and_count(
+                    key=f"{org_id}:{actor_id}", now=when, window=timedelta(minutes=10)
+                )
+                if count >= 5:
+                    alerts.append(
+                        DetectionAlert(
+                            rule="repeated_auth_failures",
+                            severity="high",
+                            message="Repeated authentication failures detected",
+                            context={"org_id": org_id, "actor_id": actor_id, "count": count, "window": "10m"},
+                        )
+                    )
+
+            if action.startswith("admin."):
+                count = self._admin_actions.increment_and_count(
+                    key=f"{org_id}:{actor_id}", now=when, window=timedelta(minutes=5)
+                )
+                if outcome == "failure" or count >= 10:
+                    alerts.append(
+                        DetectionAlert(
+                            rule="suspicious_admin_activity",
+                            severity="high" if outcome == "failure" else "medium",
+                            message="Suspicious admin activity detected",
+                            context={
+                                "org_id": org_id,
+                                "actor_id": actor_id,
+                                "action": action,
+                                "outcome": outcome,
+                                "count": count,
+                                "window": "5m",
+                            },
+                        )
+                    )
+
+            if event_type == "export_downloaded" and action == "export.download" and outcome == "success":
+                count = self._downloads.increment_and_count(
+                    key=f"{org_id}:{actor_id}", now=when, window=timedelta(minutes=15)
+                )
+                if count >= 8:
+                    alerts.append(
+                        DetectionAlert(
+                            rule="unusual_export_downloads",
+                            severity="medium",
+                            message="Unusual export download volume detected",
+                            context={"org_id": org_id, "actor_id": actor_id, "count": count, "window": "15m"},
+                        )
+                    )
+
+            if event_type == "authorization_failed" and action in {
+                "export.authorize",
+                "export.download",
+                "export.request",
+            }:
+                alerts.append(
+                    DetectionAlert(
+                        rule="cross_org_access_attempt",
+                        severity="high",
+                        message="Potential cross-org access attempt detected",
+                        context={
+                            "org_id": org_id,
+                            "actor_id": actor_id,
+                            "action": action,
+                            "resource": details.get("resource"),
+                        },
+                    )
+                )
+
+        return alerts
+
+
+audit_activity_detector = AuditActivityDetector()

--- a/backend/app/observability/logging.py
+++ b/backend/app/observability/logging.py
@@ -8,6 +8,8 @@ import sys
 from datetime import datetime, timezone
 from typing import Any
 
+from app.observability.redaction import redact_log_data
+
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
@@ -33,18 +35,18 @@ class JsonFormatter(logging.Formatter):
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "level": record.levelname,
             "logger": record.name,
-            "message": record.getMessage(),
+            "message": redact_log_data(record.getMessage()),
             "request_id": get_correlation_id(),
             "user_id": get_user_id(),
             "org_id": get_org_id(),
         }
 
         if record.exc_info:
-            payload["exc_info"] = self.formatException(record.exc_info)
+            payload["exc_info"] = redact_log_data(self.formatException(record.exc_info))
 
         for key in ("path", "method", "status_code", "metric", "value", "alert"):
             if hasattr(record, key):
-                payload[key] = getattr(record, key)
+                payload[key] = redact_log_data(getattr(record, key), key=key)
 
         return json.dumps(payload, default=str)
 

--- a/backend/app/observability/redaction.py
+++ b/backend/app/observability/redaction.py
@@ -1,0 +1,64 @@
+"""Helpers for scrubbing sensitive values from logs and error payloads."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+SENSITIVE_CLASS_A_KEYS = frozenset(
+    {
+        "password",
+        "password_hash",
+        "secret",
+        "jwt_secret_key",
+        "otp_hash_pepper",
+        "api_key",
+        "authorization",
+        "access_token",
+        "refresh_token",
+        "token",
+        "bearer_token",
+    }
+)
+SENSITIVE_CLASS_B_KEYS = frozenset({"otp_code", "mfa_code", "note", "notes", "narrative"})
+
+_RE_BEARER = re.compile(r"(?i)\bbearer\s+[a-z0-9\-._~+/]+=*")
+_RE_SECRET_ASSIGN = re.compile(
+    r"(?i)\b(password|secret|api[_-]?key|token|authorization)\b\s*([:=])\s*([^\s,;]+)"
+)
+_RE_OTP_INLINE = re.compile(
+    r"(?i)\b(otp(?:_code)?|mfa(?:_code)?|verification(?:_code)?)\b([^\d]{0,20})(\d{4,8})"
+)
+_RE_NOTE_KV = re.compile(r"(?i)\b(note|notes|narrative)\b\s*([:=])\s*([^,;\n]+)")
+
+
+REDACTED = "[REDACTED]"
+REDACTED_OTP = "[REDACTED_OTP]"
+REDACTED_NOTE = "[REDACTED_NOTE]"
+
+
+def _redact_string(text: str) -> str:
+    value = _RE_BEARER.sub("Bearer [REDACTED]", text)
+    value = _RE_SECRET_ASSIGN.sub(lambda m: f"{m.group(1)}{m.group(2)}{REDACTED}", value)
+    value = _RE_OTP_INLINE.sub(lambda m: f"{m.group(1)}{m.group(2)}{REDACTED_OTP}", value)
+    value = _RE_NOTE_KV.sub(lambda m: f"{m.group(1)}{m.group(2)}{REDACTED_NOTE}", value)
+    return value
+
+
+def redact_log_data(value: Any, *, key: str | None = None) -> Any:
+    """Recursively sanitize sensitive values before they are logged."""
+    lowered_key = (key or "").lower()
+    if lowered_key in SENSITIVE_CLASS_A_KEYS:
+        return REDACTED
+    if lowered_key in SENSITIVE_CLASS_B_KEYS:
+        return REDACTED_NOTE if lowered_key in {"note", "notes", "narrative"} else REDACTED_OTP
+
+    if isinstance(value, str):
+        return _redact_string(value)
+    if isinstance(value, dict):
+        return {k: redact_log_data(v, key=str(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [redact_log_data(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_log_data(item) for item in value)
+    return value

--- a/backend/tests/test_observability_privacy.py
+++ b/backend/tests/test_observability_privacy.py
@@ -1,0 +1,111 @@
+"""Privacy and suspicious-activity observability tests."""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from app.observability.detection import AuditActivityDetector
+from app.observability.logging import JsonFormatter
+
+
+def _format_log(message: str, **extra) -> dict:
+    logger = logging.getLogger("privacy-test")
+    record = logger.makeRecord(
+        name="privacy-test",
+        level=logging.INFO,
+        fn=__file__,
+        lno=10,
+        msg=message,
+        args=(),
+        exc_info=None,
+        extra=extra,
+    )
+    rendered = JsonFormatter().format(record)
+    return json.loads(rendered)
+
+
+def test_generic_logs_redact_sensitive_class_a_values():
+    payload = _format_log(
+        "Authorization: Bearer super.secret.token password=hunter2",
+        user_id="u-1",
+        path="/auth/login",
+    )
+
+    assert "super.secret.token" not in payload["message"]
+    assert "hunter2" not in payload["message"]
+    assert "[REDACTED]" in payload["message"]
+
+
+def test_generic_logs_redact_sensitive_class_b_values():
+    payload = _format_log(
+        "otp_code=123456 note=driver admitted fault",
+        method="POST",
+        status_code=401,
+    )
+
+    assert "123456" not in payload["message"]
+    assert "driver admitted fault" not in payload["message"]
+    assert "[REDACTED_OTP]" in payload["message"]
+    assert "[REDACTED_NOTE]" in payload["message"]
+
+
+def test_detection_rules_cover_expected_suspicious_behaviors():
+    detector = AuditActivityDetector()
+    org_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc)
+
+    alerts = []
+    for offset in range(5):
+        alerts.extend(
+            detector.evaluate(
+                org_id=org_id,
+                actor_type="user",
+                actor_id="user-1",
+                action="auth.login",
+                event_type="auth_login_failed",
+                outcome="failure",
+                now=now + timedelta(minutes=offset),
+            )
+        )
+    assert any(a.rule == "repeated_auth_failures" for a in alerts)
+
+    admin_alerts = detector.evaluate(
+        org_id=org_id,
+        actor_type="user",
+        actor_id="admin-1",
+        action="admin.vehicle_qr.rotate",
+        event_type="authorization_failed",
+        outcome="failure",
+        now=now,
+    )
+    assert any(a.rule == "suspicious_admin_activity" for a in admin_alerts)
+
+    export_alerts = []
+    for offset in range(8):
+        export_alerts.extend(
+            detector.evaluate(
+                org_id=org_id,
+                actor_type="user",
+                actor_id="user-2",
+                action="export.download",
+                event_type="export_downloaded",
+                outcome="success",
+                now=now + timedelta(minutes=offset),
+            )
+        )
+    assert any(a.rule == "unusual_export_downloads" for a in export_alerts)
+
+    cross_org_alerts = detector.evaluate(
+        org_id=org_id,
+        actor_type="user",
+        actor_id="user-3",
+        action="export.download",
+        event_type="authorization_failed",
+        outcome="failure",
+        metadata={"resource": "export_download"},
+        now=now,
+    )
+    assert any(a.rule == "cross_org_access_attempt" for a in cross_org_alerts)


### PR DESCRIPTION
### Motivation

- Prevent sensitive data from leaking into generic logs and alert payloads by redacting OTPs, bearer tokens, secrets, and sensitive note/narrative content before emission.
- Surface high-signal suspicious behavior (admin anomalies, repeated auth failures, unusual export downloads, cross-org access attempts) to improve operational visibility.

### Description

- Add centralized redaction helpers in `app/observability/redaction.py` that scrub Class A (secrets/tokens) and Class B (OTP/note) values and recursively sanitize nested structures.
- Add in-process detection engine `app/observability/detection.py` implementing thresholded rules for `repeated_auth_failures`, `suspicious_admin_activity`, `unusual_export_downloads`, and `cross_org_access_attempt`.
- Integrate redaction into structured JSON logging by applying `redact_log_data` in `JsonFormatter` for messages, exception traces, and extra fields; integrate redaction into alerting paths in `app/observability/alerts.py`.
- Wire audit emissions to evaluate detection rules in `app/audit/emitter.py` and emit sanitized warning alerts when rules trigger.
- Add privacy-focused tests `backend/tests/test_observability_privacy.py` asserting that Class A/B sensitive data is redacted from generic logs and that detection rules report the expected alerts.

### Testing

- Ran the new privacy tests with `python -m pytest tests/test_observability_privacy.py -q` and they passed (`3 passed`).
- Ran lint with `make lint` and checks passed (`ruff` and hardening matrix lint passed).
- Ran a subset of backend tests `python -m pytest tests/test_audit_service.py tests/test_auth.py tests/test_api_endpoints.py -q` and they passed (existing suite passed; previously reported `79 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c431e3648321be51f08fd945a1aa)