### PR TITLE
Add normalized integration errors, mappers, persistence, and wiring

### DIFF
--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -184,6 +184,7 @@ def get_incident_endpoint(
                     else None
                 ),
                 unavailable_reason=a.unavailable_reason_code,
+                unavailable_message=a.unavailable_reason_detail,
             )
             for a in artifacts
         ],

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -247,6 +247,7 @@ class ArtifactSummary(BaseModel):
     status: ArtifactStatus
     captured_at_utc: Optional[datetime] = None
     unavailable_reason: Optional[ShortText] = None
+    unavailable_message: Optional[str] = None
 
 
 class ExportSummary(BaseModel):

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -419,6 +419,12 @@ class IntegrationOperation(Base):
     payload_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
     result_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
     error_message = Column(Text, nullable=True)
+    error_code = Column(Text, nullable=True, index=True)
+    error_category = Column(Text, nullable=True, index=True)
+    error_provider_key = Column(Text, nullable=True, index=True)
+    error_retryable = Column(Boolean, nullable=True)
+    error_user_facing_message = Column(Text, nullable=True)
+    error_operator_message = Column(Text, nullable=True)
     requested_at_utc = Column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
     )
@@ -541,6 +547,12 @@ class EvidenceRequest(Base):
     response_payload_json = Column(
         JSONB, nullable=False, default=dict, server_default=text("'{}'")
     )
+    error_code = Column(Text, nullable=True, index=True)
+    error_category = Column(Text, nullable=True, index=True)
+    error_provider_key = Column(Text, nullable=True, index=True)
+    error_retryable = Column(Boolean, nullable=True)
+    error_user_facing_message = Column(Text, nullable=True)
+    error_operator_message = Column(Text, nullable=True)
     requested_at_utc = Column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
     )

--- a/backend/app/db/repo/evidence_requests.py
+++ b/backend/app/db/repo/evidence_requests.py
@@ -5,6 +5,7 @@ import uuid as _uuid
 from sqlalchemy.orm import Session
 
 from app.db.models import EvidenceRequest
+from app.integrations.errors import NormalizedIntegrationError
 
 
 def create_evidence_request(
@@ -18,7 +19,9 @@ def create_evidence_request(
     correlation_id: str | None = None,
     external_reference: str | None = None,
     request_payload_json: dict | None = None,
+    normalized_error: NormalizedIntegrationError | None = None,
 ):
+    normalized_payload = normalized_error.to_dict() if normalized_error else None
     evidence_request = EvidenceRequest(
         org_id=org_id,
         provider=provider,
@@ -29,7 +32,37 @@ def create_evidence_request(
         correlation_id=correlation_id,
         external_reference=external_reference,
         request_payload_json=request_payload_json or {},
+        error_code=normalized_payload["code"] if normalized_payload else None,
+        error_category=normalized_payload["category"] if normalized_payload else None,
+        error_provider_key=(
+            normalized_payload["provider_key"] if normalized_payload else None
+        ),
+        error_retryable=normalized_payload["retryable"] if normalized_payload else None,
+        error_user_facing_message=(
+            normalized_payload["user_facing_message"] if normalized_payload else None
+        ),
+        error_operator_message=(
+            normalized_payload["operator_message"] if normalized_payload else None
+        ),
     )
+    db.add(evidence_request)
+    db.commit()
+    db.refresh(evidence_request)
+    return evidence_request
+
+
+def update_evidence_request_error(
+    db: Session,
+    evidence_request: EvidenceRequest,
+    normalized_error: NormalizedIntegrationError,
+) -> EvidenceRequest:
+    payload = normalized_error.to_dict()
+    evidence_request.error_code = str(payload["code"])
+    evidence_request.error_category = str(payload["category"])
+    evidence_request.error_provider_key = str(payload["provider_key"])
+    evidence_request.error_retryable = bool(payload["retryable"])
+    evidence_request.error_user_facing_message = str(payload["user_facing_message"])
+    evidence_request.error_operator_message = str(payload["operator_message"])
     db.add(evidence_request)
     db.commit()
     db.refresh(evidence_request)

--- a/backend/app/db/repo/integration_operations.py
+++ b/backend/app/db/repo/integration_operations.py
@@ -5,6 +5,7 @@ import uuid as _uuid
 from sqlalchemy.orm import Session
 
 from app.db.models import IntegrationOperation
+from app.integrations.errors import NormalizedIntegrationError
 
 
 def create_integration_operation(
@@ -19,7 +20,9 @@ def create_integration_operation(
     correlation_id: str | None = None,
     external_reference: str | None = None,
     payload_json: dict | None = None,
+    normalized_error: NormalizedIntegrationError | None = None,
 ):
+    normalized_payload = normalized_error.to_dict() if normalized_error else None
     operation = IntegrationOperation(
         org_id=org_id,
         provider=provider,
@@ -31,7 +34,39 @@ def create_integration_operation(
         correlation_id=correlation_id,
         external_reference=external_reference,
         payload_json=payload_json or {},
+        error_code=normalized_payload["code"] if normalized_payload else None,
+        error_category=normalized_payload["category"] if normalized_payload else None,
+        error_provider_key=(
+            normalized_payload["provider_key"] if normalized_payload else None
+        ),
+        error_retryable=normalized_payload["retryable"] if normalized_payload else None,
+        error_user_facing_message=(
+            normalized_payload["user_facing_message"] if normalized_payload else None
+        ),
+        error_operator_message=(
+            normalized_payload["operator_message"] if normalized_payload else None
+        ),
+        error_message=normalized_payload["operator_message"] if normalized_payload else None,
     )
+    db.add(operation)
+    db.commit()
+    db.refresh(operation)
+    return operation
+
+
+def update_integration_operation_error(
+    db: Session,
+    operation: IntegrationOperation,
+    normalized_error: NormalizedIntegrationError,
+) -> IntegrationOperation:
+    payload = normalized_error.to_dict()
+    operation.error_code = str(payload["code"])
+    operation.error_category = str(payload["category"])
+    operation.error_provider_key = str(payload["provider_key"])
+    operation.error_retryable = bool(payload["retryable"])
+    operation.error_user_facing_message = str(payload["user_facing_message"])
+    operation.error_operator_message = str(payload["operator_message"])
+    operation.error_message = str(payload["operator_message"])
     db.add(operation)
     db.commit()
     db.refresh(operation)

--- a/backend/app/integrations/errors.py
+++ b/backend/app/integrations/errors.py
@@ -1,8 +1,91 @@
-"""Integration-layer exceptions."""
+"""Integration-layer normalized error types and mappers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+import httpx
+
+
+ErrorCategory = Literal["telematics", "dashcam", "messaging", "mapping", "auth", "storage", "integration"]
+
+# Canonical code sets by integration domain.
+TELEMATICS_ERROR_CODES = frozenset(
+    {
+        "TELEMATICS_AUTH_FAILED",
+        "TELEMATICS_RATE_LIMITED",
+        "TELEMATICS_TIMEOUT",
+        "TELEMATICS_UNAVAILABLE",
+        "TELEMATICS_NOT_MAPPED",
+        "TELEMATICS_DATA_NOT_AVAILABLE",
+        "TELEMATICS_PROVIDER_ERROR",
+    }
+)
+DASHCAM_ERROR_CODES = frozenset(
+    {
+        "DASHCAM_AUTH_FAILED",
+        "DASHCAM_RATE_LIMITED",
+        "DASHCAM_TIMEOUT",
+        "DASHCAM_STREAM_UNAVAILABLE",
+        "DASHCAM_MEDIA_NOT_AVAILABLE",
+        "DASHCAM_PROVIDER_ERROR",
+    }
+)
+MESSAGING_ERROR_CODES = frozenset(
+    {
+        "MESSAGING_AUTH_FAILED",
+        "MESSAGING_RATE_LIMITED",
+        "MESSAGING_TIMEOUT",
+        "MESSAGING_INVALID_DESTINATION",
+        "MESSAGING_PROVIDER_ERROR",
+    }
+)
+MAPPING_ERROR_CODES = frozenset(
+    {
+        "MAPPING_NOT_FOUND",
+        "MAPPING_CONFLICT",
+        "MAPPING_INVALID_REFERENCE",
+        "MAPPING_PROVIDER_ERROR",
+    }
+)
+AUTH_ERROR_CODES = frozenset(
+    {
+        "AUTH_INVALID_CREDENTIALS",
+        "AUTH_EXPIRED_TOKEN",
+        "AUTH_PROVIDER_UNAVAILABLE",
+        "AUTH_PROVIDER_ERROR",
+    }
+)
+STORAGE_ERROR_CODES = frozenset(
+    {
+        "STORAGE_INVALID_OBJECT_KEY",
+        "STORAGE_TIMEOUT",
+        "STORAGE_UNAVAILABLE",
+        "STORAGE_PROVIDER_ERROR",
+    }
+)
+
+
+@dataclass(frozen=True)
+class NormalizedIntegrationError:
+    code: str
+    category: ErrorCategory
+    provider_key: str
+    retryable: bool
+    user_facing_message: str
+    operator_message: str
+
+    def to_dict(self) -> dict[str, str | bool]:
+        return asdict(self)
 
 
 class IntegrationError(Exception):
-    """Base integration error."""
+    """Base integration error carrying normalized error metadata."""
+
+    def __init__(self, normalized_error: NormalizedIntegrationError):
+        super().__init__(normalized_error.operator_message)
+        self.normalized_error = normalized_error
 
 
 class ProviderNotRegisteredError(IntegrationError):
@@ -15,3 +98,139 @@ class CapabilityNotSupportedError(IntegrationError):
 
 class ProviderHealthError(IntegrationError):
     """Raised when a provider health check fails."""
+
+
+def map_samsara_error(exc: Exception, *, category: ErrorCategory = "dashcam") -> NormalizedIntegrationError:
+    if isinstance(exc, httpx.TimeoutException):
+        code = "DASHCAM_TIMEOUT" if category == "dashcam" else "TELEMATICS_TIMEOUT"
+        return NormalizedIntegrationError(
+            code=code,
+            category=category,
+            provider_key="samsara",
+            retryable=True,
+            user_facing_message="Provider request timed out. Please retry shortly.",
+            operator_message=str(exc),
+        )
+    if isinstance(exc, httpx.HTTPStatusError):
+        status_code = exc.response.status_code
+        if status_code in {401, 403}:
+            code = "DASHCAM_AUTH_FAILED" if category == "dashcam" else "TELEMATICS_AUTH_FAILED"
+            return NormalizedIntegrationError(code, category, "samsara", False, "Integration authorization failed.", str(exc))
+        if status_code == 429:
+            code = "DASHCAM_RATE_LIMITED" if category == "dashcam" else "TELEMATICS_RATE_LIMITED"
+            return NormalizedIntegrationError(code, category, "samsara", True, "Provider rate limit reached. Please retry.", str(exc))
+        return NormalizedIntegrationError(
+            code="DASHCAM_PROVIDER_ERROR" if category == "dashcam" else "TELEMATICS_PROVIDER_ERROR",
+            category=category,
+            provider_key="samsara",
+            retryable=status_code >= 500,
+            user_facing_message="Provider request failed.",
+            operator_message=str(exc),
+        )
+    message = str(exc).lower()
+    if "no footage" in message or "not_found" in message:
+        return NormalizedIntegrationError(
+            code="DASHCAM_MEDIA_NOT_AVAILABLE",
+            category="dashcam",
+            provider_key="samsara",
+            retryable=False,
+            user_facing_message="Dashcam media was not available for the requested time window.",
+            operator_message=str(exc),
+        )
+    return NormalizedIntegrationError(
+        code="DASHCAM_STREAM_UNAVAILABLE" if category == "dashcam" else "TELEMATICS_UNAVAILABLE",
+        category=category,
+        provider_key="samsara",
+        retryable=True,
+        user_facing_message="Provider is temporarily unavailable.",
+        operator_message=str(exc),
+    )
+
+
+def map_twilio_error(exc: Exception, *, category: ErrorCategory = "messaging") -> NormalizedIntegrationError:
+    provider_key = "twilio"
+    if isinstance(exc, httpx.TimeoutException):
+        return NormalizedIntegrationError(
+            code="MESSAGING_TIMEOUT" if category != "auth" else "AUTH_PROVIDER_UNAVAILABLE",
+            category=category,
+            provider_key=provider_key,
+            retryable=True,
+            user_facing_message="Messaging service timed out. Please retry.",
+            operator_message=str(exc),
+        )
+    if isinstance(exc, httpx.HTTPStatusError):
+        status_code = exc.response.status_code
+        if status_code in {401, 403}:
+            code = "AUTH_PROVIDER_ERROR" if category == "auth" else "MESSAGING_AUTH_FAILED"
+            return NormalizedIntegrationError(code, category, provider_key, False, "Provider authentication failed.", str(exc))
+        if status_code == 429:
+            return NormalizedIntegrationError("MESSAGING_RATE_LIMITED", category, provider_key, True, "Messaging provider rate limit reached.", str(exc))
+        if status_code == 400:
+            return NormalizedIntegrationError("MESSAGING_INVALID_DESTINATION", category, provider_key, False, "The destination phone number is invalid.", str(exc))
+    if isinstance(exc, ValueError):
+        return NormalizedIntegrationError(
+            code="MESSAGING_INVALID_DESTINATION",
+            category=category,
+            provider_key=provider_key,
+            retryable=False,
+            user_facing_message="The destination phone number is invalid or unsupported.",
+            operator_message=str(exc),
+        )
+    return NormalizedIntegrationError(
+        code="MESSAGING_PROVIDER_ERROR" if category != "auth" else "AUTH_PROVIDER_ERROR",
+        category=category,
+        provider_key=provider_key,
+        retryable=True,
+        user_facing_message="Messaging provider operation failed.",
+        operator_message=str(exc),
+    )
+
+
+def map_storage_error(exc: Exception, *, provider_key: str = "storage") -> NormalizedIntegrationError:
+    from app.services.vault_s3 import S3ObjectKeyValidationError, S3PresignGenerationError
+
+    if isinstance(exc, S3ObjectKeyValidationError):
+        return NormalizedIntegrationError(
+            code="STORAGE_INVALID_OBJECT_KEY",
+            category="storage",
+            provider_key=provider_key,
+            retryable=False,
+            user_facing_message="Storage key validation failed.",
+            operator_message=str(exc),
+        )
+    if isinstance(exc, S3PresignGenerationError):
+        return NormalizedIntegrationError(
+            code="STORAGE_UNAVAILABLE",
+            category="storage",
+            provider_key=provider_key,
+            retryable=True,
+            user_facing_message="Storage service unavailable.",
+            operator_message=str(exc),
+        )
+    return NormalizedIntegrationError(
+        code="STORAGE_PROVIDER_ERROR",
+        category="storage",
+        provider_key=provider_key,
+        retryable=True,
+        user_facing_message="Storage operation failed.",
+        operator_message=str(exc),
+    )
+
+
+def as_normalized_error(exc: Exception, *, provider_hint: str | None = None, category: ErrorCategory = "integration") -> NormalizedIntegrationError:
+    if isinstance(exc, IntegrationError):
+        return exc.normalized_error
+    if provider_hint == "samsara":
+        return map_samsara_error(exc, category=category)
+    if provider_hint == "twilio":
+        return map_twilio_error(exc, category=category)
+    if provider_hint in {"s3", "storage"}:
+        return map_storage_error(exc, provider_key=provider_hint)
+    return NormalizedIntegrationError(
+        code="INTEGRATION_PROVIDER_ERROR",
+        category=category,
+        provider_key=provider_hint or "unknown",
+        retryable=True,
+        user_facing_message="An integration error occurred.",
+        operator_message=str(exc),
+    )

--- a/backend/app/integrations/health.py
+++ b/backend/app/integrations/health.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from app.integrations.errors import ProviderHealthError
+from app.integrations.errors import NormalizedIntegrationError, ProviderHealthError
 
 
 @dataclass(frozen=True)
@@ -17,6 +17,16 @@ class ProviderHealth:
 def ensure_healthy(health: ProviderHealth) -> ProviderHealth:
     if not health.healthy:
         raise ProviderHealthError(
-            f"Provider {health.provider} is unhealthy: {health.details or 'unknown reason'}"
+            NormalizedIntegrationError(
+                code="INTEGRATION_PROVIDER_ERROR",
+                category="integration",
+                provider_key=health.provider,
+                retryable=True,
+                user_facing_message="Integration provider health check failed.",
+                operator_message=(
+                    f"Provider {health.provider} is unhealthy: "
+                    f"{health.details or 'unknown reason'}"
+                ),
+            )
         )
     return health

--- a/backend/app/integrations/registry.py
+++ b/backend/app/integrations/registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import MutableMapping
 from typing import Any
 
-from app.integrations.errors import ProviderNotRegisteredError
+from app.integrations.errors import NormalizedIntegrationError, ProviderNotRegisteredError
 from app.integrations.models import ProviderCapability
 
 
@@ -22,7 +22,16 @@ class IntegrationRegistry:
         provider = self._providers.get(capability)
         if provider is None:
             raise ProviderNotRegisteredError(
-                f"No provider registered for capability={capability.value}"
+                NormalizedIntegrationError(
+                    code="MAPPING_NOT_FOUND",
+                    category="mapping",
+                    provider_key="registry",
+                    retryable=False,
+                    user_facing_message="Integration provider is not configured.",
+                    operator_message=(
+                        f"No provider registered for capability={capability.value}"
+                    ),
+                )
             )
         return provider
 

--- a/backend/app/services/twilio_notify.py
+++ b/backend/app/services/twilio_notify.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
+from app.integrations.errors import IntegrationError, map_twilio_error
 from app.integrations.service import get_messaging_provider, get_voice_provider
 
 
 def send_sms(to: str, message: str) -> str:
-    return get_messaging_provider().send_sms(to=to, message=message)
+    try:
+        return get_messaging_provider().send_sms(to=to, message=message)
+    except Exception as exc:
+        raise IntegrationError(map_twilio_error(exc, category="messaging")) from exc
 
 
 def place_call(to: str, twiml_content: str) -> str:
-    return get_voice_provider().place_call(to=to, twiml_content=twiml_content)
+    try:
+        return get_voice_provider().place_call(to=to, twiml_content=twiml_content)
+    except Exception as exc:
+        raise IntegrationError(map_twilio_error(exc, category="messaging")) from exc
 
 
 def build_voice_twiml(message: str) -> str:

--- a/backend/app/services/twilio_verify.py
+++ b/backend/app/services/twilio_verify.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+from app.integrations.errors import IntegrationError, map_twilio_error
 from app.integrations.service import get_verify_provider
 
 
 def start_verification(phone_e164: str) -> str:
-    return get_verify_provider().start_verification(phone_e164)
+    try:
+        return get_verify_provider().start_verification(phone_e164)
+    except Exception as exc:
+        raise IntegrationError(map_twilio_error(exc, category="auth")) from exc
 
 
 def check_verification(phone_e164: str, otp: str) -> bool:
-    return get_verify_provider().check_verification(phone_e164, otp)
+    try:
+        return get_verify_provider().check_verification(phone_e164, otp)
+    except Exception as exc:
+        raise IntegrationError(map_twilio_error(exc, category="auth")) from exc

--- a/backend/app/tasks/evidence_tasks.py
+++ b/backend/app/tasks/evidence_tasks.py
@@ -6,6 +6,7 @@ import uuid as _uuid
 from datetime import datetime, timezone
 
 from app.core.metrics import MetricNames, increment
+from app.integrations.errors import as_normalized_error
 from app.tasks.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
@@ -130,6 +131,14 @@ def capture_dashcam(
     increment("evidence.capture_dashcam.attempts")
     from app.core.config import settings
     from app.db.repo.artifacts import create_artifact
+    from app.db.repo.evidence_requests import (
+        create_evidence_request,
+        update_evidence_request_error,
+    )
+    from app.db.repo.integration_operations import (
+        create_integration_operation,
+        update_integration_operation_error,
+    )
     from app.domain.system_event_types import SystemEventType
     from app.services import s3_key_builder
     from app.services.samsara_client import SamsaraClient
@@ -184,6 +193,20 @@ def capture_dashcam(
 
         samsara = SamsaraClient()
         s3 = VaultS3(bucket=settings.S3_BUCKET, region=settings.AWS_REGION)
+        operation = create_integration_operation(
+            db,
+            org_id=_uuid.UUID(org_id),
+            incident_id=inc_uuid,
+            provider="samsara",
+            domain="dashcam",
+            operation_type="capture_dashcam",
+            status="running",
+            correlation_id=workflow_key,
+            payload_json={
+                "window_start": window_start,
+                "window_end": window_end,
+            },
+        )
 
         streams = {
             "road_facing": "dash_cam_video_road",
@@ -191,7 +214,24 @@ def capture_dashcam(
         }
 
         for stream_label, artifact_type in streams.items():
+            evidence_request = None
             try:
+                evidence_request = create_evidence_request(
+                    db,
+                    org_id=_uuid.UUID(org_id),
+                    incident_id=inc_uuid,
+                    operation_id=operation.operation_id,
+                    provider="samsara",
+                    domain="dashcam",
+                    correlation_id=workflow_key,
+                    external_reference=stream_label,
+                    request_payload_json={
+                        "stream": stream_label,
+                        "window_start": window_start,
+                        "window_end": window_end,
+                    },
+                    status="in_progress",
+                )
                 # 2. Attempt Samsara call for this stream
                 video_bytes = samsara.fetch_dashcam_stream(
                     stream=stream_label,
@@ -260,16 +300,31 @@ def capture_dashcam(
                     sha256=sha,
                     byte_size=len(video_bytes),
                 )
+                evidence_request.status = "fulfilled"
+                evidence_request.response_payload_json = {
+                    "artifact_id": str(art_id),
+                    "artifact_type": artifact_type,
+                    "byte_size": len(video_bytes),
+                }
+                db.commit()
 
             except Exception as stream_exc:
                 # Stream unavailable — document, don't crash
-                reason = str(stream_exc)
+                normalized_error = as_normalized_error(
+                    stream_exc, provider_hint="samsara", category="dashcam"
+                )
                 logger.warning(
                     "Dashcam stream %s unavailable for incident %s: %s",
                     stream_label,
                     incident_id,
-                    reason,
+                    normalized_error.operator_message,
                 )
+                if evidence_request is not None:
+                    update_evidence_request_error(db, evidence_request, normalized_error)
+                    evidence_request.status = "failed"
+                    evidence_request.response_payload_json = normalized_error.to_dict()
+                    db.commit()
+                update_integration_operation_error(db, operation, normalized_error)
 
                 _emit_once(
                     db,
@@ -280,7 +335,9 @@ def capture_dashcam(
                         "artifact_type": artifact_type,
                         "stream": stream_label,
                         "status": "unavailable",
-                        "reason": reason,
+                        "reason": normalized_error.user_facing_message,
+                        "error_code": normalized_error.code,
+                        "retryable": normalized_error.retryable,
                     },
                 )
 
@@ -298,7 +355,7 @@ def capture_dashcam(
                         capture_window_start_utc=ws_dt,
                         capture_window_end_utc=we_dt,
                         unavailable_reason_code="stream_unavailable",
-                        unavailable_reason_detail=reason,
+                        unavailable_reason_detail=normalized_error.user_facing_message,
                     )
 
         # 4. Emit EVIDENCE_CAPTURE_SUCCEEDED
@@ -311,6 +368,8 @@ def capture_dashcam(
                 "type": "dashcam",
             },
         )
+        operation.status = "succeeded"
+        db.commit()
 
         return {
             "incident_id": incident_id,

--- a/backend/app/tasks/notification_tasks.py
+++ b/backend/app/tasks/notification_tasks.py
@@ -7,6 +7,7 @@ import uuid as _uuid
 import httpx
 
 from app.core.metrics import MetricNames, increment
+from app.integrations.errors import IntegrationError, as_normalized_error
 from app.tasks.celery_app import celery_app
 
 
@@ -174,7 +175,10 @@ def notify_safety_manager(self, incident_id: str):
                             "sms_sid": sms_sid,
                         },
                     )
-                except (httpx.HTTPError, ValueError) as exc:
+                except (httpx.HTTPError, ValueError, IntegrationError) as exc:
+                    normalized_error = as_normalized_error(
+                        exc, provider_hint="twilio", category="messaging"
+                    )
                     _emit_once(
                         db,
                         inc_uuid,
@@ -182,10 +186,12 @@ def notify_safety_manager(self, incident_id: str):
                         f"{workflow_key}:sms_failed",
                         {
                             "phone": phone,
-                            "reason": str(exc),
+                            "reason": normalized_error.user_facing_message,
+                            "error_code": normalized_error.code,
+                            "retryable": normalized_error.retryable,
                         },
                     )
-                    errors.append(f"SMS failed: {exc}")
+                    errors.append(f"SMS failed: {normalized_error.operator_message}")
 
         if org.voice_enabled:
             call_event_key = f"{workflow_key}:call_placed"
@@ -207,7 +213,10 @@ def notify_safety_manager(self, incident_id: str):
                             "call_sid": call_sid,
                         },
                     )
-                except (httpx.HTTPError, ValueError) as exc:
+                except (httpx.HTTPError, ValueError, IntegrationError) as exc:
+                    normalized_error = as_normalized_error(
+                        exc, provider_hint="twilio", category="messaging"
+                    )
                     _emit_once(
                         db,
                         inc_uuid,
@@ -215,10 +224,12 @@ def notify_safety_manager(self, incident_id: str):
                         f"{workflow_key}:call_failed",
                         {
                             "phone": phone,
-                            "reason": str(exc),
+                            "reason": normalized_error.user_facing_message,
+                            "error_code": normalized_error.code,
+                            "retryable": normalized_error.retryable,
                         },
                     )
-                    errors.append(f"Call failed: {exc}")
+                    errors.append(f"Call failed: {normalized_error.operator_message}")
 
         if errors:
             raise RuntimeError(f"Notification failures: {'; '.join(errors)}")

--- a/contracts/schemas/runtime_api_contracts.json
+++ b/contracts/schemas/runtime_api_contracts.json
@@ -436,6 +436,18 @@
               "title": "Status",
               "type": "string"
             },
+            "unavailable_message": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Unavailable Message"
+            },
             "unavailable_reason": {
               "anyOf": [
                 {

--- a/migrations/versions/20260411_0002_add_normalized_integration_errors.py
+++ b/migrations/versions/20260411_0002_add_normalized_integration_errors.py
@@ -1,0 +1,80 @@
+"""Add normalized integration error columns.
+
+Revision ID: 20260411_0002
+Revises: 20260411_0001
+Create Date: 2026-04-11
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260411_0002"
+down_revision = "20260411_0001"
+branch_labels = None
+depends_on = None
+
+
+def _add_columns(table_name: str) -> None:
+    op.add_column(table_name, sa.Column("error_code", sa.Text(), nullable=True))
+    op.add_column(table_name, sa.Column("error_category", sa.Text(), nullable=True))
+    op.add_column(table_name, sa.Column("error_provider_key", sa.Text(), nullable=True))
+    op.add_column(table_name, sa.Column("error_retryable", sa.Boolean(), nullable=True))
+    op.add_column(table_name, sa.Column("error_user_facing_message", sa.Text(), nullable=True))
+    op.add_column(table_name, sa.Column("error_operator_message", sa.Text(), nullable=True))
+
+
+def _drop_columns(table_name: str) -> None:
+    op.drop_column(table_name, "error_operator_message")
+    op.drop_column(table_name, "error_user_facing_message")
+    op.drop_column(table_name, "error_retryable")
+    op.drop_column(table_name, "error_provider_key")
+    op.drop_column(table_name, "error_category")
+    op.drop_column(table_name, "error_code")
+
+
+def upgrade() -> None:
+    _add_columns("integration_operations")
+    _add_columns("evidence_requests")
+
+    op.create_index(
+        "ix_integration_operations_error_code",
+        "integration_operations",
+        ["error_code"],
+    )
+    op.create_index(
+        "ix_integration_operations_error_category",
+        "integration_operations",
+        ["error_category"],
+    )
+    op.create_index(
+        "ix_integration_operations_error_provider_key",
+        "integration_operations",
+        ["error_provider_key"],
+    )
+
+    op.create_index("ix_evidence_requests_error_code", "evidence_requests", ["error_code"])
+    op.create_index(
+        "ix_evidence_requests_error_category", "evidence_requests", ["error_category"]
+    )
+    op.create_index(
+        "ix_evidence_requests_error_provider_key",
+        "evidence_requests",
+        ["error_provider_key"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_evidence_requests_error_provider_key", table_name="evidence_requests")
+    op.drop_index("ix_evidence_requests_error_category", table_name="evidence_requests")
+    op.drop_index("ix_evidence_requests_error_code", table_name="evidence_requests")
+
+    op.drop_index(
+        "ix_integration_operations_error_provider_key",
+        table_name="integration_operations",
+    )
+    op.drop_index("ix_integration_operations_error_category", table_name="integration_operations")
+    op.drop_index("ix_integration_operations_error_code", table_name="integration_operations")
+
+    _drop_columns("evidence_requests")
+    _drop_columns("integration_operations")


### PR DESCRIPTION
### Motivation
- Provide a single, consistent error model for external integration failures so platform code and UI can expose safe, user-facing messages while retaining operator diagnostics. 
- Normalize disparate provider exceptions (Samsara, Twilio, S3/storage) into canonical codes and categories for observability and retry logic. 
- Persist structured error details on integration tracking records so operators can triage failures and UI can display safe messages. 

### Description
- Implemented `NormalizedIntegrationError` and provider mappers in `backend/app/integrations/errors.py`, including canonical code sets and mapping helpers `map_samsara_error`, `map_twilio_error`, `map_storage_error`, and `as_normalized_error`. 
- Introduced `IntegrationError` wrapper that carries a `NormalizedIntegrationError` and updated provider registry and healthchecks to raise normalized errors (`backend/app/integrations/registry.py`, `backend/app/integrations/health.py`). 
- Wrapped Twilio messaging/verify flows to normalize and rethrow integration errors (`backend/app/services/twilio_notify.py`, `backend/app/services/twilio_verify.py`) and updated notification/evidence tasks to create/update `integration_operations` and `evidence_requests`, map exceptions via `as_normalized_error`, and persist normalized fields (`backend/app/tasks/evidence_tasks.py`, `backend/app/tasks/notification_tasks.py`). 
- Added new error persistence columns to models and repositories, repository helpers to create/update normalized errors, and an Alembic migration `migrations/versions/20260411_0002_add_normalized_integration_errors.py` to add indexes (`backend/app/db/models.py`, `backend/app/db/repo/integration_operations.py`, `backend/app/db/repo/evidence_requests.py`). 
- Exposed a UI-safe unavailable message for artifacts via `unavailable_message` in the API schema and incident response (`backend/app/api/schemas.py`, `backend/app/api/routes_incidents.py`) and regenerated the runtime API contract snapshot. 

### Testing
- Regenerated API contract with `python scripts/generate_runtime_api_contract.py` and committed the snapshot, which matched the updated schemas. (succeeded) 
- Ran linter checks with `cd backend && ruff check app tests`, which passed after fixes. (succeeded) 
- Ran the full backend test suite with `cd backend && pytest -q`, with all tests passing (`368 passed`). (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9ae22c63483219d3b347f21e8a379)