### PR TITLE
Orchestrate incident evidence capture with new services and correlation IDs

### DIFF
--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -27,9 +27,9 @@ from app.db.repo.incidents import create_incident, get_incident, list_incidents
 from app.db.session import get_db
 from app.domain.system_event_types import SystemEventType
 from app.domain.packet_profiles import get_default_packet_profile
-from app.tasks.evidence_tasks import capture_dashcam, capture_telematics_bundle
 from app.tasks.export_tasks import build_export
 from app.services.idempotency_service import optional_idempotency_key, find_event_by_idempotency
+from app.services.incident_evidence_orchestrator import IncidentEvidenceOrchestrator
 from app.services.rate_limit_service import enforce_rate_limit
 from app.core.config import settings
 from app.security.authn import build_user_auth_context
@@ -81,6 +81,7 @@ def list_incidents_endpoint(
 @router.post("/", response_model=CreateIncidentResponse, status_code=201)
 def create_incident_endpoint(
     body: CreateIncidentRequest,
+    request: Request,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -128,13 +129,27 @@ def create_incident_endpoint(
             actor_id=str(current_user.id),
         )
 
-        window_start = body.window_start or ""
-        window_end = body.window_end or ""
-        str_id = str(incident_id)
-
-        logger.info("Queueing evidence capture tasks", extra={"request_id": get_request_id()})
-        capture_dashcam.delay(str_id, window_start, window_end)
-        capture_telematics_bundle.delay(str_id, window_start, window_end)
+        window_start = body.window_start
+        window_end = body.window_end
+        request_correlation_id = (
+            request.headers.get("x-correlation-id") or get_request_id() or str(uuid.uuid4())
+        )
+        logger.info(
+            "Queueing orchestrated evidence capture",
+            extra={
+                "request_id": get_request_id(),
+                "correlation_id": request_correlation_id,
+            },
+        )
+        IncidentEvidenceOrchestrator(db).begin_capture(
+            org_id=org_id,
+            incident_id=incident_id,
+            actor_type="user",
+            actor_id=str(current_user.id),
+            window_start=window_start,
+            window_end=window_end,
+            correlation_id=request_correlation_id,
+        )
 
     return CreateIncidentResponse(
         incident_id=incident_id,

--- a/backend/app/services/dashcam_capture_service.py
+++ b/backend/app/services/dashcam_capture_service.py
@@ -1,0 +1,71 @@
+"""Queue dashcam evidence capture operations."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.orm import Session
+
+from app.db.models import EvidenceRequest
+from app.db.repo.integration_operations import create_integration_operation
+from app.services.integration_health_service import (
+    set_evidence_request_status,
+    transition_operation_status,
+)
+from app.tasks.evidence_tasks import capture_dashcam
+
+
+def queue_dashcam_capture(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    incident_id: uuid.UUID,
+    window_start: str | None,
+    window_end: str | None,
+    api_correlation_id: str,
+    evidence_request_ids: list[uuid.UUID],
+) -> uuid.UUID:
+    """Create and queue dashcam capture operation."""
+    operation_correlation_id = f"{api_correlation_id}:dashcam"
+    operation = create_integration_operation(
+        db,
+        org_id=org_id,
+        incident_id=incident_id,
+        provider="samsara",
+        domain="dashcam",
+        operation_type="capture_dashcam",
+        status="queued",
+        correlation_id=operation_correlation_id,
+        payload_json={
+            "window_start": window_start,
+            "window_end": window_end,
+            "evidence_request_ids": [str(er_id) for er_id in evidence_request_ids],
+        },
+    )
+    transition_operation_status(
+        db,
+        operation=operation,
+        to_status="queued",
+        message="Dashcam capture operation queued",
+    )
+    evidence_requests = (
+        db.query(EvidenceRequest)
+        .filter(EvidenceRequest.evidence_request_id.in_(evidence_request_ids))
+        .all()
+    )
+    for evidence_request in evidence_requests:
+        evidence_request.operation_id = operation.operation_id
+        db.add(evidence_request)
+    db.commit()
+
+    for evidence_request in evidence_requests:
+        set_evidence_request_status(db, evidence_request=evidence_request, status="in_progress")
+
+    capture_dashcam.delay(
+        str(incident_id),
+        window_start,
+        window_end,
+        operation_id=str(operation.operation_id),
+        correlation_id=operation_correlation_id,
+    )
+    return operation.operation_id

--- a/backend/app/services/incident_evidence_orchestrator.py
+++ b/backend/app/services/incident_evidence_orchestrator.py
@@ -1,0 +1,130 @@
+"""Orchestrates incident evidence request creation and capture queueing."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from app.db.repo.evidence_requests import create_evidence_request
+from app.domain.system_event_types import SystemEventType
+from app.services.dashcam_capture_service import queue_dashcam_capture
+from app.services.messaging_service import emit_timeline_event
+from app.services.telematics_capture_service import queue_telematics_capture
+
+
+@dataclass
+class IncidentEvidenceOrchestrationResult:
+    """Result of evidence orchestration for incident creation."""
+
+    correlation_id: str
+    dashcam_operation_id: uuid.UUID
+    telematics_operation_id: uuid.UUID
+
+
+class IncidentEvidenceOrchestrator:
+    """Creates evidence requests first, then queues provider operations."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def begin_capture(
+        self,
+        *,
+        org_id: uuid.UUID,
+        incident_id: uuid.UUID,
+        actor_id: str,
+        actor_type: str,
+        window_start: str | None,
+        window_end: str | None,
+        correlation_id: str,
+    ) -> IncidentEvidenceOrchestrationResult:
+        dashcam_request_ids = [
+            create_evidence_request(
+                self.db,
+                org_id=org_id,
+                incident_id=incident_id,
+                provider="samsara",
+                domain="dashcam",
+                external_reference=stream,
+                status="open",
+                correlation_id=f"{correlation_id}:dashcam",
+                request_payload_json={
+                    "stream": stream,
+                    "window_start": window_start,
+                    "window_end": window_end,
+                },
+            ).evidence_request_id
+            for stream in ("road_facing", "driver_facing")
+        ]
+        telematics_request_ids = [
+            create_evidence_request(
+                self.db,
+                org_id=org_id,
+                incident_id=incident_id,
+                provider="samsara",
+                domain="telematics",
+                external_reference=dataset,
+                status="open",
+                correlation_id=f"{correlation_id}:telematics",
+                request_payload_json={
+                    "dataset": dataset,
+                    "window_start": window_start,
+                    "window_end": window_end,
+                },
+            ).evidence_request_id
+            for dataset in ("eld", "gps", "safety_events", "vehicle_state")
+        ]
+
+        emit_timeline_event(
+            self.db,
+            incident_id=incident_id,
+            event_type=SystemEventType.EVIDENCE_CAPTURE_REQUESTED,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            payload={
+                "correlation_id": correlation_id,
+                "window_start": window_start,
+                "window_end": window_end,
+                "dashcam_request_ids": [str(v) for v in dashcam_request_ids],
+                "telematics_request_ids": [str(v) for v in telematics_request_ids],
+            },
+        )
+
+        dashcam_operation_id = queue_dashcam_capture(
+            self.db,
+            org_id=org_id,
+            incident_id=incident_id,
+            window_start=window_start,
+            window_end=window_end,
+            api_correlation_id=correlation_id,
+            evidence_request_ids=dashcam_request_ids,
+        )
+        telematics_operation_id = queue_telematics_capture(
+            self.db,
+            org_id=org_id,
+            incident_id=incident_id,
+            window_start=window_start,
+            window_end=window_end,
+            api_correlation_id=correlation_id,
+            evidence_request_ids=telematics_request_ids,
+        )
+
+        emit_timeline_event(
+            self.db,
+            incident_id=incident_id,
+            event_type=SystemEventType.EVIDENCE_CAPTURE_ATTEMPTED,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            payload={
+                "correlation_id": correlation_id,
+                "dashcam_operation_id": str(dashcam_operation_id),
+                "telematics_operation_id": str(telematics_operation_id),
+            },
+        )
+        return IncidentEvidenceOrchestrationResult(
+            correlation_id=correlation_id,
+            dashcam_operation_id=dashcam_operation_id,
+            telematics_operation_id=telematics_operation_id,
+        )

--- a/backend/app/services/integration_health_service.py
+++ b/backend/app/services/integration_health_service.py
@@ -1,0 +1,63 @@
+"""Integration operation/evidence status tracking helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.db.models import EvidenceRequest, IntegrationOperation
+from app.db.repo.integration_operation_status_history import create_operation_status_history
+
+
+def transition_operation_status(
+    db: Session,
+    *,
+    operation: IntegrationOperation,
+    to_status: str,
+    message: str | None = None,
+):
+    """Transition an operation status and write history."""
+    from_status = operation.status
+    operation.status = to_status
+    if to_status == "running" and operation.started_at_utc is None:
+        operation.started_at_utc = datetime.now(timezone.utc)
+    if to_status in {"succeeded", "failed", "canceled"}:
+        operation.completed_at_utc = datetime.now(timezone.utc)
+    db.add(operation)
+    db.commit()
+    db.refresh(operation)
+
+    create_operation_status_history(
+        db,
+        operation_id=operation.operation_id,
+        org_id=operation.org_id,
+        incident_id=operation.incident_id,
+        provider=operation.provider,
+        domain=operation.domain,
+        from_status=from_status,
+        to_status=to_status,
+        correlation_id=operation.correlation_id,
+        external_reference=operation.external_reference,
+        message=message,
+    )
+    return operation
+
+
+def set_evidence_request_status(
+    db: Session,
+    *,
+    evidence_request: EvidenceRequest,
+    status: str,
+    response_payload_json: dict | None = None,
+):
+    """Update evidence request status and timestamps."""
+    evidence_request.status = status
+    if response_payload_json is not None:
+        evidence_request.response_payload_json = response_payload_json
+    if status == "fulfilled":
+        evidence_request.fulfilled_at_utc = datetime.now(timezone.utc)
+    db.add(evidence_request)
+    db.commit()
+    db.refresh(evidence_request)
+    return evidence_request

--- a/backend/app/services/messaging_service.py
+++ b/backend/app/services/messaging_service.py
@@ -1,0 +1,29 @@
+"""Helpers for writing incident timeline/system events."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.orm import Session
+
+from app.db.repo.events import create_event
+
+
+def emit_timeline_event(
+    db: Session,
+    *,
+    incident_id: uuid.UUID,
+    event_type: str,
+    actor_type: str,
+    actor_id: str,
+    payload: dict | None = None,
+):
+    """Append a timeline event for an incident."""
+    return create_event(
+        db,
+        incident_id=incident_id,
+        event_type=event_type,
+        actor_type=actor_type,
+        actor_id=actor_id,
+        payload=payload,
+    )

--- a/backend/app/services/telematics_capture_service.py
+++ b/backend/app/services/telematics_capture_service.py
@@ -1,0 +1,71 @@
+"""Queue telematics evidence capture operations."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.orm import Session
+
+from app.db.models import EvidenceRequest
+from app.db.repo.integration_operations import create_integration_operation
+from app.services.integration_health_service import (
+    set_evidence_request_status,
+    transition_operation_status,
+)
+from app.tasks.evidence_tasks import capture_telematics_bundle
+
+
+def queue_telematics_capture(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    incident_id: uuid.UUID,
+    window_start: str | None,
+    window_end: str | None,
+    api_correlation_id: str,
+    evidence_request_ids: list[uuid.UUID],
+) -> uuid.UUID:
+    """Create and queue telematics capture operation."""
+    operation_correlation_id = f"{api_correlation_id}:telematics"
+    operation = create_integration_operation(
+        db,
+        org_id=org_id,
+        incident_id=incident_id,
+        provider="samsara",
+        domain="telematics",
+        operation_type="capture_telematics_bundle",
+        status="queued",
+        correlation_id=operation_correlation_id,
+        payload_json={
+            "window_start": window_start,
+            "window_end": window_end,
+            "evidence_request_ids": [str(er_id) for er_id in evidence_request_ids],
+        },
+    )
+    transition_operation_status(
+        db,
+        operation=operation,
+        to_status="queued",
+        message="Telematics capture operation queued",
+    )
+    evidence_requests = (
+        db.query(EvidenceRequest)
+        .filter(EvidenceRequest.evidence_request_id.in_(evidence_request_ids))
+        .all()
+    )
+    for evidence_request in evidence_requests:
+        evidence_request.operation_id = operation.operation_id
+        db.add(evidence_request)
+    db.commit()
+
+    for evidence_request in evidence_requests:
+        set_evidence_request_status(db, evidence_request=evidence_request, status="in_progress")
+
+    capture_telematics_bundle.delay(
+        str(incident_id),
+        window_start,
+        window_end,
+        operation_id=str(operation.operation_id),
+        correlation_id=operation_correlation_id,
+    )
+    return operation.operation_id

--- a/backend/app/tasks/evidence_tasks.py
+++ b/backend/app/tasks/evidence_tasks.py
@@ -118,7 +118,12 @@ def _artifact_exists(db, artifact_id: _uuid.UUID) -> bool:
     time_limit=660,
 )
 def capture_dashcam(
-    self, incident_id: str, window_start: str | None, window_end: str | None
+    self,
+    incident_id: str,
+    window_start: str | None,
+    window_end: str | None,
+    operation_id: str | None = None,
+    correlation_id: str | None = None,
 ):
     """Capture dashcam footage for an incident.
 
@@ -131,15 +136,14 @@ def capture_dashcam(
     increment("evidence.capture_dashcam.attempts")
     from app.core.config import settings
     from app.db.repo.artifacts import create_artifact
-    from app.db.repo.evidence_requests import (
-        create_evidence_request,
-        update_evidence_request_error,
-    )
-    from app.db.repo.integration_operations import (
-        create_integration_operation,
-        update_integration_operation_error,
-    )
+    from app.db.models import EvidenceRequest, IntegrationOperation
+    from app.db.repo.evidence_requests import create_evidence_request, update_evidence_request_error
+    from app.db.repo.integration_operations import create_integration_operation, update_integration_operation_error
     from app.domain.system_event_types import SystemEventType
+    from app.services.integration_health_service import (
+        set_evidence_request_status,
+        transition_operation_status,
+    )
     from app.services import s3_key_builder
     from app.services.samsara_client import SamsaraClient
     from app.services.vault_s3 import VaultS3
@@ -193,19 +197,33 @@ def capture_dashcam(
 
         samsara = SamsaraClient()
         s3 = VaultS3(bucket=settings.S3_BUCKET, region=settings.AWS_REGION)
-        operation = create_integration_operation(
+        operation = None
+        if operation_id:
+            operation = (
+                db.query(IntegrationOperation)
+                .filter(IntegrationOperation.operation_id == _uuid.UUID(operation_id))
+                .first()
+            )
+        if operation is None:
+            operation = create_integration_operation(
+                db,
+                org_id=_uuid.UUID(org_id),
+                incident_id=inc_uuid,
+                provider="samsara",
+                domain="dashcam",
+                operation_type="capture_dashcam",
+                status="queued",
+                correlation_id=correlation_id or workflow_key,
+                payload_json={
+                    "window_start": window_start,
+                    "window_end": window_end,
+                },
+            )
+        transition_operation_status(
             db,
-            org_id=_uuid.UUID(org_id),
-            incident_id=inc_uuid,
-            provider="samsara",
-            domain="dashcam",
-            operation_type="capture_dashcam",
-            status="running",
-            correlation_id=workflow_key,
-            payload_json={
-                "window_start": window_start,
-                "window_end": window_end,
-            },
+            operation=operation,
+            to_status="running",
+            message="Dashcam capture task started",
         )
 
         streams = {
@@ -216,22 +234,32 @@ def capture_dashcam(
         for stream_label, artifact_type in streams.items():
             evidence_request = None
             try:
-                evidence_request = create_evidence_request(
-                    db,
-                    org_id=_uuid.UUID(org_id),
-                    incident_id=inc_uuid,
-                    operation_id=operation.operation_id,
-                    provider="samsara",
-                    domain="dashcam",
-                    correlation_id=workflow_key,
-                    external_reference=stream_label,
-                    request_payload_json={
-                        "stream": stream_label,
-                        "window_start": window_start,
-                        "window_end": window_end,
-                    },
-                    status="in_progress",
+                evidence_request = (
+                    db.query(EvidenceRequest)
+                    .filter(
+                        EvidenceRequest.incident_id == inc_uuid,
+                        EvidenceRequest.operation_id == operation.operation_id,
+                        EvidenceRequest.external_reference == stream_label,
+                    )
+                    .first()
                 )
+                if evidence_request is None:
+                    evidence_request = create_evidence_request(
+                        db,
+                        org_id=_uuid.UUID(org_id),
+                        incident_id=inc_uuid,
+                        operation_id=operation.operation_id,
+                        provider="samsara",
+                        domain="dashcam",
+                        correlation_id=correlation_id or workflow_key,
+                        external_reference=stream_label,
+                        request_payload_json={
+                            "stream": stream_label,
+                            "window_start": window_start,
+                            "window_end": window_end,
+                        },
+                        status="in_progress",
+                    )
                 # 2. Attempt Samsara call for this stream
                 video_bytes = samsara.fetch_dashcam_stream(
                     stream=stream_label,
@@ -283,6 +311,8 @@ def capture_dashcam(
                     {
                         "artifact_type": artifact_type,
                         "sha256": sha,
+                        "correlation_id": correlation_id or workflow_key,
+                        "operation_id": str(operation.operation_id) if operation is not None else None,
                     },
                 )
 
@@ -300,13 +330,16 @@ def capture_dashcam(
                     sha256=sha,
                     byte_size=len(video_bytes),
                 )
-                evidence_request.status = "fulfilled"
-                evidence_request.response_payload_json = {
-                    "artifact_id": str(art_id),
-                    "artifact_type": artifact_type,
-                    "byte_size": len(video_bytes),
-                }
-                db.commit()
+                set_evidence_request_status(
+                    db,
+                    evidence_request=evidence_request,
+                    status="fulfilled",
+                    response_payload_json={
+                        "artifact_id": str(art_id),
+                        "artifact_type": artifact_type,
+                        "byte_size": len(video_bytes),
+                    },
+                )
 
             except Exception as stream_exc:
                 # Stream unavailable — document, don't crash
@@ -321,9 +354,12 @@ def capture_dashcam(
                 )
                 if evidence_request is not None:
                     update_evidence_request_error(db, evidence_request, normalized_error)
-                    evidence_request.status = "failed"
-                    evidence_request.response_payload_json = normalized_error.to_dict()
-                    db.commit()
+                    set_evidence_request_status(
+                        db,
+                        evidence_request=evidence_request,
+                        status="failed",
+                        response_payload_json=normalized_error.to_dict(),
+                    )
                 update_integration_operation_error(db, operation, normalized_error)
 
                 _emit_once(
@@ -338,6 +374,8 @@ def capture_dashcam(
                         "reason": normalized_error.user_facing_message,
                         "error_code": normalized_error.code,
                         "retryable": normalized_error.retryable,
+                        "correlation_id": correlation_id or workflow_key,
+                        "operation_id": str(operation.operation_id) if operation is not None else None,
                     },
                 )
 
@@ -368,8 +406,12 @@ def capture_dashcam(
                 "type": "dashcam",
             },
         )
-        operation.status = "succeeded"
-        db.commit()
+        transition_operation_status(
+            db,
+            operation=operation,
+            to_status="succeeded",
+            message="Dashcam capture task succeeded",
+        )
 
         return {
             "incident_id": incident_id,
@@ -390,6 +432,13 @@ def capture_dashcam(
                 "reason": str(exc),
             },
         )
+        if "operation" in locals() and operation is not None:
+            transition_operation_status(
+                db,
+                operation=operation,
+                to_status="failed",
+                message=f"Dashcam capture task failed: {exc}",
+            )
         increment(MetricNames.CELERY_TASK_FAILURES)
         raise
 
@@ -410,7 +459,12 @@ def capture_dashcam(
     time_limit=360,
 )
 def capture_telematics_bundle(
-    self, incident_id: str, window_start: str | None, window_end: str | None
+    self,
+    incident_id: str,
+    window_start: str | None,
+    window_end: str | None,
+    operation_id: str | None = None,
+    correlation_id: str | None = None,
 ):
     """Capture telematics bundle for an incident.
 
@@ -428,8 +482,13 @@ def capture_telematics_bundle(
     import io
 
     from app.core.config import settings
+    from app.db.models import EvidenceRequest, IntegrationOperation
     from app.db.repo.artifacts import create_artifact
     from app.domain.system_event_types import SystemEventType
+    from app.services.integration_health_service import (
+        set_evidence_request_status,
+        transition_operation_status,
+    )
     from app.services import s3_key_builder
     from app.services.samsara_client import SamsaraClient
     from app.services.vault_s3 import VaultS3
@@ -488,6 +547,33 @@ def capture_telematics_bundle(
 
         samsara = SamsaraClient()
         s3 = VaultS3(bucket=settings.S3_BUCKET, region=settings.AWS_REGION)
+        operation = None
+        if operation_id:
+            operation = (
+                db.query(IntegrationOperation)
+                .filter(IntegrationOperation.operation_id == _uuid.UUID(operation_id))
+                .first()
+            )
+        if operation is None:
+            from app.db.repo.integration_operations import create_integration_operation
+
+            operation = create_integration_operation(
+                db,
+                org_id=_uuid.UUID(org_id),
+                incident_id=inc_uuid,
+                provider="samsara",
+                domain="telematics",
+                operation_type="capture_telematics_bundle",
+                status="queued",
+                correlation_id=correlation_id or workflow_key,
+                payload_json={"window_start": window_start, "window_end": window_end},
+            )
+        transition_operation_status(
+            db,
+            operation=operation,
+            to_status="running",
+            message="Telematics capture task started",
+        )
 
         datasets = {
             "eld": {
@@ -517,7 +603,36 @@ def capture_telematics_bundle(
         }
 
         for dataset_name, spec in datasets.items():
+            evidence_request = None
             try:
+                evidence_request = (
+                    db.query(EvidenceRequest)
+                    .filter(
+                        EvidenceRequest.incident_id == inc_uuid,
+                        EvidenceRequest.operation_id == operation.operation_id,
+                        EvidenceRequest.external_reference == dataset_name,
+                    )
+                    .first()
+                )
+                if evidence_request is None:
+                    from app.db.repo.evidence_requests import create_evidence_request
+
+                    evidence_request = create_evidence_request(
+                        db,
+                        org_id=_uuid.UUID(org_id),
+                        incident_id=inc_uuid,
+                        operation_id=operation.operation_id,
+                        provider="samsara",
+                        domain="telematics",
+                        correlation_id=correlation_id or workflow_key,
+                        external_reference=dataset_name,
+                        request_payload_json={
+                            "dataset": dataset_name,
+                            "window_start": window_start,
+                            "window_end": window_end,
+                        },
+                        status="in_progress",
+                    )
                 # 1. Fetch raw data
                 fetcher = getattr(samsara, spec["fetcher"], None)
                 if fetcher is None:
@@ -565,6 +680,8 @@ def capture_telematics_bundle(
                             "format": "json",
                             "s3_key": json_key,
                             "status": "captured",
+                            "correlation_id": correlation_id or workflow_key,
+                            "operation_id": str(operation.operation_id) if operation is not None else None,
                         },
                     )
                     _emit_once(
@@ -576,6 +693,8 @@ def capture_telematics_bundle(
                             "artifact_type": spec["artifact_type"],
                             "format": "json",
                             "sha256": json_sha,
+                            "correlation_id": correlation_id or workflow_key,
+                            "operation_id": str(operation.operation_id) if operation is not None else None,
                         },
                     )
 
@@ -628,6 +747,8 @@ def capture_telematics_bundle(
                             "format": "csv",
                             "s3_key": csv_key,
                             "status": "captured",
+                            "correlation_id": correlation_id or workflow_key,
+                            "operation_id": str(operation.operation_id) if operation is not None else None,
                         },
                     )
                     _emit_once(
@@ -639,6 +760,8 @@ def capture_telematics_bundle(
                             "artifact_type": spec["artifact_type"],
                             "format": "csv",
                             "sha256": csv_sha,
+                            "correlation_id": correlation_id or workflow_key,
+                            "operation_id": str(operation.operation_id) if operation is not None else None,
                         },
                     )
 
@@ -686,6 +809,8 @@ def capture_telematics_bundle(
                             "format": "pdf",
                             "s3_key": pdf_key,
                             "status": "captured",
+                            "correlation_id": correlation_id or workflow_key,
+                            "operation_id": str(operation.operation_id) if operation is not None else None,
                         },
                     )
                     _emit_once(
@@ -697,6 +822,8 @@ def capture_telematics_bundle(
                             "artifact_type": spec["artifact_type"],
                             "format": "pdf",
                             "sha256": pdf_sha,
+                            "correlation_id": correlation_id or workflow_key,
+                            "operation_id": str(operation.operation_id) if operation is not None else None,
                         },
                     )
 
@@ -713,6 +840,12 @@ def capture_telematics_bundle(
                         sha256=pdf_sha,
                         byte_size=len(pdf_bytes),
                     )
+                set_evidence_request_status(
+                    db,
+                    evidence_request=evidence_request,
+                    status="fulfilled",
+                    response_payload_json={"dataset": dataset_name, "status": "captured"},
+                )
 
             except Exception as ds_exc:
                 reason = str(ds_exc)
@@ -732,6 +865,8 @@ def capture_telematics_bundle(
                         "artifact_type": spec["artifact_type"],
                         "status": "unavailable",
                         "reason": reason,
+                        "correlation_id": correlation_id or workflow_key,
+                        "operation_id": str(operation.operation_id) if operation is not None else None,
                     },
                 )
 
@@ -751,6 +886,13 @@ def capture_telematics_bundle(
                         unavailable_reason_code="dataset_unavailable",
                         unavailable_reason_detail=reason,
                     )
+                if evidence_request is not None:
+                    set_evidence_request_status(
+                        db,
+                        evidence_request=evidence_request,
+                        status="failed",
+                        response_payload_json={"dataset": dataset_name, "error": reason},
+                    )
 
         _emit_once(
             db,
@@ -760,6 +902,12 @@ def capture_telematics_bundle(
             {
                 "type": "telematics",
             },
+        )
+        transition_operation_status(
+            db,
+            operation=operation,
+            to_status="succeeded",
+            message="Telematics capture task succeeded",
         )
 
         return {
@@ -781,6 +929,13 @@ def capture_telematics_bundle(
                 "reason": str(exc),
             },
         )
+        if "operation" in locals() and operation is not None:
+            transition_operation_status(
+                db,
+                operation=operation,
+                to_status="failed",
+                message=f"Telematics capture task failed: {exc}",
+            )
         increment(MetricNames.CELERY_TASK_FAILURES)
         raise
 

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -105,14 +105,10 @@ def client(db_session):
 
 
 class TestCreateIncident:
-    @patch("app.api.routes_incidents.capture_telematics_bundle")
-    @patch("app.api.routes_incidents.capture_dashcam")
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_create_incident_returns_201(
-        self, mock_dash, mock_tele, client, auth_headers
+        self, mock_begin_capture, client, auth_headers
     ):
-        mock_dash.delay = MagicMock()
-        mock_tele.delay = MagicMock()
-
         resp = client.post(
             "/incidents/",
             json={
@@ -128,14 +124,10 @@ class TestCreateIncident:
         assert "incident_id" in data
         assert data["status"] == "evidence_capturing"
 
-    @patch("app.api.routes_incidents.capture_telematics_bundle")
-    @patch("app.api.routes_incidents.capture_dashcam")
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_create_incident_enqueues_tasks(
-        self, mock_dash, mock_tele, client, auth_headers
+        self, mock_begin_capture, client, auth_headers
     ):
-        mock_dash.delay = MagicMock()
-        mock_tele.delay = MagicMock()
-
         resp = client.post(
             "/incidents/",
             json={
@@ -148,17 +140,14 @@ class TestCreateIncident:
         )
         assert resp.status_code == 201
         incident_id = resp.json()["incident_id"]
-        mock_dash.delay.assert_called_once_with(incident_id, "", "")
-        mock_tele.delay.assert_called_once_with(incident_id, "", "")
+        mock_begin_capture.assert_called_once()
+        call_kwargs = mock_begin_capture.call_args.kwargs
+        assert str(call_kwargs["incident_id"]) == incident_id
 
-    @patch("app.api.routes_incidents.capture_telematics_bundle")
-    @patch("app.api.routes_incidents.capture_dashcam")
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_create_incident_writes_events(
-        self, mock_dash, mock_tele, client, db_session, auth_headers
+        self, mock_begin_capture, client, db_session, auth_headers
     ):
-        mock_dash.delay = MagicMock()
-        mock_tele.delay = MagicMock()
-
         resp = client.post(
             "/incidents/",
             json={
@@ -205,14 +194,10 @@ class TestCreateIncident:
 
 
 class TestGetIncident:
-    @patch("app.api.routes_incidents.capture_telematics_bundle")
-    @patch("app.api.routes_incidents.capture_dashcam")
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_get_incident_returns_detail(
-        self, mock_dash, mock_tele, client, auth_headers
+        self, mock_begin_capture, client, auth_headers
     ):
-        mock_dash.delay = MagicMock()
-        mock_tele.delay = MagicMock()
-
         create_resp = client.post(
             "/incidents/",
             json={
@@ -234,14 +219,10 @@ class TestGetIncident:
         assert "evidence_inventory" in data
         assert "export_status" in data
 
-    @patch("app.api.routes_incidents.capture_telematics_bundle")
-    @patch("app.api.routes_incidents.capture_dashcam")
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_get_incident_returns_timeline(
-        self, mock_dash, mock_tele, client, auth_headers
+        self, mock_begin_capture, client, auth_headers
     ):
-        mock_dash.delay = MagicMock()
-        mock_tele.delay = MagicMock()
-
         create_resp = client.post(
             "/incidents/",
             json={
@@ -265,14 +246,10 @@ class TestGetIncident:
             assert "occurred_at_utc" in event
             assert "actor_type" in event
 
-    @patch("app.api.routes_incidents.capture_telematics_bundle")
-    @patch("app.api.routes_incidents.capture_dashcam")
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_get_incident_returns_created_at(
-        self, mock_dash, mock_tele, client, auth_headers
+        self, mock_begin_capture, client, auth_headers
     ):
-        mock_dash.delay = MagicMock()
-        mock_tele.delay = MagicMock()
-
         create_resp = client.post(
             "/incidents/",
             json={
@@ -289,14 +266,10 @@ class TestGetIncident:
         data = resp.json()
         assert "created_at_utc" in data
 
-    @patch("app.api.routes_incidents.capture_telematics_bundle")
-    @patch("app.api.routes_incidents.capture_dashcam")
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_get_incident_artifact_has_extra_fields(
-        self, mock_dash, mock_tele, client, db_session, auth_headers
+        self, mock_begin_capture, client, db_session, auth_headers
     ):
-        mock_dash.delay = MagicMock()
-        mock_tele.delay = MagicMock()
-
         create_resp = client.post(
             "/incidents/",
             json={
@@ -354,14 +327,10 @@ class TestGetIncident:
 
 
 class TestListIncidents:
-    @patch("app.api.routes_incidents.capture_telematics_bundle")
-    @patch("app.api.routes_incidents.capture_dashcam")
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_list_incidents_returns_evidence_counts(
-        self, mock_dash, mock_tele, client, db_session, auth_headers
+        self, mock_begin_capture, client, db_session, auth_headers
     ):
-        mock_dash.delay = MagicMock()
-        mock_tele.delay = MagicMock()
-
         create_resp = client.post(
             "/incidents/",
             json={
@@ -403,13 +372,10 @@ class TestListIncidents:
 
 class TestRequestExport:
     @patch("app.api.routes_exports.build_export")
-    @patch("app.api.routes_incidents.capture_telematics_bundle")
-    @patch("app.api.routes_incidents.capture_dashcam")
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_request_export_returns_201(
-        self, mock_dash, mock_tele, mock_gen, client, auth_headers
+        self, mock_begin_capture, mock_gen, client, auth_headers
     ):
-        mock_dash.delay = MagicMock()
-        mock_tele.delay = MagicMock()
         mock_gen.delay = MagicMock()
 
         create_resp = client.post(
@@ -438,13 +404,10 @@ class TestRequestExport:
         assert data["created_at_utc"] is not None
 
     @patch("app.api.routes_exports.build_export")
-    @patch("app.api.routes_incidents.capture_telematics_bundle")
-    @patch("app.api.routes_incidents.capture_dashcam")
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_request_export_enqueues_task(
-        self, mock_dash, mock_tele, mock_gen, client, auth_headers
+        self, mock_begin_capture, mock_gen, client, auth_headers
     ):
-        mock_dash.delay = MagicMock()
-        mock_tele.delay = MagicMock()
         mock_gen.delay = MagicMock()
 
         create_resp = client.post(

--- a/backend/tests/test_frontend_contracts.py
+++ b/backend/tests/test_frontend_contracts.py
@@ -91,17 +91,12 @@ def _assert_iso_datetime(value: str):
     datetime.fromisoformat(normalized)
 
 
-@patch("app.api.routes_incidents.capture_telematics_bundle")
-@patch("app.api.routes_incidents.capture_dashcam")
+@patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
 def test_incident_list_contract_matches_frontend(
-    mock_dash,
-    mock_tele,
+    mock_begin_capture,
     client: TestClient,
     auth_headers: dict[str, str],
 ):
-    mock_dash.delay = MagicMock()
-    mock_tele.delay = MagicMock()
-
     create_resp = client.post(
         "/incidents/",
         json={
@@ -147,17 +142,12 @@ def test_incident_list_contract_matches_frontend(
         assert isinstance(item["evidence_total"], int)
 
 
-@patch("app.api.routes_incidents.capture_telematics_bundle")
-@patch("app.api.routes_incidents.capture_dashcam")
+@patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
 def test_incident_detail_contract_matches_frontend(
-    mock_dash,
-    mock_tele,
+    mock_begin_capture,
     client: TestClient,
     auth_headers: dict[str, str],
 ):
-    mock_dash.delay = MagicMock()
-    mock_tele.delay = MagicMock()
-
     create_resp = client.post(
         "/incidents/",
         json={
@@ -194,17 +184,13 @@ def test_incident_detail_contract_matches_frontend(
 
 
 @patch("app.api.routes_exports.build_export")
-@patch("app.api.routes_incidents.capture_telematics_bundle")
-@patch("app.api.routes_incidents.capture_dashcam")
+@patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
 def test_export_response_contract_matches_frontend(
-    mock_dash,
-    mock_tele,
+    mock_begin_capture,
     mock_build_export,
     client: TestClient,
     auth_headers: dict[str, str],
 ):
-    mock_dash.delay = MagicMock()
-    mock_tele.delay = MagicMock()
     mock_build_export.delay = MagicMock()
 
     create_resp = client.post(


### PR DESCRIPTION
### Motivation
- Centralize and sequence evidence capture so evidence requests are created before provider operations are queued and timeline events are emitted.  
- Ensure a correlation ID is propagated across the API request -> integration operation -> Celery task -> artifact events chain for debugging and observability.  
- Track integration operation and evidence request statuses (with history) to make task state explicit and auditable.

### Description
- Added new orchestration and helper services: `backend/app/services/incident_evidence_orchestrator.py`, `telematics_capture_service.py`, `dashcam_capture_service.py`, `messaging_service.py`, and `integration_health_service.py` to create evidence requests, emit timeline events, queue provider operations, and record operation/evidence status transitions.  
- Refactored `backend/app/api/routes_incidents.py` so the incident creation endpoint delegates evidence kickoff to `IncidentEvidenceOrchestrator.begin_capture(...)` and supplies a request-level correlation id (from `x-correlation-id` header / request id / new UUID).  
- Updated Celery evidence tasks in `backend/app/tasks/evidence_tasks.py` to accept `operation_id` and `correlation_id`, to reuse pre-created `IntegrationOperation` / `EvidenceRequest` rows when present, to call `integration_health_service` for status transitions, and to include `correlation_id`/`operation_id` in artifact/timeline payloads.  
- Tests updated to patch the orchestrator entrypoint instead of the previous direct task symbols and minor test adjustments to validate the new flow.

### Testing
- Ran the linter with `cd backend && ruff check app tests` and it completed with no failures.  
- Ran unit/contract/task tests with `cd backend && pytest tests/test_api_endpoints.py tests/test_frontend_contracts.py tests/test_celery_tasks.py -q`, and the test run completed successfully with `92 passed` and no failures.  
- Verified Python byte-compile for modified modules (`py_compile`) during development to catch syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9b221b62c83219cb0991baf33b23a)