### PR TITLE
Track message operation lifecycle, Twilio status reconciliation, and expose messaging reliability

### DIFF
--- a/backend/app/api/routes_admin.py
+++ b/backend/app/api/routes_admin.py
@@ -21,6 +21,7 @@ from app.api.schemas import (
     IntegrationHealthItem,
     JobExecutionMetaItem,
     JobExecutionMetaSummary,
+    MessagingReliabilityResponse,
     OpsAnomalyItem,
     OpsDashboardResponse,
     OpsFailedExportItem,
@@ -49,6 +50,7 @@ from app.db.models import (
     VehicleQrToken,
 )
 from app.db.session import get_db
+from app.db.repo.message_operations import get_messaging_reliability_summary
 from app.domain.system_event_types import SystemEventType
 from app.db.repo.job_execution_meta import (
     list_ops_jobs_with_db,
@@ -797,6 +799,33 @@ def get_ops_dashboard(
             )
             for row in anomaly_events
         ],
+        org_messaging_reliability=MessagingReliabilityResponse(
+            **get_messaging_reliability_summary(db, org_id=org_id)
+        ),
+    )
+
+
+@router.get(
+    "/ops/messaging-reliability",
+    response_model=MessagingReliabilityResponse,
+)
+def ops_messaging_reliability(
+    incident_id: uuid.UUID | None = None,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, admin)
+    _require_admin_policy(
+        db,
+        allowed=_can_access_ops_views(context),
+        actor_id=admin.id,
+        org_id=context.org_ids[0] if context.org_ids else None,
+        action="admin.ops.messaging_reliability.read",
+        metadata={"required_roles": sorted(OPS_ALLOWED_ROLES)},
+    )
+    org_id = context.org_ids[0]
+    return MessagingReliabilityResponse(
+        **get_messaging_reliability_summary(db, org_id=org_id, incident_id=incident_id)
     )
 
 

--- a/backend/app/api/routes_driver_auth.py
+++ b/backend/app/api/routes_driver_auth.py
@@ -29,7 +29,9 @@ from app.db.repo.drivers import (
     increment_otp_attempts,
     mark_otp_verified,
 )
+from app.db.repo.message_operations import create_message_operation, update_message_operation_status
 from app.db.session import get_db
+from app.integrations.errors import as_normalized_error
 from app.security.session import create_session, revoke_session, rotate_refresh_token
 from app.services.phone_normalize import normalize_phone
 
@@ -132,12 +134,37 @@ def request_otp(body: DriverOtpRequest, db: Session = Depends(get_db)):
         )
     _enforce_rate_limit("request", phone_e164, _REQUEST_LIMIT)
 
+    msg_op = create_message_operation(
+        db,
+        org_id=None,
+        provider="twilio",
+        domain="auth",
+        purpose="otp_request",
+        to_e164=phone_e164,
+        status="queued",
+        payload_json={"flow": "driver_auth"},
+    )
     twilio_sid: str | None = None
     try:
         from app.services import twilio_verify
 
         twilio_sid = twilio_verify.start_verification(phone_e164)
-    except Exception:
+        update_message_operation_status(
+            db,
+            msg_op,
+            to_status="sent",
+            provider_message_id=twilio_sid,
+            details_json={"verify_sid": twilio_sid},
+        )
+    except Exception as exc:
+        normalized_error = as_normalized_error(exc, provider_hint="twilio", category="auth")
+        update_message_operation_status(
+            db,
+            msg_op,
+            to_status="failed",
+            normalized_error_code=normalized_error.code,
+            details_json={"reason": "twilio_verify_start_failed"},
+        )
         logger.warning(
             "Twilio verify start failed for phone hash=%s", _phone_hash(phone_e164)
         )
@@ -163,6 +190,16 @@ def verify_otp(body: DriverOtpVerifyRequest, db: Session = Depends(get_db)):
             detail="Invalid phone number",
         )
     _enforce_rate_limit("verify", phone_e164, _VERIFY_LIMIT)
+    verify_operation = create_message_operation(
+        db,
+        org_id=None,
+        provider="twilio",
+        domain="auth",
+        purpose="otp_verify",
+        to_e164=phone_e164,
+        status="queued",
+        payload_json={"flow": "driver_auth"},
+    )
 
     challenge = get_latest_otp_challenge_by_phone(db, phone_e164)
     if challenge is None:
@@ -231,7 +268,15 @@ def verify_otp(body: DriverOtpVerifyRequest, db: Session = Depends(get_db)):
         from app.services import twilio_verify
 
         otp_ok = twilio_verify.check_verification(phone_e164, body.otp_code)
-    except Exception:
+    except Exception as exc:
+        normalized_error = as_normalized_error(exc, provider_hint="twilio", category="auth")
+        update_message_operation_status(
+            db,
+            verify_operation,
+            to_status="failed",
+            normalized_error_code=normalized_error.code,
+            details_json={"reason": "twilio_verify_check_failed"},
+        )
         logger.exception("Twilio verify check failed")
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -239,6 +284,13 @@ def verify_otp(body: DriverOtpVerifyRequest, db: Session = Depends(get_db)):
         )
 
     if not otp_ok:
+        update_message_operation_status(
+            db,
+            verify_operation,
+            to_status="undelivered",
+            normalized_error_code="AUTH_INVALID_OTP",
+            details_json={"reason": "invalid_otp"},
+        )
         challenge = increment_otp_attempts(db, challenge)
         logger.info(
             "DRIVER_OTP_FAILED phone_hash=%s attempts=%d status=%s",
@@ -275,6 +327,12 @@ def verify_otp(body: DriverOtpVerifyRequest, db: Session = Depends(get_db)):
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid OTP",
         )
+    update_message_operation_status(
+        db,
+        verify_operation,
+        to_status="delivered",
+        details_json={"reason": "otp_approved"},
+    )
 
     driver = get_driver_by_phone(db, phone_e164)
     if driver is None:

--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -24,6 +24,7 @@ from app.db.repo.artifacts import get_artifacts_by_incident
 from app.db.repo.events import create_event, get_events_by_incident
 from app.db.repo.exports import create_export, get_exports_by_incident
 from app.db.repo.incidents import create_incident, get_incident, list_incidents
+from app.db.repo.message_operations import get_messaging_reliability_summary
 from app.db.session import get_db
 from app.domain.system_event_types import SystemEventType
 from app.domain.packet_profiles import get_default_packet_profile
@@ -249,6 +250,11 @@ def get_incident_endpoint(
             )
             for ev in sorted(events, key=lambda e: e.occurred_at_utc or "")
         ],
+        messaging_reliability=get_messaging_reliability_summary(
+            db, org_id=incident.org_id, incident_id=incident.incident_id
+        )
+        if incident.org_id
+        else {},
     )
 
 

--- a/backend/app/api/routes_twilio.py
+++ b/backend/app/api/routes_twilio.py
@@ -8,10 +8,17 @@ import hashlib
 import hmac
 from urllib.parse import parse_qs
 
-from fastapi import APIRouter, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.core.metrics import MetricNames, increment, timed
+from app.db.repo.message_operations import (
+    get_message_operation_by_provider_message_id,
+    update_message_operation_status,
+)
+from app.db.repo.provider_webhook_events import create_provider_webhook_event
+from app.db.session import get_db
 from app.services.twilio_notify import build_voice_twiml
 
 logger = logging.getLogger(__name__)
@@ -84,3 +91,46 @@ async def twilio_voice_webhook(request: Request):
         content=build_voice_twiml(VOICE_MESSAGE),
         media_type="application/xml",
     )
+
+
+@router.post("/status")
+async def twilio_status_webhook(request: Request, db: Session = Depends(get_db)):
+    body = await request.body()
+    raw_params = parse_qs(body.decode(), keep_blank_values=True)
+    params = _flatten_twilio_params(raw_params)
+    _validate_twilio_request(request, params)
+    create_provider_webhook_event(
+        db,
+        org_id=None,
+        provider="twilio",
+        domain="messaging",
+        event_type="status_callback",
+        status="processed",
+        external_reference=params.get("MessageSid"),
+        payload_json=params,
+    )
+    message_sid = params.get("MessageSid")
+    message_status = (params.get("MessageStatus") or "").strip().lower()
+    error_code = params.get("ErrorCode") or None
+    if message_sid:
+        operation = get_message_operation_by_provider_message_id(
+            db, provider="twilio", provider_message_id=message_sid
+        )
+        if operation is not None:
+            status_map = {
+                "queued": "queued",
+                "sent": "sent",
+                "delivered": "delivered",
+                "undelivered": "undelivered",
+                "failed": "failed",
+            }
+            mapped = status_map.get(message_status)
+            if mapped:
+                update_message_operation_status(
+                    db,
+                    operation,
+                    to_status=mapped,
+                    normalized_error_code=f"TWILIO_{error_code}" if error_code else None,
+                    details_json=params,
+                )
+    return {"status": "ok"}

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -303,6 +303,15 @@ class IncidentDetailResponse(BaseModel):
     evidence_inventory: list[ArtifactSummary] = Field(default_factory=list)
     export_status: list[ExportSummary] = Field(default_factory=list)
     timeline: list[EventSummary] = Field(default_factory=list)
+    messaging_reliability: dict[str, int] = Field(default_factory=dict)
+
+
+class MessagingReliabilityResponse(BaseModel):
+    total: int = Field(default=0, ge=0)
+    delivered: int = Field(default=0, ge=0)
+    undelivered: int = Field(default=0, ge=0)
+    failed: int = Field(default=0, ge=0)
+    success_rate_pct: int = Field(default=0, ge=0, le=100)
 
 
 # ── Exports ─────────────────────────────────────────────────────────
@@ -779,6 +788,9 @@ class OpsDashboardResponse(BaseModel):
     failed_exports: list[OpsFailedExportItem] = Field(default_factory=list)
     integration_health: list[IntegrationHealthItem] = Field(default_factory=list)
     recent_anomalies: list[OpsAnomalyItem] = Field(default_factory=list)
+    org_messaging_reliability: MessagingReliabilityResponse = Field(
+        default_factory=MessagingReliabilityResponse
+    )
 
 
 class AuditSearchResponseItem(BaseModel):

--- a/backend/app/db/migrations/versions/0017_expand_message_operations_for_delivery_reliability.py
+++ b/backend/app/db/migrations/versions/0017_expand_message_operations_for_delivery_reliability.py
@@ -1,0 +1,71 @@
+"""expand message operations for delivery reliability
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2026-04-11
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0017"
+down_revision: Union[str, None] = "0016"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("message_operations", sa.Column("purpose", sa.Text(), nullable=False, server_default="notification"))
+    op.add_column("message_operations", sa.Column("to_e164", sa.Text(), nullable=True))
+    op.add_column("message_operations", sa.Column("provider_message_id", sa.Text(), nullable=True))
+    op.add_column("message_operations", sa.Column("normalized_error_code", sa.Text(), nullable=True))
+
+    op.create_index("ix_message_operations_purpose", "message_operations", ["purpose"], unique=False)
+    op.create_index("ix_message_operations_to_e164", "message_operations", ["to_e164"], unique=False)
+    op.create_index("ix_message_operations_provider_message_id", "message_operations", ["provider_message_id"], unique=False)
+    op.create_index("ix_message_operations_normalized_error_code", "message_operations", ["normalized_error_code"], unique=False)
+
+    op.execute("ALTER TYPE message_operation_status ADD VALUE IF NOT EXISTS 'undelivered'")
+
+    op.create_table(
+        "message_operation_status_history",
+        sa.Column("history_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("message_operation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("from_status", sa.Text(), nullable=True),
+        sa.Column("to_status", sa.Text(), nullable=False),
+        sa.Column("provider_message_id", sa.Text(), nullable=True),
+        sa.Column("normalized_error_code", sa.Text(), nullable=True),
+        sa.Column("details_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("created_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["message_operation_id"], ["message_operations.message_operation_id"]),
+        sa.PrimaryKeyConstraint("history_id"),
+    )
+    op.create_index("ix_message_operation_status_history_message_operation_id", "message_operation_status_history", ["message_operation_id"], unique=False)
+    op.create_index("ix_message_operation_status_history_to_status", "message_operation_status_history", ["to_status"], unique=False)
+    op.create_index("ix_message_operation_status_history_provider_message_id", "message_operation_status_history", ["provider_message_id"], unique=False)
+    op.create_index("ix_message_operation_status_history_normalized_error_code", "message_operation_status_history", ["normalized_error_code"], unique=False)
+    op.create_index("ix_message_operation_status_history_created_at_utc", "message_operation_status_history", ["created_at_utc"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_message_operation_status_history_created_at_utc", table_name="message_operation_status_history")
+    op.drop_index("ix_message_operation_status_history_normalized_error_code", table_name="message_operation_status_history")
+    op.drop_index("ix_message_operation_status_history_provider_message_id", table_name="message_operation_status_history")
+    op.drop_index("ix_message_operation_status_history_to_status", table_name="message_operation_status_history")
+    op.drop_index("ix_message_operation_status_history_message_operation_id", table_name="message_operation_status_history")
+    op.drop_table("message_operation_status_history")
+
+    op.drop_index("ix_message_operations_normalized_error_code", table_name="message_operations")
+    op.drop_index("ix_message_operations_provider_message_id", table_name="message_operations")
+    op.drop_index("ix_message_operations_to_e164", table_name="message_operations")
+    op.drop_index("ix_message_operations_purpose", table_name="message_operations")
+
+    op.drop_column("message_operations", "normalized_error_code")
+    op.drop_column("message_operations", "provider_message_id")
+    op.drop_column("message_operations", "to_e164")
+    op.drop_column("message_operations", "purpose")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -714,6 +714,10 @@ class MessageOperation(Base):
         UUID(as_uuid=True), ForeignKey("incidents.incident_id"), nullable=True, index=True
     )
     provider = Column(Text, nullable=False, index=True)
+    purpose = Column(Text, nullable=False, server_default="notification", index=True)
+    to_e164 = Column(Text, nullable=True, index=True)
+    provider_message_id = Column(Text, nullable=True, index=True)
+    normalized_error_code = Column(Text, nullable=True, index=True)
     domain = Column(Text, nullable=True, index=True)
     channel = Column(Text, nullable=True, index=True)
     direction = Column(Text, nullable=True, index=True)
@@ -722,6 +726,7 @@ class MessageOperation(Base):
             "queued",
             "sent",
             "delivered",
+            "undelivered",
             "failed",
             "received",
             name="message_operation_status",
@@ -757,6 +762,28 @@ class MessageOperation(Base):
             "created_at_utc",
         ),
         Index("ix_message_operations_org_incident_created", "org_id", "incident_id", "created_at_utc"),
+    )
+
+
+class MessageOperationStatusHistory(Base):
+    """Timeline of status transitions for a message operation."""
+
+    __tablename__ = "message_operation_status_history"
+
+    history_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    message_operation_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("message_operations.message_operation_id"),
+        nullable=False,
+        index=True,
+    )
+    from_status = Column(Text, nullable=True)
+    to_status = Column(Text, nullable=False, index=True)
+    provider_message_id = Column(Text, nullable=True, index=True)
+    normalized_error_code = Column(Text, nullable=True, index=True)
+    details_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now(), index=True
     )
 
 

--- a/backend/app/db/repo/message_operations.py
+++ b/backend/app/db/repo/message_operations.py
@@ -1,10 +1,12 @@
 """Repository layer for message operations."""
 
 import uuid as _uuid
+from datetime import datetime, timezone
 
+from sqlalchemy import case, func
 from sqlalchemy.orm import Session
 
-from app.db.models import MessageOperation
+from app.db.models import MessageOperation, MessageOperationStatusHistory
 
 
 def create_message_operation(
@@ -15,8 +17,12 @@ def create_message_operation(
     incident_id: _uuid.UUID | None = None,
     operation_id: _uuid.UUID | None = None,
     domain: str | None = None,
+    purpose: str = "notification",
+    to_e164: str | None = None,
+    provider_message_id: str | None = None,
     correlation_id: str | None = None,
     external_reference: str | None = None,
+    normalized_error_code: str | None = None,
     payload_json: dict | None = None,
 ):
     message_operation = MessageOperation(
@@ -25,15 +31,110 @@ def create_message_operation(
         status=status,
         incident_id=incident_id,
         operation_id=operation_id,
+        purpose=purpose,
+        to_e164=to_e164,
+        provider_message_id=provider_message_id,
+        normalized_error_code=normalized_error_code,
         domain=domain,
         correlation_id=correlation_id,
         external_reference=external_reference,
         payload_json=payload_json or {},
     )
     db.add(message_operation)
+    db.flush()
+    db.add(
+        MessageOperationStatusHistory(
+            message_operation_id=message_operation.message_operation_id,
+            from_status=None,
+            to_status=status,
+            provider_message_id=provider_message_id,
+            normalized_error_code=normalized_error_code,
+            details_json={},
+        )
+    )
     db.commit()
     db.refresh(message_operation)
     return message_operation
+
+
+def update_message_operation_status(
+    db: Session,
+    message_operation: MessageOperation,
+    *,
+    to_status: str,
+    provider_message_id: str | None = None,
+    normalized_error_code: str | None = None,
+    details_json: dict | None = None,
+) -> MessageOperation:
+    from_status = message_operation.status
+    message_operation.status = to_status
+    if provider_message_id:
+        message_operation.provider_message_id = provider_message_id
+    if normalized_error_code is not None:
+        message_operation.normalized_error_code = normalized_error_code
+    now = datetime.now(timezone.utc)
+    if to_status == "sent":
+        message_operation.sent_at_utc = now
+    if to_status in {"delivered", "undelivered", "failed"}:
+        message_operation.delivered_at_utc = now
+    db.add(
+        MessageOperationStatusHistory(
+            message_operation_id=message_operation.message_operation_id,
+            from_status=from_status,
+            to_status=to_status,
+            provider_message_id=provider_message_id or message_operation.provider_message_id,
+            normalized_error_code=normalized_error_code,
+            details_json=details_json or {},
+        )
+    )
+    db.commit()
+    db.refresh(message_operation)
+    return message_operation
+
+
+def get_message_operation_by_provider_message_id(
+    db: Session,
+    *,
+    provider: str,
+    provider_message_id: str,
+) -> MessageOperation | None:
+    return (
+        db.query(MessageOperation)
+        .filter(
+            MessageOperation.provider == provider,
+            MessageOperation.provider_message_id == provider_message_id,
+        )
+        .order_by(MessageOperation.created_at_utc.desc())
+        .first()
+    )
+
+
+def get_messaging_reliability_summary(
+    db: Session,
+    *,
+    org_id: _uuid.UUID,
+    incident_id: _uuid.UUID | None = None,
+) -> dict[str, int]:
+    query = db.query(
+        func.count(MessageOperation.message_operation_id).label("total"),
+        func.sum(case((MessageOperation.status == "delivered", 1), else_=0)).label("delivered"),
+        func.sum(case((MessageOperation.status == "undelivered", 1), else_=0)).label("undelivered"),
+        func.sum(case((MessageOperation.status == "failed", 1), else_=0)).label("failed"),
+    ).filter(MessageOperation.org_id == org_id)
+    if incident_id is not None:
+        query = query.filter(MessageOperation.incident_id == incident_id)
+    row = query.one()
+    total = int(row.total or 0)
+    delivered = int(row.delivered or 0)
+    undelivered = int(row.undelivered or 0)
+    failed = int(row.failed or 0)
+    return {
+        "total": total,
+        "delivered": delivered,
+        "undelivered": undelivered,
+        "failed": failed,
+        "success_rate_pct": int(round((delivered / total) * 100)) if total else 0,
+    }
 
 
 def list_message_operations(

--- a/backend/app/tasks/notification_tasks.py
+++ b/backend/app/tasks/notification_tasks.py
@@ -99,6 +99,7 @@ def notify_safety_manager(self, incident_id: str):
     increment("notifications.safety_manager.attempts")
     from app.db.models import Org
     from app.db.repo.incidents import get_incident
+    from app.db.repo.message_operations import create_message_operation, update_message_operation_status
     from app.domain.system_event_types import SystemEventType
     from app.services.twilio_notify import build_voice_twiml, place_call, send_sms
 
@@ -156,15 +157,39 @@ def notify_safety_manager(self, incident_id: str):
         }
 
         if org.sms_enabled:
+            sms_operation = create_message_operation(
+                db,
+                org_id=incident.org_id,
+                incident_id=inc_uuid,
+                provider="twilio",
+                domain="messaging",
+                purpose="safety_manager_sms_notification",
+                to_e164=phone,
+                status="queued",
+                payload_json={"task": "notify_safety_manager"},
+            )
             sms_event_key = f"{workflow_key}:sms_sent"
             if _event_exists(
                 db, inc_uuid, SystemEventType.SAFETY_MANAGER_SMS_SENT, sms_event_key
             ):
                 result["sms_status"] = "already_sent"
+                update_message_operation_status(
+                    db,
+                    sms_operation,
+                    to_status="sent",
+                    details_json={"reason": "already_sent_event_exists"},
+                )
             else:
                 try:
                     sms_sid = send_sms(phone, message)
                     result["sms_sid"] = sms_sid
+                    update_message_operation_status(
+                        db,
+                        sms_operation,
+                        to_status="sent",
+                        provider_message_id=sms_sid,
+                        details_json={"sms_sid": sms_sid},
+                    )
                     _emit_once(
                         db,
                         inc_uuid,
@@ -178,6 +203,13 @@ def notify_safety_manager(self, incident_id: str):
                 except (httpx.HTTPError, ValueError, IntegrationError) as exc:
                     normalized_error = as_normalized_error(
                         exc, provider_hint="twilio", category="messaging"
+                    )
+                    update_message_operation_status(
+                        db,
+                        sms_operation,
+                        to_status="failed",
+                        normalized_error_code=normalized_error.code,
+                        details_json={"reason": normalized_error.operator_message},
                     )
                     _emit_once(
                         db,
@@ -194,15 +226,39 @@ def notify_safety_manager(self, incident_id: str):
                     errors.append(f"SMS failed: {normalized_error.operator_message}")
 
         if org.voice_enabled:
+            call_operation = create_message_operation(
+                db,
+                org_id=incident.org_id,
+                incident_id=inc_uuid,
+                provider="twilio",
+                domain="voice",
+                purpose="safety_manager_voice_notification",
+                to_e164=phone,
+                status="queued",
+                payload_json={"task": "notify_safety_manager"},
+            )
             call_event_key = f"{workflow_key}:call_placed"
             if _event_exists(
                 db, inc_uuid, SystemEventType.SAFETY_MANAGER_CALL_PLACED, call_event_key
             ):
                 result["call_status"] = "already_placed"
+                update_message_operation_status(
+                    db,
+                    call_operation,
+                    to_status="sent",
+                    details_json={"reason": "already_placed_event_exists"},
+                )
             else:
                 try:
                     call_sid = place_call(phone, twiml)
                     result["call_sid"] = call_sid
+                    update_message_operation_status(
+                        db,
+                        call_operation,
+                        to_status="sent",
+                        provider_message_id=call_sid,
+                        details_json={"call_sid": call_sid},
+                    )
                     _emit_once(
                         db,
                         inc_uuid,
@@ -216,6 +272,13 @@ def notify_safety_manager(self, incident_id: str):
                 except (httpx.HTTPError, ValueError, IntegrationError) as exc:
                     normalized_error = as_normalized_error(
                         exc, provider_hint="twilio", category="messaging"
+                    )
+                    update_message_operation_status(
+                        db,
+                        call_operation,
+                        to_status="failed",
+                        normalized_error_code=normalized_error.code,
+                        details_json={"reason": normalized_error.operator_message},
                     )
                     _emit_once(
                         db,

--- a/backend/tests/test_driver_auth_endpoints.py
+++ b/backend/tests/test_driver_auth_endpoints.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from app.api import routes_driver_auth
-from app.db.models import Base, Driver, Org, OtpChallenge
+from app.db.models import Base, Driver, MessageOperation, Org, OtpChallenge
 from app.db.session import get_db
 from app.main import app
 from tests.helpers.fake_redis import FakeRedisRateLimiter
@@ -94,6 +94,17 @@ def test_driver_otp_flow(client, db_session, driver):
         )
         assert challenge is not None
         assert challenge.twilio_sid == "VE123"
+        otp_request_operation = (
+            db_session.query(MessageOperation)
+            .filter(
+                MessageOperation.purpose == "otp_request",
+                MessageOperation.to_e164 == driver.phone_e164,
+            )
+            .first()
+        )
+        assert otp_request_operation is not None
+        assert otp_request_operation.status == "sent"
+        assert otp_request_operation.provider_message_id == "VE123"
 
         verify_resp = client.post(
             "/driver/auth/verify-otp",
@@ -102,6 +113,14 @@ def test_driver_otp_flow(client, db_session, driver):
         assert verify_resp.status_code == 200
         token = verify_resp.json()["access_token"]
         assert token
+        otp_verify_operation = (
+            db_session.query(MessageOperation)
+            .filter(MessageOperation.purpose == "otp_verify")
+            .order_by(MessageOperation.created_at_utc.desc())
+            .first()
+        )
+        assert otp_verify_operation is not None
+        assert otp_verify_operation.status == "delivered"
 
         me_resp = client.get(
             "/driver/me",

--- a/backend/tests/test_twilio_routes.py
+++ b/backend/tests/test_twilio_routes.py
@@ -1,24 +1,59 @@
 """Tests for Twilio webhook routes."""
 
+import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from app.api.routes_twilio import VOICE_MESSAGE, _build_twilio_signature
 from app.core.config import settings
+from app.db.models import Base, MessageOperation, Org
+from app.db.repo.message_operations import create_message_operation
+from app.db.session import get_db
 from app.main import app
 
 
-def test_twilio_voice_rejects_missing_signature(monkeypatch):
+@pytest.fixture()
+def db_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine)
+    session = TestSession()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def test_twilio_voice_rejects_missing_signature(monkeypatch, client):
     monkeypatch.setattr(settings, "TWILIO_AUTH_TOKEN", "secret")
-    client = TestClient(app)
 
     response = client.post("/twilio/voice", data={"CallSid": "CA123"})
 
     assert response.status_code == 403
 
 
-def test_twilio_voice_accepts_valid_signature(monkeypatch):
+def test_twilio_voice_accepts_valid_signature(monkeypatch, client):
     monkeypatch.setattr(settings, "TWILIO_AUTH_TOKEN", "secret")
-    client = TestClient(app)
     params = {"CallSid": "CA123", "From": "+15551234567"}
     url = f"{client.base_url}/twilio/voice"
     signature = _build_twilio_signature("secret", url, params)
@@ -31,3 +66,36 @@ def test_twilio_voice_accepts_valid_signature(monkeypatch):
 
     assert response.status_code == 200
     assert VOICE_MESSAGE in response.text
+
+
+def test_twilio_status_callback_reconciles_message_operation(monkeypatch, client, db_session):
+    monkeypatch.setattr(settings, "TWILIO_AUTH_TOKEN", "secret")
+    org = Org(name="Test Org")
+    db_session.add(org)
+    db_session.commit()
+
+    create_message_operation(
+        db_session,
+        org_id=org.id,
+        provider="twilio",
+        domain="messaging",
+        purpose="safety_manager_sms_notification",
+        to_e164="+15551234567",
+        status="sent",
+        provider_message_id="SM123",
+    )
+
+    params = {"MessageSid": "SM123", "MessageStatus": "delivered"}
+    url = f"{client.base_url}/twilio/status"
+    signature = _build_twilio_signature("secret", url, params)
+
+    response = client.post(
+        "/twilio/status",
+        data=params,
+        headers={"X-Twilio-Signature": signature},
+    )
+
+    assert response.status_code == 200
+    op = db_session.query(MessageOperation).filter(MessageOperation.provider_message_id == "SM123").first()
+    assert op is not None
+    assert op.status == "delivered"

--- a/contracts/schemas/runtime_api_contracts.json
+++ b/contracts/schemas/runtime_api_contracts.json
@@ -802,6 +802,13 @@
           "title": "Incident Id",
           "type": "string"
         },
+        "messaging_reliability": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "title": "Messaging Reliability",
+          "type": "object"
+        },
         "samsara_vehicle_id": {
           "anyOf": [
             {


### PR DESCRIPTION
### Motivation
- Add structured persistence for messaging/OTP/notification operations and a status timeline to record send/delivery/error transitions for observability and reconciliation. 
- Surface org/incident-level messaging reliability metrics and use provider callbacks (Twilio) to reconcile final delivery state and normalized error codes. 

### Description
- Extended `message_operations` with typed fields: `purpose`, `to_e164`, `provider_message_id`, and `normalized_error_code`, added `undelivered` status, and created a `message_operation_status_history` table to capture timeline transitions (migration `0017`).
- Implemented repository helpers in `app/db/repo/message_operations.py` to create operations with initial history, update status entries with history, look up operations by provider message id, and compute org/incident reliability rollups.
- Wired OTP flows to message operations by creating/updating operation records in `app/api/routes_driver_auth.py` for `otp_request` and `otp_verify`, capturing send/fail/undelivered/delivered transitions and normalized error codes.
- Wired notification task flow to create/update message operations for SMS and voice attempts in `app/tasks/notification_tasks.py`, recording provider SIDs and normalized errors.
- Added a Twilio status webhook endpoint (`POST /twilio/status`) in `app/api/routes_twilio.py` which validates Twilio signatures, persists the raw webhook event, and reconciles `MessageSid` status/error into `message_operations`.
- Exposed messaging reliability: included `messaging_reliability` in the incident detail response and `org_messaging_reliability` in the ops dashboard, and added `/admin/ops/messaging-reliability` endpoint with optional `incident_id` filter.
- Added/updated tests covering OTP operation tracking and Twilio status callback reconciliation and included an Alembic migration `0017_expand_message_operations_for_delivery_reliability.py` to apply schema changes.

### Testing
- Linted code with `cd backend && ruff check app tests` which completed successfully.
- Ran targeted test suite with `cd backend && pytest -q tests/test_driver_auth_endpoints.py tests/test_twilio_routes.py tests/test_celery_tasks.py::TestNotifySafetyManager tests/test_migration_integrity.py` and all selected tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9ba92a1e883219c4db063e3454e9c)