### PR TITLE
Add integration diagnostics, evidence retry endpoints and provider webhooks

### DIFF
--- a/backend/app/api/routes_integrations.py
+++ b/backend/app/api/routes_integrations.py
@@ -1,0 +1,408 @@
+"""Integration and evidence diagnostics API routes."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from sqlalchemy.orm import Session
+
+from app.api.schemas import (
+    EvidenceRequestSummary,
+    EvidenceRetryActionRequest,
+    EvidenceRetryActionResponse,
+    EvidenceSummaryResponse,
+    IntegrationConnectionHealthResponse,
+    IntegrationConnectionUpdateRequest,
+    IntegrationConnectionValidateResponse,
+    IntegrationOperationDiagnosticsResponse,
+)
+from app.core.config import settings
+from app.core.deps import get_current_user
+from app.core.logging import get_request_id
+from app.db.models import (
+    EvidenceRequest,
+    IntegrationConnection,
+    IntegrationOperation,
+    User,
+)
+from app.db.session import get_db
+from app.integrations.webhooks.handlers import (
+    persist_twilio_voice_callback,
+    process_twilio_status_callback,
+)
+from app.integrations.webhooks.signatures import (
+    parse_form_encoded_body,
+    validate_twilio_signature,
+)
+from app.security.authn import build_user_auth_context
+from app.services.dashcam_capture_service import queue_dashcam_capture
+from app.services.telematics_capture_service import queue_telematics_capture
+
+router = APIRouter()
+
+
+@router.get("/org/integrations", response_model=list[IntegrationConnectionHealthResponse])
+def list_org_integrations(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    rows = (
+        db.query(IntegrationConnection)
+        .filter(IntegrationConnection.org_id.in_(context.org_ids))
+        .order_by(IntegrationConnection.updated_at_utc.desc())
+        .all()
+    )
+    return [
+        IntegrationConnectionHealthResponse(
+            integration_id=row.connection_id,
+            provider=row.provider,
+            domain=row.domain,
+            status=row.status,
+            healthy=row.status in {"active", "pending"},
+            reason=None if row.status in {"active", "pending"} else "Connection not healthy",
+            last_synced_at_utc=row.last_synced_at_utc,
+            updated_at_utc=row.updated_at_utc,
+        )
+        for row in rows
+    ]
+
+
+@router.get("/org/integrations/{integration_id}", response_model=IntegrationConnectionHealthResponse)
+def get_org_integration(
+    integration_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    row = (
+        db.query(IntegrationConnection)
+        .filter(
+            IntegrationConnection.connection_id == integration_id,
+            IntegrationConnection.org_id.in_(context.org_ids),
+        )
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Integration not found")
+    return IntegrationConnectionHealthResponse(
+        integration_id=row.connection_id,
+        provider=row.provider,
+        domain=row.domain,
+        status=row.status,
+        healthy=row.status in {"active", "pending"},
+        reason=None if row.status in {"active", "pending"} else "Connection not healthy",
+        last_synced_at_utc=row.last_synced_at_utc,
+        updated_at_utc=row.updated_at_utc,
+    )
+
+
+@router.post(
+    "/org/integrations/{integration_id}/validate",
+    response_model=IntegrationConnectionValidateResponse,
+)
+def validate_org_integration(
+    integration_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    row = (
+        db.query(IntegrationConnection)
+        .filter(
+            IntegrationConnection.connection_id == integration_id,
+            IntegrationConnection.org_id.in_(context.org_ids),
+        )
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Integration not found")
+
+    valid = bool(row.credentials_ref) and row.status != "inactive"
+    return IntegrationConnectionValidateResponse(
+        integration_id=row.connection_id,
+        valid=valid,
+        status=row.status,
+        message="Connection validated" if valid else "Connection missing credentials or disabled",
+    )
+
+
+@router.patch("/org/integrations/{integration_id}", response_model=IntegrationConnectionHealthResponse)
+def patch_org_integration(
+    integration_id: uuid.UUID,
+    payload: IntegrationConnectionUpdateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    row = (
+        db.query(IntegrationConnection)
+        .filter(
+            IntegrationConnection.connection_id == integration_id,
+            IntegrationConnection.org_id.in_(context.org_ids),
+        )
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Integration not found")
+
+    updates = payload.model_dump(exclude_unset=True)
+    for field in ("status", "credentials_ref", "config_json"):
+        if field in updates:
+            setattr(row, field, updates[field])
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+
+    return IntegrationConnectionHealthResponse(
+        integration_id=row.connection_id,
+        provider=row.provider,
+        domain=row.domain,
+        status=row.status,
+        healthy=row.status in {"active", "pending"},
+        reason=None if row.status in {"active", "pending"} else "Connection not healthy",
+        last_synced_at_utc=row.last_synced_at_utc,
+        updated_at_utc=row.updated_at_utc,
+    )
+
+
+@router.post("/org/integrations/{integration_id}/disable", response_model=IntegrationConnectionHealthResponse)
+def disable_org_integration(
+    integration_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    row = (
+        db.query(IntegrationConnection)
+        .filter(
+            IntegrationConnection.connection_id == integration_id,
+            IntegrationConnection.org_id.in_(context.org_ids),
+        )
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Integration not found")
+
+    row.status = "inactive"
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+
+    return IntegrationConnectionHealthResponse(
+        integration_id=row.connection_id,
+        provider=row.provider,
+        domain=row.domain,
+        status=row.status,
+        healthy=False,
+        reason="Connection disabled",
+        last_synced_at_utc=row.last_synced_at_utc,
+        updated_at_utc=row.updated_at_utc,
+    )
+
+
+@router.get("/integration-operations", response_model=list[IntegrationOperationDiagnosticsResponse])
+def list_integration_operations(
+    incident_id: uuid.UUID | None = None,
+    status: str | None = None,
+    provider: str | None = None,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    query = db.query(IntegrationOperation).filter(IntegrationOperation.org_id.in_(context.org_ids))
+    if incident_id is not None:
+        query = query.filter(IntegrationOperation.incident_id == incident_id)
+    if status is not None:
+        query = query.filter(IntegrationOperation.status == status)
+    if provider is not None:
+        query = query.filter(IntegrationOperation.provider == provider)
+    rows = query.order_by(IntegrationOperation.requested_at_utc.desc()).all()
+    return [IntegrationOperationDiagnosticsResponse.model_validate(row, from_attributes=True) for row in rows]
+
+
+@router.get(
+    "/integration-operations/{operation_id}",
+    response_model=IntegrationOperationDiagnosticsResponse,
+)
+def get_integration_operation(
+    operation_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    row = (
+        db.query(IntegrationOperation)
+        .filter(
+            IntegrationOperation.operation_id == operation_id,
+            IntegrationOperation.org_id.in_(context.org_ids),
+        )
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Integration operation not found")
+    return IntegrationOperationDiagnosticsResponse.model_validate(row, from_attributes=True)
+
+
+@router.get(
+    "/incidents/{incident_id}/evidence-requests",
+    response_model=list[EvidenceRequestSummary],
+)
+def list_incident_evidence_requests(
+    incident_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    rows = (
+        db.query(EvidenceRequest)
+        .filter(
+            EvidenceRequest.incident_id == incident_id,
+            EvidenceRequest.org_id.in_(context.org_ids),
+        )
+        .order_by(EvidenceRequest.requested_at_utc.desc())
+        .all()
+    )
+    return [EvidenceRequestSummary.model_validate(row, from_attributes=True) for row in rows]
+
+
+@router.post(
+    "/incidents/{incident_id}/evidence-requests/retry",
+    response_model=EvidenceRetryActionResponse,
+)
+def retry_incident_evidence_requests(
+    incident_id: uuid.UUID,
+    payload: EvidenceRetryActionRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    query = db.query(EvidenceRequest).filter(
+        EvidenceRequest.incident_id == incident_id,
+        EvidenceRequest.org_id.in_(context.org_ids),
+    )
+    if payload.evidence_request_ids:
+        query = query.filter(EvidenceRequest.evidence_request_id.in_(payload.evidence_request_ids))
+    if payload.retry_failed_only:
+        query = query.filter(EvidenceRequest.status == "failed")
+
+    rows = query.order_by(EvidenceRequest.requested_at_utc.desc()).all()
+    if not rows:
+        return EvidenceRetryActionResponse(incident_id=incident_id, retried_count=0, queued_operation_ids=[])
+
+    correlation_id = get_request_id() or str(uuid.uuid4())
+    operation_ids: list[uuid.UUID] = []
+
+    dashcam_ids = [row.evidence_request_id for row in rows if row.domain == "dashcam"]
+    telematics_ids = [row.evidence_request_id for row in rows if row.domain == "telematics"]
+    org_id = rows[0].org_id
+    if org_id is None:
+        raise HTTPException(status_code=422, detail="Evidence requests are missing org_id")
+
+    if dashcam_ids:
+        operation_ids.append(
+            queue_dashcam_capture(
+                db,
+                org_id=org_id,
+                incident_id=incident_id,
+                window_start=None,
+                window_end=None,
+                api_correlation_id=correlation_id,
+                evidence_request_ids=dashcam_ids,
+            )
+        )
+    if telematics_ids:
+        operation_ids.append(
+            queue_telematics_capture(
+                db,
+                org_id=org_id,
+                incident_id=incident_id,
+                window_start=None,
+                window_end=None,
+                api_correlation_id=correlation_id,
+                evidence_request_ids=telematics_ids,
+            )
+        )
+
+    return EvidenceRetryActionResponse(
+        incident_id=incident_id,
+        retried_count=len(rows),
+        queued_operation_ids=operation_ids,
+    )
+
+
+@router.get("/incidents/{incident_id}/evidence-summary", response_model=EvidenceSummaryResponse)
+def get_incident_evidence_summary(
+    incident_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    rows = (
+        db.query(EvidenceRequest)
+        .filter(
+            EvidenceRequest.incident_id == incident_id,
+            EvidenceRequest.org_id.in_(context.org_ids),
+        )
+        .order_by(EvidenceRequest.requested_at_utc.desc())
+        .all()
+    )
+
+    status_counts: dict[str, int] = {}
+    provider_counts: dict[str, int] = {}
+    retryable_failures = 0
+    for row in rows:
+        status_counts[row.status] = status_counts.get(row.status, 0) + 1
+        provider_counts[row.provider] = provider_counts.get(row.provider, 0) + 1
+        if row.status == "failed" and row.error_retryable:
+            retryable_failures += 1
+
+    return EvidenceSummaryResponse(
+        incident_id=incident_id,
+        total_requests=len(rows),
+        status_counts=status_counts,
+        provider_counts=provider_counts,
+        retryable_failures=retryable_failures,
+        requests=[EvidenceRequestSummary.model_validate(row, from_attributes=True) for row in rows],
+    )
+
+
+@router.post("/provider-webhooks/twilio/voice")
+async def provider_twilio_voice_webhook(request: Request, db: Session = Depends(get_db)):
+    raw_body = await request.body()
+    params = parse_form_encoded_body(raw_body)
+    signature_valid, signature_error = validate_twilio_signature(
+        auth_token=settings.TWILIO_AUTH_TOKEN,
+        request_url=str(request.url),
+        params=params,
+        provided_signature=request.headers.get("X-Twilio-Signature"),
+    )
+    result = persist_twilio_voice_callback(
+        db,
+        payload=params,
+        raw_payload=raw_body.decode("utf-8", errors="ignore"),
+        signature_valid=signature_valid,
+        signature_error=signature_error,
+    )
+    return Response(status_code=result.status_code, content=result.body.get("detail", "ok"))
+
+
+@router.post("/provider-webhooks/twilio/status")
+async def provider_twilio_status_webhook(request: Request, db: Session = Depends(get_db)):
+    raw_body = await request.body()
+    params = parse_form_encoded_body(raw_body)
+    signature_valid, signature_error = validate_twilio_signature(
+        auth_token=settings.TWILIO_AUTH_TOKEN,
+        request_url=str(request.url),
+        params=params,
+        provided_signature=request.headers.get("X-Twilio-Signature"),
+    )
+    result = process_twilio_status_callback(
+        db,
+        payload=params,
+        raw_payload=raw_body.decode("utf-8", errors="ignore"),
+        signature_valid=signature_valid,
+        signature_error=signature_error,
+    )
+    return result.body

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -771,6 +771,109 @@ class IntegrationHealthItem(BaseModel):
     details: str | None = None
 
 
+IntegrationConnectionStatus = Literal["pending", "active", "inactive", "error"]
+IntegrationOperationStatus = Literal[
+    "requested",
+    "submitted_to_provider",
+    "processing_at_provider",
+    "available",
+    "downloaded",
+    "unavailable",
+    "queued",
+    "running",
+    "succeeded",
+    "failed",
+    "canceled",
+]
+EvidenceRequestStatus = Literal["open", "in_progress", "fulfilled", "failed", "canceled"]
+
+
+class IntegrationConnectionHealthResponse(BaseModel):
+    integration_id: uuid.UUID
+    provider: str
+    domain: str | None = None
+    status: IntegrationConnectionStatus
+    healthy: bool
+    reason: str | None = None
+    last_synced_at_utc: datetime | None = None
+    updated_at_utc: datetime | None = None
+
+
+class IntegrationConnectionUpdateRequest(BaseModel):
+    status: IntegrationConnectionStatus | None = None
+    credentials_ref: str | None = None
+    config_json: dict[str, Any] | None = None
+
+
+class IntegrationConnectionValidateResponse(BaseModel):
+    integration_id: uuid.UUID
+    valid: bool
+    status: IntegrationConnectionStatus
+    message: str
+
+
+class IntegrationOperationDiagnosticsResponse(BaseModel):
+    operation_id: uuid.UUID
+    org_id: uuid.UUID | None = None
+    incident_id: uuid.UUID | None = None
+    connection_id: uuid.UUID | None = None
+    provider: str
+    domain: str | None = None
+    operation_type: str
+    status: IntegrationOperationStatus
+    correlation_id: str | None = None
+    external_reference: str | None = None
+    external_reference_id: str | None = None
+    payload_json: dict[str, Any] = Field(default_factory=dict)
+    result_json: dict[str, Any] = Field(default_factory=dict)
+    error_message: str | None = None
+    error_code: str | None = None
+    error_category: str | None = None
+    error_provider_key: str | None = None
+    error_retryable: bool | None = None
+    error_user_facing_message: str | None = None
+    error_operator_message: str | None = None
+    requested_at_utc: datetime | None = None
+    started_at_utc: datetime | None = None
+    completed_at_utc: datetime | None = None
+    updated_at_utc: datetime | None = None
+
+
+class EvidenceRequestSummary(BaseModel):
+    evidence_request_id: uuid.UUID
+    operation_id: uuid.UUID | None = None
+    provider: str
+    domain: str | None = None
+    status: EvidenceRequestStatus
+    external_reference: str | None = None
+    error_code: str | None = None
+    error_category: str | None = None
+    error_retryable: bool | None = None
+    error_user_facing_message: str | None = None
+    requested_at_utc: datetime | None = None
+    fulfilled_at_utc: datetime | None = None
+
+
+class EvidenceSummaryResponse(BaseModel):
+    incident_id: uuid.UUID
+    total_requests: int
+    status_counts: dict[str, int] = Field(default_factory=dict)
+    provider_counts: dict[str, int] = Field(default_factory=dict)
+    retryable_failures: int = 0
+    requests: list[EvidenceRequestSummary] = Field(default_factory=list)
+
+
+class EvidenceRetryActionRequest(BaseModel):
+    evidence_request_ids: list[uuid.UUID] | None = None
+    retry_failed_only: bool = True
+
+
+class EvidenceRetryActionResponse(BaseModel):
+    incident_id: uuid.UUID
+    retried_count: int
+    queued_operation_ids: list[uuid.UUID] = Field(default_factory=list)
+
+
 class OpsAnomalyItem(BaseModel):
     audit_event_id: uuid.UUID
     occurred_at_utc: datetime

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from app.api.routes_driver_auth import router as driver_auth_router
 from app.api.routes_incidents import router as incidents_router
 from app.api.routes_exports import router as exports_router
 from app.api.routes_driver import router as driver_router
+from app.api.routes_integrations import router as integrations_router
 from app.api.routes.routes_driver_artifacts import router as driver_artifacts_router
 from app.api.routes.routes_driver_report import router as driver_report_router
 from app.api.routes_admin import router as admin_router
@@ -46,6 +47,7 @@ app.include_router(driver_artifacts_router, prefix="/driver", tags=["driver-arti
 app.include_router(driver_report_router, prefix="/driver", tags=["driver-report"])
 app.include_router(admin_router, prefix="/admin", tags=["admin"])
 app.include_router(twilio_router, prefix="/twilio", tags=["twilio"])
+app.include_router(integrations_router, tags=["integrations"])
 app.include_router(health_router)
 
 

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -9,7 +9,19 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from app.db.models import Base, Incident, Artifact, Event, Export, User, Org, UserOrg
+from app.db.models import (
+    Base,
+    Incident,
+    Artifact,
+    Event,
+    Export,
+    User,
+    Org,
+    UserOrg,
+    IntegrationConnection,
+    IntegrationOperation,
+    EvidenceRequest,
+)
 from app.db.session import get_db
 from app.core.security import hash_password, create_access_token
 from app.main import app
@@ -245,6 +257,87 @@ class TestGetIncident:
         for event in data["timeline"]:
             assert "occurred_at_utc" in event
             assert "actor_type" in event
+
+
+class TestIntegrationDiagnosticsRoutes:
+    def test_org_integrations_and_details(self, client, db_session, test_org, auth_headers):
+        connection = IntegrationConnection(
+            org_id=test_org.id,
+            provider="samsara",
+            domain="telematics",
+            status="active",
+            credentials_ref="vault://samsara",
+        )
+        db_session.add(connection)
+        db_session.commit()
+        db_session.refresh(connection)
+
+        list_resp = client.get("/org/integrations", headers=auth_headers)
+        assert list_resp.status_code == 200
+        assert len(list_resp.json()) == 1
+
+        detail_resp = client.get(f"/org/integrations/{connection.connection_id}", headers=auth_headers)
+        assert detail_resp.status_code == 200
+        assert detail_resp.json()["provider"] == "samsara"
+
+    def test_integration_operations_and_evidence_summary(self, client, db_session, test_org, auth_headers):
+        incident = Incident(
+            org_id=test_org.id,
+            status="evidence_capturing",
+            severity="serious",
+            adc_vehicle_id="veh-123",
+            samsara_vehicle_id="sm-veh-123",
+            adc_driver_id="drv-123",
+        )
+        db_session.add(incident)
+        db_session.commit()
+        db_session.refresh(incident)
+
+        operation = IntegrationOperation(
+            org_id=test_org.id,
+            incident_id=incident.incident_id,
+            provider="samsara",
+            domain="dashcam",
+            operation_type="capture_dashcam",
+            status="failed",
+            payload_json={},
+            result_json={},
+        )
+        db_session.add(operation)
+        db_session.commit()
+        db_session.refresh(operation)
+
+        evidence = EvidenceRequest(
+            org_id=test_org.id,
+            incident_id=incident.incident_id,
+            operation_id=operation.operation_id,
+            provider="samsara",
+            domain="dashcam",
+            status="failed",
+            error_retryable=True,
+            request_payload_json={},
+            response_payload_json={},
+        )
+        db_session.add(evidence)
+        db_session.commit()
+
+        ops_resp = client.get("/integration-operations", headers=auth_headers)
+        assert ops_resp.status_code == 200
+        assert len(ops_resp.json()) == 1
+
+        evidence_list = client.get(
+            f"/incidents/{incident.incident_id}/evidence-requests",
+            headers=auth_headers,
+        )
+        assert evidence_list.status_code == 200
+        assert len(evidence_list.json()) == 1
+
+        summary_resp = client.get(
+            f"/incidents/{incident.incident_id}/evidence-summary",
+            headers=auth_headers,
+        )
+        assert summary_resp.status_code == 200
+        assert summary_resp.json()["retryable_failures"] == 1
 
     @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_get_incident_returns_created_at(


### PR DESCRIPTION
### Motivation
- Expose org-level integration management and health endpoints plus diagnostics for integration operations to aid operators in monitoring and remediating provider integrations.
- Provide incident-scoped visibility into external evidence requests and a retry action to re-queue failed evidence captures.
- Accept inbound provider webhooks (Twilio voice/status) through dedicated endpoints and persist/process them with existing webhook handlers.

### Description
- Added a new router `backend/app/api/routes_integrations.py` implementing endpoints: `GET /org/integrations`, `GET /org/integrations/{integration_id}`, `POST /org/integrations/{integration_id}/validate`, `PATCH /org/integrations/{integration_id}`, `POST /org/integrations/{integration_id}/disable`, `GET /integration-operations`, `GET /integration-operations/{operation_id}`, `GET /incidents/{incident_id}/evidence-requests`, `POST /incidents/{incident_id}/evidence-requests/retry`, `GET /incidents/{incident_id}/evidence-summary`, and provider webhook endpoints `POST /provider-webhooks/twilio/voice` and `POST /provider-webhooks/twilio/status`.
- Introduced new Pydantic schemas in `backend/app/api/schemas.py` for integration connection health/update/validate (`IntegrationConnectionHealthResponse`, `IntegrationConnectionUpdateRequest`, `IntegrationConnectionValidateResponse`), operation diagnostics (`IntegrationOperationDiagnosticsResponse`), evidence summaries/requests (`EvidenceSummaryResponse`, `EvidenceRequestSummary`) and retry actions (`EvidenceRetryActionRequest`, `EvidenceRetryActionResponse`) plus supporting status `Literal` types.
- Wired the new router into the FastAPI app by including it in `backend/app/main.py` so endpoints are active at runtime.
- Retry endpoint uses existing services `queue_dashcam_capture` and `queue_telematics_capture` to create/queue new provider operations; webhook endpoints delegate to existing handlers and validate signatures with `settings.TWILIO_AUTH_TOKEN`.
- Extended API tests in `backend/tests/test_api_endpoints.py` to seed integration/operation/evidence rows and assert the new endpoints return expected payloads.

### Testing
- Ran linting with `cd backend && python -m ruff check app tests`, which completed with no findings.
- Ran unit tests with `cd backend && pytest tests/test_api_endpoints.py tests/test_twilio_routes.py`, and all tests passed (`63 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1c289cf483218885db3895d0505a)