### PR TITLE
Add integration tracking models, repos, and Alembic migration

### DIFF
--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -324,6 +324,422 @@ class Export(Base):
     __table_args__ = (Index("ix_exports_org_incident", "org_id", "incident_id"),)
 
 
+class IntegrationConnection(Base):
+    """Provider integration connection configuration per org."""
+
+    __tablename__ = "integration_connections"
+
+    connection_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
+    )
+    provider = Column(Text, nullable=False, index=True)
+    domain = Column(Text, nullable=True, index=True)
+    status = Column(
+        Enum(
+            "pending",
+            "active",
+            "inactive",
+            "error",
+            name="integration_connection_status",
+        ),
+        nullable=False,
+        default="pending",
+        server_default="pending",
+        index=True,
+    )
+    external_reference = Column(Text, nullable=True, index=True)
+    credentials_ref = Column(Text, nullable=True)
+    config_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    last_synced_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_integration_connections_org_provider_domain_status",
+            "org_id",
+            "provider",
+            "domain",
+            "status",
+        ),
+        Index(
+            "ix_integration_connections_org_provider_updated",
+            "org_id",
+            "provider",
+            "updated_at_utc",
+        ),
+    )
+
+
+class IntegrationOperation(Base):
+    """Operation execution state for external provider integrations."""
+
+    __tablename__ = "integration_operations"
+
+    operation_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
+    )
+    incident_id = Column(
+        UUID(as_uuid=True), ForeignKey("incidents.incident_id"), nullable=True, index=True
+    )
+    connection_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("integration_connections.connection_id"),
+        nullable=True,
+        index=True,
+    )
+    provider = Column(Text, nullable=False, index=True)
+    domain = Column(Text, nullable=True, index=True)
+    operation_type = Column(Text, nullable=False, index=True)
+    status = Column(
+        Enum(
+            "queued",
+            "running",
+            "succeeded",
+            "failed",
+            "canceled",
+            name="integration_operation_status",
+        ),
+        nullable=False,
+        default="queued",
+        server_default="queued",
+        index=True,
+    )
+    correlation_id = Column(Text, nullable=True, index=True)
+    external_reference = Column(Text, nullable=True, index=True)
+    payload_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    result_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    error_message = Column(Text, nullable=True)
+    requested_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    started_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    completed_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_integration_operations_org_provider_domain_status_requested",
+            "org_id",
+            "provider",
+            "domain",
+            "status",
+            "requested_at_utc",
+        ),
+        Index(
+            "ix_integration_operations_org_incident_status",
+            "org_id",
+            "incident_id",
+            "status",
+        ),
+    )
+
+
+class IntegrationOperationStatusHistory(Base):
+    """Append-only status transitions for integration operations."""
+
+    __tablename__ = "integration_operation_status_history"
+
+    history_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    operation_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("integration_operations.operation_id"),
+        nullable=False,
+        index=True,
+    )
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
+    )
+    incident_id = Column(
+        UUID(as_uuid=True), ForeignKey("incidents.incident_id"), nullable=True, index=True
+    )
+    provider = Column(Text, nullable=False, index=True)
+    domain = Column(Text, nullable=True, index=True)
+    from_status = Column(Text, nullable=True)
+    to_status = Column(Text, nullable=False, index=True)
+    correlation_id = Column(Text, nullable=True, index=True)
+    external_reference = Column(Text, nullable=True, index=True)
+    message = Column(Text, nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_integration_op_history_org_provider_domain_to_status_created",
+            "org_id",
+            "provider",
+            "domain",
+            "to_status",
+            "created_at_utc",
+        ),
+        Index(
+            "ix_integration_op_history_org_incident_created",
+            "org_id",
+            "incident_id",
+            "created_at_utc",
+        ),
+    )
+
+
+class EvidenceRequest(Base):
+    """External evidence request state per incident/provider."""
+
+    __tablename__ = "evidence_requests"
+
+    evidence_request_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
+    )
+    incident_id = Column(
+        UUID(as_uuid=True), ForeignKey("incidents.incident_id"), nullable=True, index=True
+    )
+    operation_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("integration_operations.operation_id"),
+        nullable=True,
+        index=True,
+    )
+    provider = Column(Text, nullable=False, index=True)
+    domain = Column(Text, nullable=True, index=True)
+    status = Column(
+        Enum(
+            "open",
+            "in_progress",
+            "fulfilled",
+            "failed",
+            "canceled",
+            name="evidence_request_status",
+        ),
+        nullable=False,
+        default="open",
+        server_default="open",
+        index=True,
+    )
+    correlation_id = Column(Text, nullable=True, index=True)
+    external_reference = Column(Text, nullable=True, index=True)
+    request_payload_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    response_payload_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    requested_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    due_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    fulfilled_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_evidence_requests_org_provider_domain_status_requested",
+            "org_id",
+            "provider",
+            "domain",
+            "status",
+            "requested_at_utc",
+        ),
+        Index("ix_evidence_requests_org_incident_status", "org_id", "incident_id", "status"),
+    )
+
+
+class ExternalMapping(Base):
+    """Cross-reference between internal ids and provider external ids."""
+
+    __tablename__ = "external_mappings"
+
+    mapping_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
+    )
+    incident_id = Column(
+        UUID(as_uuid=True), ForeignKey("incidents.incident_id"), nullable=True, index=True
+    )
+    provider = Column(Text, nullable=False, index=True)
+    domain = Column(Text, nullable=True, index=True)
+    internal_entity_type = Column(Text, nullable=False, index=True)
+    internal_entity_id = Column(Text, nullable=False, index=True)
+    external_reference = Column(Text, nullable=False, index=True)
+    status = Column(Text, nullable=False, default="active", server_default="active")
+    metadata_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_external_mappings_org_provider_domain_entity",
+            "org_id",
+            "provider",
+            "domain",
+            "internal_entity_type",
+            "internal_entity_id",
+        ),
+        Index(
+            "ix_external_mappings_org_provider_external_ref",
+            "org_id",
+            "provider",
+            "external_reference",
+        ),
+        Index("ix_external_mappings_org_incident", "org_id", "incident_id"),
+    )
+
+
+class ProviderWebhookEvent(Base):
+    """Inbound provider webhook events for processing and replay."""
+
+    __tablename__ = "provider_webhook_events"
+
+    webhook_event_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
+    )
+    incident_id = Column(
+        UUID(as_uuid=True), ForeignKey("incidents.incident_id"), nullable=True, index=True
+    )
+    provider = Column(Text, nullable=False, index=True)
+    domain = Column(Text, nullable=True, index=True)
+    event_type = Column(Text, nullable=False, index=True)
+    status = Column(
+        Enum(
+            "received",
+            "processed",
+            "ignored",
+            "failed",
+            name="provider_webhook_event_status",
+        ),
+        nullable=False,
+        default="received",
+        server_default="received",
+        index=True,
+    )
+    correlation_id = Column(Text, nullable=True, index=True)
+    external_reference = Column(Text, nullable=True, index=True)
+    payload_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    error_message = Column(Text, nullable=True)
+    received_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    processed_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_provider_webhook_events_org_provider_domain_status_received",
+            "org_id",
+            "provider",
+            "domain",
+            "status",
+            "received_at_utc",
+        ),
+        Index(
+            "ix_provider_webhook_events_org_incident_received",
+            "org_id",
+            "incident_id",
+            "received_at_utc",
+        ),
+    )
+
+
+class MessageOperation(Base):
+    """Message send/receive operations, optionally tied to integration operations."""
+
+    __tablename__ = "message_operations"
+
+    message_operation_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    operation_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("integration_operations.operation_id"),
+        nullable=True,
+        index=True,
+    )
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
+    )
+    incident_id = Column(
+        UUID(as_uuid=True), ForeignKey("incidents.incident_id"), nullable=True, index=True
+    )
+    provider = Column(Text, nullable=False, index=True)
+    domain = Column(Text, nullable=True, index=True)
+    channel = Column(Text, nullable=True, index=True)
+    direction = Column(Text, nullable=True, index=True)
+    status = Column(
+        Enum(
+            "queued",
+            "sent",
+            "delivered",
+            "failed",
+            "received",
+            name="message_operation_status",
+        ),
+        nullable=False,
+        default="queued",
+        server_default="queued",
+        index=True,
+    )
+    correlation_id = Column(Text, nullable=True, index=True)
+    external_reference = Column(Text, nullable=True, index=True)
+    template_name = Column(Text, nullable=True)
+    payload_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    sent_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    delivered_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_message_operations_org_provider_domain_status_created",
+            "org_id",
+            "provider",
+            "domain",
+            "status",
+            "created_at_utc",
+        ),
+        Index("ix_message_operations_org_incident_created", "org_id", "incident_id", "created_at_utc"),
+    )
+
+
 class SessionRecord(Base):
     """Server-side authenticated session state."""
 

--- a/backend/app/db/repo/evidence_requests.py
+++ b/backend/app/db/repo/evidence_requests.py
@@ -1,0 +1,61 @@
+"""Repository layer for evidence requests."""
+
+import uuid as _uuid
+
+from sqlalchemy.orm import Session
+
+from app.db.models import EvidenceRequest
+
+
+def create_evidence_request(
+    db: Session,
+    org_id: _uuid.UUID | None,
+    provider: str,
+    status: str = "open",
+    incident_id: _uuid.UUID | None = None,
+    operation_id: _uuid.UUID | None = None,
+    domain: str | None = None,
+    correlation_id: str | None = None,
+    external_reference: str | None = None,
+    request_payload_json: dict | None = None,
+):
+    evidence_request = EvidenceRequest(
+        org_id=org_id,
+        provider=provider,
+        status=status,
+        incident_id=incident_id,
+        operation_id=operation_id,
+        domain=domain,
+        correlation_id=correlation_id,
+        external_reference=external_reference,
+        request_payload_json=request_payload_json or {},
+    )
+    db.add(evidence_request)
+    db.commit()
+    db.refresh(evidence_request)
+    return evidence_request
+
+
+def list_evidence_requests(
+    db: Session,
+    org_id: _uuid.UUID | None = None,
+    incident_id: _uuid.UUID | None = None,
+    status: str | None = None,
+    provider: str | None = None,
+    correlation_id: str | None = None,
+    external_reference: str | None = None,
+):
+    query = db.query(EvidenceRequest)
+    if org_id is not None:
+        query = query.filter(EvidenceRequest.org_id == org_id)
+    if incident_id is not None:
+        query = query.filter(EvidenceRequest.incident_id == incident_id)
+    if status is not None:
+        query = query.filter(EvidenceRequest.status == status)
+    if provider is not None:
+        query = query.filter(EvidenceRequest.provider == provider)
+    if correlation_id is not None:
+        query = query.filter(EvidenceRequest.correlation_id == correlation_id)
+    if external_reference is not None:
+        query = query.filter(EvidenceRequest.external_reference == external_reference)
+    return query.order_by(EvidenceRequest.requested_at_utc.desc()).all()

--- a/backend/app/db/repo/external_mappings.py
+++ b/backend/app/db/repo/external_mappings.py
@@ -1,0 +1,58 @@
+"""Repository layer for external mappings."""
+
+import uuid as _uuid
+
+from sqlalchemy.orm import Session
+
+from app.db.models import ExternalMapping
+
+
+def create_external_mapping(
+    db: Session,
+    org_id: _uuid.UUID | None,
+    provider: str,
+    internal_entity_type: str,
+    internal_entity_id: str,
+    external_reference: str,
+    incident_id: _uuid.UUID | None = None,
+    domain: str | None = None,
+    status: str = "active",
+    metadata_json: dict | None = None,
+):
+    mapping = ExternalMapping(
+        org_id=org_id,
+        provider=provider,
+        internal_entity_type=internal_entity_type,
+        internal_entity_id=internal_entity_id,
+        external_reference=external_reference,
+        incident_id=incident_id,
+        domain=domain,
+        status=status,
+        metadata_json=metadata_json or {},
+    )
+    db.add(mapping)
+    db.commit()
+    db.refresh(mapping)
+    return mapping
+
+
+def list_external_mappings(
+    db: Session,
+    org_id: _uuid.UUID | None = None,
+    incident_id: _uuid.UUID | None = None,
+    status: str | None = None,
+    provider: str | None = None,
+    external_reference: str | None = None,
+):
+    query = db.query(ExternalMapping)
+    if org_id is not None:
+        query = query.filter(ExternalMapping.org_id == org_id)
+    if incident_id is not None:
+        query = query.filter(ExternalMapping.incident_id == incident_id)
+    if status is not None:
+        query = query.filter(ExternalMapping.status == status)
+    if provider is not None:
+        query = query.filter(ExternalMapping.provider == provider)
+    if external_reference is not None:
+        query = query.filter(ExternalMapping.external_reference == external_reference)
+    return query.order_by(ExternalMapping.created_at_utc.desc()).all()

--- a/backend/app/db/repo/integration_connections.py
+++ b/backend/app/db/repo/integration_connections.py
@@ -1,0 +1,56 @@
+"""Repository layer for integration connections."""
+
+import uuid as _uuid
+
+from sqlalchemy.orm import Session
+
+from app.db.models import IntegrationConnection
+
+
+def create_integration_connection(
+    db: Session,
+    org_id: _uuid.UUID | None,
+    provider: str,
+    domain: str | None = None,
+    status: str = "pending",
+    external_reference: str | None = None,
+    credentials_ref: str | None = None,
+    config_json: dict | None = None,
+):
+    connection = IntegrationConnection(
+        org_id=org_id,
+        provider=provider,
+        domain=domain,
+        status=status,
+        external_reference=external_reference,
+        credentials_ref=credentials_ref,
+        config_json=config_json or {},
+    )
+    db.add(connection)
+    db.commit()
+    db.refresh(connection)
+    return connection
+
+
+def list_integration_connections(
+    db: Session,
+    org_id: _uuid.UUID | None = None,
+    provider: str | None = None,
+    domain: str | None = None,
+    status: str | None = None,
+    external_reference: str | None = None,
+):
+    query = db.query(IntegrationConnection)
+    if org_id is not None:
+        query = query.filter(IntegrationConnection.org_id == org_id)
+    if provider is not None:
+        query = query.filter(IntegrationConnection.provider == provider)
+    if domain is not None:
+        query = query.filter(IntegrationConnection.domain == domain)
+    if status is not None:
+        query = query.filter(IntegrationConnection.status == status)
+    if external_reference is not None:
+        query = query.filter(
+            IntegrationConnection.external_reference == external_reference
+        )
+    return query.order_by(IntegrationConnection.created_at_utc.desc()).all()

--- a/backend/app/db/repo/integration_operation_status_history.py
+++ b/backend/app/db/repo/integration_operation_status_history.py
@@ -1,0 +1,67 @@
+"""Repository layer for integration operation status history."""
+
+import uuid as _uuid
+
+from sqlalchemy.orm import Session
+
+from app.db.models import IntegrationOperationStatusHistory
+
+
+def create_operation_status_history(
+    db: Session,
+    operation_id: _uuid.UUID,
+    provider: str,
+    to_status: str,
+    org_id: _uuid.UUID | None = None,
+    incident_id: _uuid.UUID | None = None,
+    domain: str | None = None,
+    from_status: str | None = None,
+    correlation_id: str | None = None,
+    external_reference: str | None = None,
+    message: str | None = None,
+):
+    history = IntegrationOperationStatusHistory(
+        operation_id=operation_id,
+        provider=provider,
+        to_status=to_status,
+        org_id=org_id,
+        incident_id=incident_id,
+        domain=domain,
+        from_status=from_status,
+        correlation_id=correlation_id,
+        external_reference=external_reference,
+        message=message,
+    )
+    db.add(history)
+    db.commit()
+    db.refresh(history)
+    return history
+
+
+def list_operation_status_history(
+    db: Session,
+    org_id: _uuid.UUID | None = None,
+    incident_id: _uuid.UUID | None = None,
+    status: str | None = None,
+    provider: str | None = None,
+    correlation_id: str | None = None,
+    external_reference: str | None = None,
+):
+    query = db.query(IntegrationOperationStatusHistory)
+    if org_id is not None:
+        query = query.filter(IntegrationOperationStatusHistory.org_id == org_id)
+    if incident_id is not None:
+        query = query.filter(IntegrationOperationStatusHistory.incident_id == incident_id)
+    if status is not None:
+        query = query.filter(IntegrationOperationStatusHistory.to_status == status)
+    if provider is not None:
+        query = query.filter(IntegrationOperationStatusHistory.provider == provider)
+    if correlation_id is not None:
+        query = query.filter(
+            IntegrationOperationStatusHistory.correlation_id == correlation_id
+        )
+    if external_reference is not None:
+        query = query.filter(
+            IntegrationOperationStatusHistory.external_reference == external_reference
+        )
+    return query.order_by(IntegrationOperationStatusHistory.created_at_utc.desc()).all()

--- a/backend/app/db/repo/integration_operations.py
+++ b/backend/app/db/repo/integration_operations.py
@@ -1,0 +1,65 @@
+"""Repository layer for integration operations."""
+
+import uuid as _uuid
+
+from sqlalchemy.orm import Session
+
+from app.db.models import IntegrationOperation
+
+
+def create_integration_operation(
+    db: Session,
+    org_id: _uuid.UUID | None,
+    provider: str,
+    operation_type: str,
+    status: str = "queued",
+    incident_id: _uuid.UUID | None = None,
+    connection_id: _uuid.UUID | None = None,
+    domain: str | None = None,
+    correlation_id: str | None = None,
+    external_reference: str | None = None,
+    payload_json: dict | None = None,
+):
+    operation = IntegrationOperation(
+        org_id=org_id,
+        provider=provider,
+        operation_type=operation_type,
+        status=status,
+        incident_id=incident_id,
+        connection_id=connection_id,
+        domain=domain,
+        correlation_id=correlation_id,
+        external_reference=external_reference,
+        payload_json=payload_json or {},
+    )
+    db.add(operation)
+    db.commit()
+    db.refresh(operation)
+    return operation
+
+
+def list_integration_operations(
+    db: Session,
+    org_id: _uuid.UUID | None = None,
+    incident_id: _uuid.UUID | None = None,
+    status: str | None = None,
+    provider: str | None = None,
+    correlation_id: str | None = None,
+    external_reference: str | None = None,
+):
+    query = db.query(IntegrationOperation)
+    if org_id is not None:
+        query = query.filter(IntegrationOperation.org_id == org_id)
+    if incident_id is not None:
+        query = query.filter(IntegrationOperation.incident_id == incident_id)
+    if status is not None:
+        query = query.filter(IntegrationOperation.status == status)
+    if provider is not None:
+        query = query.filter(IntegrationOperation.provider == provider)
+    if correlation_id is not None:
+        query = query.filter(IntegrationOperation.correlation_id == correlation_id)
+    if external_reference is not None:
+        query = query.filter(
+            IntegrationOperation.external_reference == external_reference
+        )
+    return query.order_by(IntegrationOperation.requested_at_utc.desc()).all()

--- a/backend/app/db/repo/message_operations.py
+++ b/backend/app/db/repo/message_operations.py
@@ -1,0 +1,61 @@
+"""Repository layer for message operations."""
+
+import uuid as _uuid
+
+from sqlalchemy.orm import Session
+
+from app.db.models import MessageOperation
+
+
+def create_message_operation(
+    db: Session,
+    org_id: _uuid.UUID | None,
+    provider: str,
+    status: str = "queued",
+    incident_id: _uuid.UUID | None = None,
+    operation_id: _uuid.UUID | None = None,
+    domain: str | None = None,
+    correlation_id: str | None = None,
+    external_reference: str | None = None,
+    payload_json: dict | None = None,
+):
+    message_operation = MessageOperation(
+        org_id=org_id,
+        provider=provider,
+        status=status,
+        incident_id=incident_id,
+        operation_id=operation_id,
+        domain=domain,
+        correlation_id=correlation_id,
+        external_reference=external_reference,
+        payload_json=payload_json or {},
+    )
+    db.add(message_operation)
+    db.commit()
+    db.refresh(message_operation)
+    return message_operation
+
+
+def list_message_operations(
+    db: Session,
+    org_id: _uuid.UUID | None = None,
+    incident_id: _uuid.UUID | None = None,
+    status: str | None = None,
+    provider: str | None = None,
+    correlation_id: str | None = None,
+    external_reference: str | None = None,
+):
+    query = db.query(MessageOperation)
+    if org_id is not None:
+        query = query.filter(MessageOperation.org_id == org_id)
+    if incident_id is not None:
+        query = query.filter(MessageOperation.incident_id == incident_id)
+    if status is not None:
+        query = query.filter(MessageOperation.status == status)
+    if provider is not None:
+        query = query.filter(MessageOperation.provider == provider)
+    if correlation_id is not None:
+        query = query.filter(MessageOperation.correlation_id == correlation_id)
+    if external_reference is not None:
+        query = query.filter(MessageOperation.external_reference == external_reference)
+    return query.order_by(MessageOperation.created_at_utc.desc()).all()

--- a/backend/app/db/repo/provider_webhook_events.py
+++ b/backend/app/db/repo/provider_webhook_events.py
@@ -1,0 +1,61 @@
+"""Repository layer for provider webhook events."""
+
+import uuid as _uuid
+
+from sqlalchemy.orm import Session
+
+from app.db.models import ProviderWebhookEvent
+
+
+def create_provider_webhook_event(
+    db: Session,
+    org_id: _uuid.UUID | None,
+    provider: str,
+    event_type: str,
+    status: str = "received",
+    incident_id: _uuid.UUID | None = None,
+    domain: str | None = None,
+    correlation_id: str | None = None,
+    external_reference: str | None = None,
+    payload_json: dict | None = None,
+):
+    webhook_event = ProviderWebhookEvent(
+        org_id=org_id,
+        provider=provider,
+        event_type=event_type,
+        status=status,
+        incident_id=incident_id,
+        domain=domain,
+        correlation_id=correlation_id,
+        external_reference=external_reference,
+        payload_json=payload_json or {},
+    )
+    db.add(webhook_event)
+    db.commit()
+    db.refresh(webhook_event)
+    return webhook_event
+
+
+def list_provider_webhook_events(
+    db: Session,
+    org_id: _uuid.UUID | None = None,
+    incident_id: _uuid.UUID | None = None,
+    status: str | None = None,
+    provider: str | None = None,
+    correlation_id: str | None = None,
+    external_reference: str | None = None,
+):
+    query = db.query(ProviderWebhookEvent)
+    if org_id is not None:
+        query = query.filter(ProviderWebhookEvent.org_id == org_id)
+    if incident_id is not None:
+        query = query.filter(ProviderWebhookEvent.incident_id == incident_id)
+    if status is not None:
+        query = query.filter(ProviderWebhookEvent.status == status)
+    if provider is not None:
+        query = query.filter(ProviderWebhookEvent.provider == provider)
+    if correlation_id is not None:
+        query = query.filter(ProviderWebhookEvent.correlation_id == correlation_id)
+    if external_reference is not None:
+        query = query.filter(ProviderWebhookEvent.external_reference == external_reference)
+    return query.order_by(ProviderWebhookEvent.received_at_utc.desc()).all()

--- a/migrations/versions/20260411_0001_add_integration_tracking_tables.py
+++ b/migrations/versions/20260411_0001_add_integration_tracking_tables.py
@@ -1,0 +1,470 @@
+"""Add integration tracking and webhook persistence tables.
+
+Revision ID: 20260411_0001
+Revises:
+Create Date: 2026-04-11
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20260411_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+integration_connection_status = sa.Enum(
+    "pending", "active", "inactive", "error", name="integration_connection_status"
+)
+integration_operation_status = sa.Enum(
+    "queued", "running", "succeeded", "failed", "canceled", name="integration_operation_status"
+)
+evidence_request_status = sa.Enum(
+    "open", "in_progress", "fulfilled", "failed", "canceled", name="evidence_request_status"
+)
+provider_webhook_event_status = sa.Enum(
+    "received", "processed", "ignored", "failed", name="provider_webhook_event_status"
+)
+message_operation_status = sa.Enum(
+    "queued", "sent", "delivered", "failed", "received", name="message_operation_status"
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    integration_connection_status.create(bind, checkfirst=True)
+    integration_operation_status.create(bind, checkfirst=True)
+    evidence_request_status.create(bind, checkfirst=True)
+    provider_webhook_event_status.create(bind, checkfirst=True)
+    message_operation_status.create(bind, checkfirst=True)
+
+    op.create_table(
+        "integration_connections",
+        sa.Column("connection_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("domain", sa.Text(), nullable=True),
+        sa.Column("status", integration_connection_status, nullable=False, server_default="pending"),
+        sa.Column("external_reference", sa.Text(), nullable=True),
+        sa.Column("credentials_ref", sa.Text(), nullable=True),
+        sa.Column("config_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("last_synced_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("created_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("connection_id"),
+    )
+    op.create_index("ix_integration_connections_org_id", "integration_connections", ["org_id"])
+    op.create_index("ix_integration_connections_provider", "integration_connections", ["provider"])
+    op.create_index("ix_integration_connections_domain", "integration_connections", ["domain"])
+    op.create_index("ix_integration_connections_status", "integration_connections", ["status"])
+    op.create_index("ix_integration_connections_external_reference", "integration_connections", ["external_reference"])
+    op.create_index(
+        "ix_integration_connections_org_provider_domain_status",
+        "integration_connections",
+        ["org_id", "provider", "domain", "status"],
+    )
+    op.create_index(
+        "ix_integration_connections_org_provider_updated",
+        "integration_connections",
+        ["org_id", "provider", "updated_at_utc"],
+    )
+
+    op.create_table(
+        "integration_operations",
+        sa.Column("operation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("incident_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("connection_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("domain", sa.Text(), nullable=True),
+        sa.Column("operation_type", sa.Text(), nullable=False),
+        sa.Column("status", integration_operation_status, nullable=False, server_default="queued"),
+        sa.Column("correlation_id", sa.Text(), nullable=True),
+        sa.Column("external_reference", sa.Text(), nullable=True),
+        sa.Column("payload_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("result_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("requested_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("started_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("completed_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("created_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["connection_id"], ["integration_connections.connection_id"]),
+        sa.ForeignKeyConstraint(["incident_id"], ["incidents.incident_id"]),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("operation_id"),
+    )
+    for index_column in [
+        "org_id",
+        "incident_id",
+        "connection_id",
+        "provider",
+        "domain",
+        "operation_type",
+        "status",
+        "correlation_id",
+        "external_reference",
+    ]:
+        op.create_index(f"ix_integration_operations_{index_column}", "integration_operations", [index_column])
+    op.create_index(
+        "ix_integration_operations_org_provider_domain_status_requested",
+        "integration_operations",
+        ["org_id", "provider", "domain", "status", "requested_at_utc"],
+    )
+    op.create_index(
+        "ix_integration_operations_org_incident_status",
+        "integration_operations",
+        ["org_id", "incident_id", "status"],
+    )
+
+    op.create_table(
+        "integration_operation_status_history",
+        sa.Column("history_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("operation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("incident_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("domain", sa.Text(), nullable=True),
+        sa.Column("from_status", sa.Text(), nullable=True),
+        sa.Column("to_status", sa.Text(), nullable=False),
+        sa.Column("correlation_id", sa.Text(), nullable=True),
+        sa.Column("external_reference", sa.Text(), nullable=True),
+        sa.Column("message", sa.Text(), nullable=True),
+        sa.Column("created_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["incident_id"], ["incidents.incident_id"]),
+        sa.ForeignKeyConstraint(["operation_id"], ["integration_operations.operation_id"]),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("history_id"),
+    )
+    for index_column in [
+        "operation_id",
+        "org_id",
+        "incident_id",
+        "provider",
+        "domain",
+        "to_status",
+        "correlation_id",
+        "external_reference",
+    ]:
+        op.create_index(
+            f"ix_integration_operation_status_history_{index_column}",
+            "integration_operation_status_history",
+            [index_column],
+        )
+    op.create_index(
+        "ix_integration_op_history_org_provider_domain_to_status_created",
+        "integration_operation_status_history",
+        ["org_id", "provider", "domain", "to_status", "created_at_utc"],
+    )
+    op.create_index(
+        "ix_integration_op_history_org_incident_created",
+        "integration_operation_status_history",
+        ["org_id", "incident_id", "created_at_utc"],
+    )
+
+    op.create_table(
+        "evidence_requests",
+        sa.Column("evidence_request_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("incident_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("operation_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("domain", sa.Text(), nullable=True),
+        sa.Column("status", evidence_request_status, nullable=False, server_default="open"),
+        sa.Column("correlation_id", sa.Text(), nullable=True),
+        sa.Column("external_reference", sa.Text(), nullable=True),
+        sa.Column("request_payload_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("response_payload_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("requested_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("due_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("fulfilled_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("created_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["incident_id"], ["incidents.incident_id"]),
+        sa.ForeignKeyConstraint(["operation_id"], ["integration_operations.operation_id"]),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("evidence_request_id"),
+    )
+    for index_column in [
+        "org_id",
+        "incident_id",
+        "operation_id",
+        "provider",
+        "domain",
+        "status",
+        "correlation_id",
+        "external_reference",
+    ]:
+        op.create_index(f"ix_evidence_requests_{index_column}", "evidence_requests", [index_column])
+    op.create_index(
+        "ix_evidence_requests_org_provider_domain_status_requested",
+        "evidence_requests",
+        ["org_id", "provider", "domain", "status", "requested_at_utc"],
+    )
+    op.create_index(
+        "ix_evidence_requests_org_incident_status",
+        "evidence_requests",
+        ["org_id", "incident_id", "status"],
+    )
+
+    op.create_table(
+        "external_mappings",
+        sa.Column("mapping_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("incident_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("domain", sa.Text(), nullable=True),
+        sa.Column("internal_entity_type", sa.Text(), nullable=False),
+        sa.Column("internal_entity_id", sa.Text(), nullable=False),
+        sa.Column("external_reference", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False, server_default="active"),
+        sa.Column("metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("created_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["incident_id"], ["incidents.incident_id"]),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("mapping_id"),
+    )
+    for index_column in [
+        "org_id",
+        "incident_id",
+        "provider",
+        "domain",
+        "internal_entity_type",
+        "internal_entity_id",
+        "external_reference",
+    ]:
+        op.create_index(f"ix_external_mappings_{index_column}", "external_mappings", [index_column])
+    op.create_index(
+        "ix_external_mappings_org_provider_domain_entity",
+        "external_mappings",
+        ["org_id", "provider", "domain", "internal_entity_type", "internal_entity_id"],
+    )
+    op.create_index(
+        "ix_external_mappings_org_provider_external_ref",
+        "external_mappings",
+        ["org_id", "provider", "external_reference"],
+    )
+    op.create_index("ix_external_mappings_org_incident", "external_mappings", ["org_id", "incident_id"])
+
+    op.create_table(
+        "provider_webhook_events",
+        sa.Column("webhook_event_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("incident_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("domain", sa.Text(), nullable=True),
+        sa.Column("event_type", sa.Text(), nullable=False),
+        sa.Column("status", provider_webhook_event_status, nullable=False, server_default="received"),
+        sa.Column("correlation_id", sa.Text(), nullable=True),
+        sa.Column("external_reference", sa.Text(), nullable=True),
+        sa.Column("payload_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("received_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("processed_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("created_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["incident_id"], ["incidents.incident_id"]),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("webhook_event_id"),
+    )
+    for index_column in [
+        "org_id",
+        "incident_id",
+        "provider",
+        "domain",
+        "event_type",
+        "status",
+        "correlation_id",
+        "external_reference",
+    ]:
+        op.create_index(
+            f"ix_provider_webhook_events_{index_column}",
+            "provider_webhook_events",
+            [index_column],
+        )
+    op.create_index(
+        "ix_provider_webhook_events_org_provider_domain_status_received",
+        "provider_webhook_events",
+        ["org_id", "provider", "domain", "status", "received_at_utc"],
+    )
+    op.create_index(
+        "ix_provider_webhook_events_org_incident_received",
+        "provider_webhook_events",
+        ["org_id", "incident_id", "received_at_utc"],
+    )
+
+    op.create_table(
+        "message_operations",
+        sa.Column("message_operation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("operation_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("incident_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("domain", sa.Text(), nullable=True),
+        sa.Column("channel", sa.Text(), nullable=True),
+        sa.Column("direction", sa.Text(), nullable=True),
+        sa.Column("status", message_operation_status, nullable=False, server_default="queued"),
+        sa.Column("correlation_id", sa.Text(), nullable=True),
+        sa.Column("external_reference", sa.Text(), nullable=True),
+        sa.Column("template_name", sa.Text(), nullable=True),
+        sa.Column("payload_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("sent_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("delivered_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("created_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["incident_id"], ["incidents.incident_id"]),
+        sa.ForeignKeyConstraint(["operation_id"], ["integration_operations.operation_id"]),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("message_operation_id"),
+    )
+    for index_column in [
+        "operation_id",
+        "org_id",
+        "incident_id",
+        "provider",
+        "domain",
+        "channel",
+        "direction",
+        "status",
+        "correlation_id",
+        "external_reference",
+    ]:
+        op.create_index(f"ix_message_operations_{index_column}", "message_operations", [index_column])
+    op.create_index(
+        "ix_message_operations_org_provider_domain_status_created",
+        "message_operations",
+        ["org_id", "provider", "domain", "status", "created_at_utc"],
+    )
+    op.create_index(
+        "ix_message_operations_org_incident_created",
+        "message_operations",
+        ["org_id", "incident_id", "created_at_utc"],
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    op.drop_index("ix_message_operations_org_incident_created", table_name="message_operations")
+    op.drop_index("ix_message_operations_org_provider_domain_status_created", table_name="message_operations")
+    for index_column in [
+        "external_reference",
+        "correlation_id",
+        "status",
+        "direction",
+        "channel",
+        "domain",
+        "provider",
+        "incident_id",
+        "org_id",
+        "operation_id",
+    ]:
+        op.drop_index(f"ix_message_operations_{index_column}", table_name="message_operations")
+    op.drop_table("message_operations")
+
+    op.drop_index("ix_provider_webhook_events_org_incident_received", table_name="provider_webhook_events")
+    op.drop_index("ix_provider_webhook_events_org_provider_domain_status_received", table_name="provider_webhook_events")
+    for index_column in [
+        "external_reference",
+        "correlation_id",
+        "status",
+        "event_type",
+        "domain",
+        "provider",
+        "incident_id",
+        "org_id",
+    ]:
+        op.drop_index(f"ix_provider_webhook_events_{index_column}", table_name="provider_webhook_events")
+    op.drop_table("provider_webhook_events")
+
+    op.drop_index("ix_external_mappings_org_incident", table_name="external_mappings")
+    op.drop_index("ix_external_mappings_org_provider_external_ref", table_name="external_mappings")
+    op.drop_index("ix_external_mappings_org_provider_domain_entity", table_name="external_mappings")
+    for index_column in [
+        "external_reference",
+        "internal_entity_id",
+        "internal_entity_type",
+        "domain",
+        "provider",
+        "incident_id",
+        "org_id",
+    ]:
+        op.drop_index(f"ix_external_mappings_{index_column}", table_name="external_mappings")
+    op.drop_table("external_mappings")
+
+    op.drop_index("ix_evidence_requests_org_incident_status", table_name="evidence_requests")
+    op.drop_index("ix_evidence_requests_org_provider_domain_status_requested", table_name="evidence_requests")
+    for index_column in [
+        "external_reference",
+        "correlation_id",
+        "status",
+        "domain",
+        "provider",
+        "operation_id",
+        "incident_id",
+        "org_id",
+    ]:
+        op.drop_index(f"ix_evidence_requests_{index_column}", table_name="evidence_requests")
+    op.drop_table("evidence_requests")
+
+    op.drop_index("ix_integration_op_history_org_incident_created", table_name="integration_operation_status_history")
+    op.drop_index(
+        "ix_integration_op_history_org_provider_domain_to_status_created",
+        table_name="integration_operation_status_history",
+    )
+    for index_column in [
+        "external_reference",
+        "correlation_id",
+        "to_status",
+        "domain",
+        "provider",
+        "incident_id",
+        "org_id",
+        "operation_id",
+    ]:
+        op.drop_index(
+            f"ix_integration_operation_status_history_{index_column}",
+            table_name="integration_operation_status_history",
+        )
+    op.drop_table("integration_operation_status_history")
+
+    op.drop_index("ix_integration_operations_org_incident_status", table_name="integration_operations")
+    op.drop_index(
+        "ix_integration_operations_org_provider_domain_status_requested",
+        table_name="integration_operations",
+    )
+    for index_column in [
+        "external_reference",
+        "correlation_id",
+        "status",
+        "operation_type",
+        "domain",
+        "provider",
+        "connection_id",
+        "incident_id",
+        "org_id",
+    ]:
+        op.drop_index(f"ix_integration_operations_{index_column}", table_name="integration_operations")
+    op.drop_table("integration_operations")
+
+    op.drop_index("ix_integration_connections_org_provider_updated", table_name="integration_connections")
+    op.drop_index(
+        "ix_integration_connections_org_provider_domain_status",
+        table_name="integration_connections",
+    )
+    op.drop_index("ix_integration_connections_external_reference", table_name="integration_connections")
+    op.drop_index("ix_integration_connections_status", table_name="integration_connections")
+    op.drop_index("ix_integration_connections_domain", table_name="integration_connections")
+    op.drop_index("ix_integration_connections_provider", table_name="integration_connections")
+    op.drop_index("ix_integration_connections_org_id", table_name="integration_connections")
+    op.drop_table("integration_connections")
+
+    message_operation_status.drop(bind, checkfirst=True)
+    provider_webhook_event_status.drop(bind, checkfirst=True)
+    evidence_request_status.drop(bind, checkfirst=True)
+    integration_operation_status.drop(bind, checkfirst=True)
+    integration_connection_status.drop(bind, checkfirst=True)


### PR DESCRIPTION
### Motivation
- Add persistent schema to track provider integrations, operations, webhooks, evidence requests, external ID mappings, and message operations to support integration rollout and troubleshooting. 
- Provide efficient filters for org/provider/domain/status/time and linkages to incidents to support operational queries and incident correlation. 
- Make changes rollout-safe by using nullable foreign keys and server defaults so existing incident/artifact flows continue to work during migration.

### Description
- Added new SQLAlchemy models in `backend/app/db/models.py`: `integration_connections`, `integration_operations`, `integration_operation_status_history`, `evidence_requests`, `external_mappings`, `provider_webhook_events`, and `message_operations`, with fields, nullable FKs, JSON payload/result columns, status enums, timestamps, and appropriate server defaults. 
- Added composite and per-column indexes for org/provider/domain/status/time and incident linkage to support the requested filtering and lookup patterns. 
- Implemented repository modules under `backend/app/db/repo/` for each new model providing `create_*` and `list_*` helpers with filters by org, incident, status, provider, correlation ID, and external reference as applicable. 
- Added Alembic migration `migrations/versions/20260411_0001_add_integration_tracking_tables.py` to create enums, tables, foreign keys, and indexes and to fully drop them on downgrade.

### Testing
- Ran `make lint` and the linter checks passed. 
- Ran the full test suite via `make test` and all automated tests passed (`368 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9ab745b0c8321b46c26caf34d273e)