### PR TITLE
Add integration evidence preflight UI and status badges to export flow

### DIFF
--- a/frontend/app/incidents/[id]/IncidentDetailClient.tsx
+++ b/frontend/app/incidents/[id]/IncidentDetailClient.tsx
@@ -257,6 +257,7 @@ export default function IncidentDetailClient() {
           <IncidentDetailExportPanel
             incidentId={id}
             exports={incident.export_status}
+            artifacts={incident.evidence_inventory}
             onExportsChanged={refreshIncident}
           />
         </div>

--- a/frontend/components/GenerateExportModal.tsx
+++ b/frontend/components/GenerateExportModal.tsx
@@ -16,6 +16,9 @@ interface GenerateExportModalProps {
   onSubmit: (payload: { exportType: ExportType; options: ExportOptions }) => Promise<void>;
   disabled?: boolean;
   warningCount?: number;
+  preflightPendingCount?: number;
+  preflightUnavailableCount?: number;
+  preflightWarnings?: string[];
 }
 
 const EXPORT_TYPE_OPTIONS: Array<{ value: ExportType; label: string; description: string }> = [
@@ -59,6 +62,9 @@ export default function GenerateExportModal({
   onSubmit,
   disabled = false,
   warningCount = 0,
+  preflightPendingCount = 0,
+  preflightUnavailableCount = 0,
+  preflightWarnings = [],
 }: GenerateExportModalProps) {
   const [step, setStep] = useState<"configure" | "review">("configure");
   const [exportType, setExportType] = useState<ExportType>("court_defense");
@@ -106,7 +112,7 @@ export default function GenerateExportModal({
           <div>
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Generate export</h3>
             <p className="text-sm text-gray-500">
-              {step === "configure" ? "Choose export settings." : "Review included sections and warnings."}
+              {step === "configure" ? "Choose export settings." : "Review included sections and preflight warnings."}
             </p>
           </div>
           <button onClick={handleClose} className="text-sm text-gray-500 hover:underline">
@@ -187,12 +193,17 @@ export default function GenerateExportModal({
               </ul>
             </div>
             <div className="rounded border border-amber-200 bg-amber-50 p-3">
-              <p className="text-sm font-medium text-amber-900">Non-blocking warnings</p>
+              <p className="text-sm font-medium text-amber-900">Preflight visibility</p>
               <ul className="mt-2 list-disc space-y-1 pl-5 text-xs text-amber-900">
+                <li>{preflightPendingCount} evidence item(s) are still pending upstream retrieval.</li>
+                <li>{preflightUnavailableCount} evidence item(s) are unavailable/partial and will be flagged in packet rationale.</li>
                 {NON_BLOCKING_WARNINGS.map((warning) => (
                   <li key={warning}>{warning}</li>
                 ))}
                 {warningCount > 0 && <li>{warningCount} warning(s) detected on recent export attempts.</li>}
+                {preflightWarnings.slice(0, 5).map((warning) => (
+                  <li key={warning}>{warning}</li>
+                ))}
               </ul>
             </div>
           </div>

--- a/frontend/components/IncidentDetailExportPanel.tsx
+++ b/frontend/components/IncidentDetailExportPanel.tsx
@@ -7,6 +7,7 @@ import {
   getExport,
   getExportStatus,
   retryExport,
+  type ArtifactSummary,
   type ExportProgressStage,
   type ExportStatus,
   type ExportSummary,
@@ -15,10 +16,15 @@ import {
 } from "@/lib/api";
 import { getExportStatusBadgeClass, getExportStatusLabel } from "@/lib/exportStatus";
 import GenerateExportModal from "@/components/GenerateExportModal";
+import EvidenceStatusPanel, {
+  type EvidenceStatusItem,
+} from "@/components/integrations/EvidenceStatusPanel";
+import type { EvidenceIntegrationStatus } from "@/components/integrations/EvidenceStatusBadge";
 
 interface IncidentDetailExportPanelProps {
   incidentId: string;
   exports: ExportSummary[];
+  artifacts: ArtifactSummary[];
   onExportsChanged: () => Promise<void>;
 }
 
@@ -38,9 +44,25 @@ function formatBytes(value?: number | null): string {
   return `${(value / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+function toEvidenceStatus(status: unknown): EvidenceIntegrationStatus {
+  const value = String(status ?? "").toLowerCase();
+  if (value === "requested" || value === "queued" || value === "in_progress" || value === "available" || value === "partial" || value === "unavailable" || value === "failed") {
+    return value;
+  }
+  return "requested";
+}
+
+function formatWindow(start?: string | null, end?: string | null): string | null {
+  if (!start && !end) return null;
+  const startLabel = start ? new Date(start).toLocaleString() : "—";
+  const endLabel = end ? new Date(end).toLocaleString() : "—";
+  return `${startLabel} → ${endLabel}`;
+}
+
 export default function IncidentDetailExportPanel({
   incidentId,
   exports,
+  artifacts,
   onExportsChanged,
 }: IncidentDetailExportPanelProps) {
   const [showModal, setShowModal] = useState(false);
@@ -52,6 +74,7 @@ export default function IncidentDetailExportPanel({
   const [readyExport, setReadyExport] = useState<ExportSummary | null>(null);
 
   const recentExports = exports.slice(0, 5);
+  const latestExport = recentExports[0];
   const latestFailedExportId =
     activeExportId && (status === "failed" || status === "expired")
       ? activeExportId
@@ -64,6 +87,47 @@ export default function IncidentDetailExportPanel({
       }, 0),
     [recentExports]
   );
+
+  const integrationStatusItems = useMemo<EvidenceStatusItem[]>(() => {
+    const source = latestExport?.options_json?.evidence_statuses;
+    if (Array.isArray(source)) {
+      return source.map((raw, idx) => {
+        const item = (raw ?? {}) as Record<string, unknown>;
+        return {
+          key: String(item.id ?? `${idx}-${item.evidence_type ?? "evidence"}`),
+          evidenceType: String(item.evidence_type ?? item.type ?? "Unknown evidence"),
+          status: toEvidenceStatus(item.status),
+          requestedWindow: formatWindow(
+            typeof item.requested_window_start === "string" ? item.requested_window_start : null,
+            typeof item.requested_window_end === "string" ? item.requested_window_end : null
+          ),
+          operationUrl: typeof item.operation_link === "string" ? item.operation_link : null,
+          artifactUrl: typeof item.artifact_link === "string" ? item.artifact_link : null,
+          missingReason: typeof item.missing_reason === "string" ? item.missing_reason : null,
+          retryAvailable: Boolean(item.retry_available),
+        };
+      });
+    }
+
+    return artifacts.map((artifact) => ({
+      key: artifact.artifact_id,
+      evidenceType: artifact.artifact_type,
+      status:
+        artifact.status === "captured"
+          ? "available"
+          : artifact.status === "unavailable"
+            ? "unavailable"
+            : "queued",
+      requestedWindow: null,
+      operationUrl: null,
+      artifactUrl: null,
+      missingReason: artifact.unavailable_reason,
+      retryAvailable: artifact.status === "unavailable",
+    }));
+  }, [artifacts, latestExport]);
+
+  const preflightPending = integrationStatusItems.filter((item) => item.status === "requested" || item.status === "queued" || item.status === "in_progress");
+  const preflightUnavailable = integrationStatusItems.filter((item) => item.status === "unavailable" || item.status === "failed" || item.status === "partial");
 
   useEffect(() => {
     if (!activeExportId || !status || (status !== "queued" && status !== "processing" && status !== "requested")) {
@@ -157,6 +221,18 @@ export default function IncidentDetailExportPanel({
 
   return (
     <div className="space-y-4">
+      <div className="rounded border border-gray-200 p-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Integration evidence preflight</p>
+        <p className="mb-3 text-xs text-gray-500">
+          Review evidence availability, missing reasons, and retryability before packet generation.
+        </p>
+        <EvidenceStatusPanel
+          items={integrationStatusItems}
+          onRetry={(item) => item.retryAvailable && latestFailedExportId && handleRetry(latestFailedExportId)}
+          retrying={submitting}
+        />
+      </div>
+
       <div className="flex items-center justify-between">
         <p className="text-xs text-gray-500">Recent exports and generation status.</p>
         <button
@@ -250,6 +326,9 @@ export default function IncidentDetailExportPanel({
         onSubmit={startExport}
         disabled={submitting}
         warningCount={recentWarnings}
+        preflightPendingCount={preflightPending.length}
+        preflightUnavailableCount={preflightUnavailable.length}
+        preflightWarnings={preflightUnavailable.map((item) => `${item.evidenceType}: ${item.missingReason ?? item.status}`)}
       />
     </div>
   );

--- a/frontend/components/integrations/EvidenceStatusBadge.tsx
+++ b/frontend/components/integrations/EvidenceStatusBadge.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+export type EvidenceIntegrationStatus =
+  | "requested"
+  | "queued"
+  | "in_progress"
+  | "available"
+  | "partial"
+  | "unavailable"
+  | "failed";
+
+const STATUS_STYLES: Record<EvidenceIntegrationStatus, string> = {
+  requested: "bg-slate-100 text-slate-700",
+  queued: "bg-blue-100 text-blue-800",
+  in_progress: "bg-indigo-100 text-indigo-800",
+  available: "bg-green-100 text-green-800",
+  partial: "bg-amber-100 text-amber-800",
+  unavailable: "bg-red-100 text-red-800",
+  failed: "bg-rose-100 text-rose-800",
+};
+
+const STATUS_LABELS: Record<EvidenceIntegrationStatus, string> = {
+  requested: "Requested",
+  queued: "Queued",
+  in_progress: "In progress",
+  available: "Available",
+  partial: "Partial",
+  unavailable: "Unavailable",
+  failed: "Failed",
+};
+
+interface EvidenceStatusBadgeProps {
+  status: EvidenceIntegrationStatus;
+}
+
+export default function EvidenceStatusBadge({ status }: EvidenceStatusBadgeProps) {
+  return (
+    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[status]}`}>
+      {STATUS_LABELS[status]}
+    </span>
+  );
+}

--- a/frontend/components/integrations/EvidenceStatusPanel.tsx
+++ b/frontend/components/integrations/EvidenceStatusPanel.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+import EvidenceStatusBadge, { type EvidenceIntegrationStatus } from "@/components/integrations/EvidenceStatusBadge";
+
+export interface EvidenceStatusItem {
+  key: string;
+  evidenceType: string;
+  status: EvidenceIntegrationStatus;
+  requestedWindow?: string | null;
+  operationUrl?: string | null;
+  artifactUrl?: string | null;
+  missingReason?: string | null;
+  retryAvailable?: boolean;
+}
+
+interface EvidenceStatusPanelProps {
+  items: EvidenceStatusItem[];
+  onRetry?: (item: EvidenceStatusItem) => void;
+  retrying?: boolean;
+}
+
+export default function EvidenceStatusPanel({
+  items,
+  onRetry,
+  retrying = false,
+}: EvidenceStatusPanelProps) {
+  if (items.length === 0) {
+    return <p className="text-xs text-gray-500">No integration evidence status available yet.</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto rounded border border-gray-200">
+      <table className="min-w-full divide-y divide-gray-200 text-sm">
+        <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+          <tr>
+            <th className="px-3 py-2 text-left">Evidence type</th>
+            <th className="px-3 py-2 text-left">Status</th>
+            <th className="px-3 py-2 text-left">Requested window</th>
+            <th className="px-3 py-2 text-left">Links</th>
+            <th className="px-3 py-2 text-left">Missing reason</th>
+            <th className="px-3 py-2 text-left">Retry</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100 bg-white align-top">
+          {items.map((item) => (
+            <tr key={item.key}>
+              <td className="px-3 py-2 text-gray-900">{item.evidenceType}</td>
+              <td className="px-3 py-2">
+                <EvidenceStatusBadge status={item.status} />
+              </td>
+              <td className="px-3 py-2 text-gray-700">{item.requestedWindow ?? "—"}</td>
+              <td className="px-3 py-2 text-xs">
+                <div className="flex flex-col gap-1">
+                  {item.operationUrl ? (
+                    <Link href={item.operationUrl} className="text-blue-600 hover:underline">
+                      Operation
+                    </Link>
+                  ) : (
+                    <span className="text-gray-400">Operation —</span>
+                  )}
+                  {item.artifactUrl ? (
+                    <Link href={item.artifactUrl} className="text-blue-600 hover:underline">
+                      Artifact
+                    </Link>
+                  ) : (
+                    <span className="text-gray-400">Artifact —</span>
+                  )}
+                </div>
+              </td>
+              <td className="px-3 py-2 text-gray-700">{item.missingReason ?? "—"}</td>
+              <td className="px-3 py-2">
+                {item.retryAvailable && onRetry ? (
+                  <button
+                    onClick={() => onRetry(item)}
+                    disabled={retrying}
+                    className="rounded border border-gray-300 px-2 py-1 text-xs hover:bg-gray-50 disabled:opacity-50"
+                  >
+                    Retry
+                  </button>
+                ) : (
+                  <span className="text-xs text-gray-400">Not available</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Surface integration evidence availability and reasons so operators can review pending/unavailable items and retry options before generating export packets.

### Description
- Add `EvidenceStatusBadge` at `frontend/components/integrations/EvidenceStatusBadge.tsx` providing reusable badges for `requested`, `queued`, `in_progress`, `available`, `partial`, `unavailable`, and `failed` states.
- Add `EvidenceStatusPanel` at `frontend/components/integrations/EvidenceStatusPanel.tsx` which renders a table of evidence type, status badge, requested window, operation/artifact links, missing reason, and retry action availability.
- Enhance `IncidentDetailExportPanel` to accept `artifacts`, parse rich `options_json.evidence_statuses` when present (and fall back to `incident.evidence_inventory`), compute preflight pending/unavailable rollups, and embed the `EvidenceStatusPanel` above export controls.
- Update `GenerateExportModal` to show preflight visibility in the review step by exposing `preflightPendingCount`, `preflightUnavailableCount`, and a short list of preflight warnings/rationale to users before submitting an export.
- Wire the incident detail page to pass `incident.evidence_inventory` into the export panel so preflight visibility is available even when richer integration metadata is absent.

### Testing
- Ran `npm run lint` in `frontend` and it completed successfully.
- Ran `npm run typecheck` in `frontend` and it completed successfully.
- Ran `npm test` in `frontend` and all unit tests passed (5/5 tests OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1f06ea688321a048e15872d4da34)