### PR TITLE
Add integration diagnostics settings UI and webhook diagnostics page

### DIFF
--- a/frontend/app/admin/ops/webhooks/page.tsx
+++ b/frontend/app/admin/ops/webhooks/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import AdminLayout from "@/components/AdminLayout";
+import { getWebhookDiagnostics, type ProviderWebhookEvent } from "@/lib/api";
+
+export default function WebhookDiagnosticsPage() {
+  const [rows, setRows] = useState<ProviderWebhookEvent[]>([]);
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [providerFilter, setProviderFilter] = useState("all");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    getWebhookDiagnostics({ limit: 200 })
+      .then(setRows)
+      .catch((err) => setError(err instanceof Error ? err.message : "Failed to load webhook diagnostics"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const providers = useMemo(() => Array.from(new Set(rows.map((row) => row.provider))).sort(), [rows]);
+
+  const filtered = useMemo(
+    () =>
+      rows.filter((row) => {
+        if (statusFilter !== "all" && row.status !== statusFilter) return false;
+        if (providerFilter !== "all" && row.provider !== providerFilter) return false;
+        return true;
+      }),
+    [rows, statusFilter, providerFilter]
+  );
+
+  return (
+    <AdminLayout title="Webhook Diagnostics">
+      <div className="space-y-4">
+        <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-50">Internal operator diagnostics</h2>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            <label className="text-xs">Status
+              <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)} className="mt-1 w-full rounded border px-2 py-1 dark:border-gray-600 dark:bg-gray-900">
+                <option value="all">All statuses</option>
+                <option value="accepted">Accepted</option>
+                <option value="processed">Processed</option>
+                <option value="failed">Failed</option>
+                <option value="invalid_signature">Invalid signature</option>
+              </select>
+            </label>
+            <label className="text-xs">Provider
+              <select value={providerFilter} onChange={(e) => setProviderFilter(e.target.value)} className="mt-1 w-full rounded border px-2 py-1 dark:border-gray-600 dark:bg-gray-900">
+                <option value="all">All providers</option>
+                {providers.map((provider) => <option key={provider} value={provider}>{provider}</option>)}
+              </select>
+            </label>
+          </div>
+        </section>
+
+        <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          {loading && <p className="text-xs text-gray-500">Loading webhook events…</p>}
+          {error && <p className="text-xs text-red-600">{error}</p>}
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[920px] text-left text-xs">
+              <thead className="text-gray-500">
+                <tr>
+                  <th className="py-2">Received</th>
+                  <th className="py-2">Provider</th>
+                  <th className="py-2">Domain</th>
+                  <th className="py-2">Status</th>
+                  <th className="py-2">Latency (ms)</th>
+                  <th className="py-2">Normalized code</th>
+                  <th className="py-2">Retries</th>
+                  <th className="py-2">Correlation</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y dark:divide-gray-700">
+                {filtered.map((row) => (
+                  <tr key={row.webhook_event_id}>
+                    <td className="py-2">{new Date(row.received_at_utc).toLocaleString()}</td>
+                    <td className="py-2">{row.provider}</td>
+                    <td className="py-2">{row.domain ?? "—"}</td>
+                    <td className="py-2">{row.status}</td>
+                    <td className="py-2">{row.processing_latency_ms ?? "—"}</td>
+                    <td className="py-2">{row.normalized_error_code ?? "NONE"}</td>
+                    <td className="py-2">{row.retry_count ?? 0}</td>
+                    <td className="py-2 font-mono">{row.correlation_id ?? "—"}</td>
+                  </tr>
+                ))}
+                {!loading && filtered.length === 0 && (
+                  <tr><td colSpan={8} className="py-4 text-gray-500">No webhook events found.</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </AdminLayout>
+  );
+}

--- a/frontend/app/settings/integrations/IntegrationConnectionCard.tsx
+++ b/frontend/app/settings/integrations/IntegrationConnectionCard.tsx
@@ -1,0 +1,42 @@
+import type { IntegrationConnectionHealth } from "@/lib/api";
+
+type Props = {
+  connection: IntegrationConnectionHealth;
+};
+
+const statusTone: Record<IntegrationConnectionHealth["status"], string> = {
+  active: "bg-emerald-100 text-emerald-700",
+  pending: "bg-amber-100 text-amber-700",
+  inactive: "bg-gray-200 text-gray-700",
+  error: "bg-red-100 text-red-700",
+};
+
+export default function IntegrationConnectionCard({ connection }: Props) {
+  return (
+    <article className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-50">{connection.provider}</h3>
+          <p className="text-xs text-gray-500 dark:text-gray-300">{connection.domain ?? "unscoped domain"}</p>
+        </div>
+        <span className={`rounded-full px-2 py-0.5 text-[11px] font-semibold uppercase ${statusTone[connection.status]}`}>
+          {connection.status}
+        </span>
+      </div>
+      <dl className="mt-3 space-y-1 text-xs text-gray-600 dark:text-gray-300">
+        <div className="flex justify-between gap-2">
+          <dt>Connection status</dt>
+          <dd className="font-medium">{connection.healthy ? "Healthy" : "Action needed"}</dd>
+        </div>
+        <div className="flex justify-between gap-2">
+          <dt>Last validation</dt>
+          <dd className="font-medium">{connection.updated_at_utc ? new Date(connection.updated_at_utc).toLocaleString() : "—"}</dd>
+        </div>
+        <div className="flex justify-between gap-2">
+          <dt>Last sync</dt>
+          <dd className="font-medium">{connection.last_synced_at_utc ? new Date(connection.last_synced_at_utc).toLocaleString() : "—"}</dd>
+        </div>
+      </dl>
+    </article>
+  );
+}

--- a/frontend/app/settings/integrations/IntegrationHealthTable.tsx
+++ b/frontend/app/settings/integrations/IntegrationHealthTable.tsx
@@ -1,0 +1,50 @@
+import type { IntegrationHealthSummary } from "./page";
+
+type Props = {
+  rows: IntegrationHealthSummary[];
+};
+
+function asPercent(value: number) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+export default function IntegrationHealthTable({ rows }: Props) {
+  return (
+    <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <h2 className="mb-3 text-sm font-semibold text-gray-900 dark:text-gray-50">Health summary by provider / domain</h2>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[740px] text-left text-xs">
+          <thead className="text-gray-500">
+            <tr>
+              <th className="py-2">Provider</th>
+              <th className="py-2">Domain</th>
+              <th className="py-2">Success rate</th>
+              <th className="py-2">Timeout rate</th>
+              <th className="py-2">Stuck ops</th>
+              <th className="py-2">Retries</th>
+              <th className="py-2">Top normalized codes</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y dark:divide-gray-700">
+            {rows.map((row) => (
+              <tr key={`${row.provider}-${row.domain ?? "none"}`}>
+                <td className="py-2 font-medium">{row.provider}</td>
+                <td className="py-2">{row.domain ?? "—"}</td>
+                <td className="py-2">{asPercent(row.successRate)}</td>
+                <td className="py-2">{asPercent(row.timeoutRate)}</td>
+                <td className="py-2">{row.stuckOps}</td>
+                <td className="py-2">{row.retryCount}</td>
+                <td className="py-2">{row.topNormalizedCodes.join(", ") || "—"}</td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={7} className="py-4 text-gray-500">No operations matched the selected filters.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/settings/integrations/IntegrationOperationDrawer.tsx
+++ b/frontend/app/settings/integrations/IntegrationOperationDrawer.tsx
@@ -1,0 +1,55 @@
+import type { IntegrationOperationDiagnostics } from "@/lib/api";
+
+type Props = {
+  operation: IntegrationOperationDiagnostics | null;
+  onClose: () => void;
+};
+
+export default function IntegrationOperationDrawer({ operation, onClose }: Props) {
+  if (!operation) return null;
+
+  return (
+    <div className="fixed inset-0 z-40 flex justify-end bg-black/30" onClick={onClose}>
+      <aside
+        className="h-full w-full max-w-2xl overflow-y-auto bg-white p-5 shadow-xl dark:bg-gray-900"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-50">Operation diagnostics</h2>
+          <button onClick={onClose} className="rounded border px-2 py-1 text-xs">Close</button>
+        </div>
+
+        <dl className="grid grid-cols-2 gap-3 text-xs">
+          <div><dt className="text-gray-500">Operation ID</dt><dd className="font-mono">{operation.operation_id}</dd></div>
+          <div><dt className="text-gray-500">Status</dt><dd>{operation.status}</dd></div>
+          <div><dt className="text-gray-500">Provider</dt><dd>{operation.provider}</dd></div>
+          <div><dt className="text-gray-500">Domain</dt><dd>{operation.domain ?? "—"}</dd></div>
+          <div><dt className="text-gray-500">Org</dt><dd className="font-mono">{operation.org_id ?? "—"}</dd></div>
+          <div><dt className="text-gray-500">Correlation ID</dt><dd className="font-mono">{operation.correlation_id ?? "—"}</dd></div>
+          <div><dt className="text-gray-500">Error code</dt><dd>{operation.error_code ?? "—"}</dd></div>
+          <div><dt className="text-gray-500">Retryable</dt><dd>{operation.error_retryable == null ? "—" : operation.error_retryable ? "Yes" : "No"}</dd></div>
+        </dl>
+
+        <div className="mt-4 space-y-4 text-xs">
+          <section>
+            <h3 className="font-semibold">Error details</h3>
+            <p className="mt-1 rounded border bg-gray-50 p-2 dark:border-gray-700 dark:bg-gray-800">{operation.error_message ?? "No error message"}</p>
+            {operation.error_operator_message && (
+              <p className="mt-2 rounded border border-amber-300 bg-amber-50 p-2 text-amber-800 dark:bg-amber-950/40 dark:text-amber-100">{operation.error_operator_message}</p>
+            )}
+          </section>
+
+          <section>
+            <h3 className="font-semibold">Request payload</h3>
+            <pre className="mt-1 overflow-x-auto rounded border bg-gray-50 p-2 dark:border-gray-700 dark:bg-gray-800">{JSON.stringify(operation.payload_json, null, 2)}</pre>
+          </section>
+
+          <section>
+            <h3 className="font-semibold">Provider result</h3>
+            <pre className="mt-1 overflow-x-auto rounded border bg-gray-50 p-2 dark:border-gray-700 dark:bg-gray-800">{JSON.stringify(operation.result_json, null, 2)}</pre>
+          </section>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/frontend/app/settings/integrations/IntegrationOperationTable.tsx
+++ b/frontend/app/settings/integrations/IntegrationOperationTable.tsx
@@ -1,0 +1,68 @@
+import type { IntegrationOperationDiagnostics } from "@/lib/api";
+
+type Props = {
+  rows: IntegrationOperationDiagnostics[];
+  onSelect: (row: IntegrationOperationDiagnostics) => void;
+};
+
+export default function IntegrationOperationTable({ rows, onSelect }: Props) {
+  return (
+    <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <h2 className="mb-3 text-sm font-semibold text-gray-900 dark:text-gray-50">Integration operations</h2>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[920px] text-left text-xs">
+          <thead className="text-gray-500">
+            <tr>
+              <th className="py-2">Time</th>
+              <th className="py-2">Org</th>
+              <th className="py-2">Provider</th>
+              <th className="py-2">Domain</th>
+              <th className="py-2">Operation</th>
+              <th className="py-2">Status</th>
+              <th className="py-2">Retry count</th>
+              <th className="py-2">Normalized error</th>
+              <th className="py-2" />
+            </tr>
+          </thead>
+          <tbody className="divide-y dark:divide-gray-700">
+            {rows.map((row) => {
+              const retryFromResult = row.result_json["retry_count"];
+              const retryFromPayload = row.payload_json["retry_count"];
+              const retryCount = Number(
+                (typeof retryFromResult === "number" ? retryFromResult : undefined) ??
+                (typeof retryFromPayload === "number" ? retryFromPayload : undefined) ??
+                0
+              );
+              const normalizedCode = row.error_category ?? row.error_code ?? "NONE";
+              return (
+                <tr key={row.operation_id}>
+                  <td className="py-2">{row.requested_at_utc ? new Date(row.requested_at_utc).toLocaleString() : "—"}</td>
+                  <td className="py-2 font-mono">{row.org_id ?? "—"}</td>
+                  <td className="py-2">{row.provider}</td>
+                  <td className="py-2">{row.domain ?? "—"}</td>
+                  <td className="py-2">{row.operation_type}</td>
+                  <td className="py-2">{row.status}</td>
+                  <td className="py-2">{Number.isNaN(retryCount) ? 0 : retryCount}</td>
+                  <td className="py-2">{normalizedCode}</td>
+                  <td className="py-2 text-right">
+                    <button
+                      onClick={() => onSelect(row)}
+                      className="rounded border px-2 py-1 hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-gray-700"
+                    >
+                      Inspect
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={9} className="py-4 text-gray-500">No operations found for these filters.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/settings/integrations/page.tsx
+++ b/frontend/app/settings/integrations/page.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import MainLayout from "@/components/MainLayout";
+import {
+  getIntegrationConnections,
+  getIntegrationOperations,
+  type IntegrationConnectionHealth,
+  type IntegrationOperationDiagnostics,
+} from "@/lib/api";
+import IntegrationConnectionCard from "./IntegrationConnectionCard";
+import IntegrationHealthTable from "./IntegrationHealthTable";
+import IntegrationOperationTable from "./IntegrationOperationTable";
+import IntegrationOperationDrawer from "./IntegrationOperationDrawer";
+
+export type IntegrationHealthSummary = {
+  provider: string;
+  domain: string | null;
+  successRate: number;
+  timeoutRate: number;
+  stuckOps: number;
+  retryCount: number;
+  topNormalizedCodes: string[];
+};
+
+const TIME_RANGE_HOURS: Record<string, number> = {
+  "24h": 24,
+  "72h": 72,
+  "7d": 168,
+  "30d": 720,
+};
+
+function normalizeErrorCode(operation: IntegrationOperationDiagnostics) {
+  if (operation.error_category) return operation.error_category.toUpperCase();
+  if (operation.error_code) return operation.error_code.toUpperCase();
+  if ((operation.error_message ?? "").toLowerCase().includes("timeout")) return "TIMEOUT";
+  return "NONE";
+}
+
+function isStuck(operation: IntegrationOperationDiagnostics, now: number) {
+  if (!["queued", "running", "processing_at_provider"].includes(operation.status)) return false;
+  const requested = operation.requested_at_utc ? new Date(operation.requested_at_utc).getTime() : 0;
+  return requested > 0 && now - requested > 30 * 60 * 1000;
+}
+
+export default function IntegrationSettingsPage() {
+  const [connections, setConnections] = useState<IntegrationConnectionHealth[]>([]);
+  const [operations, setOperations] = useState<IntegrationOperationDiagnostics[]>([]);
+  const [selected, setSelected] = useState<IntegrationOperationDiagnostics | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const [orgFilter, setOrgFilter] = useState("all");
+  const [providerFilter, setProviderFilter] = useState("all");
+  const [domainFilter, setDomainFilter] = useState("all");
+  const [timeRange, setTimeRange] = useState<keyof typeof TIME_RANGE_HOURS>("7d");
+
+  useEffect(() => {
+    Promise.all([getIntegrationConnections(), getIntegrationOperations({ limit: 500 })])
+      .then(([connectionRows, operationRows]) => {
+        setConnections(connectionRows);
+        setOperations(operationRows);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : "Failed to load integration diagnostics");
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const orgOptions = useMemo(
+    () => Array.from(new Set(operations.map((op) => op.org_id).filter(Boolean) as string[])).sort(),
+    [operations]
+  );
+  const providerOptions = useMemo(
+    () => Array.from(new Set(operations.map((op) => op.provider))).sort(),
+    [operations]
+  );
+  const domainOptions = useMemo(
+    () => Array.from(new Set(operations.map((op) => op.domain).filter(Boolean) as string[])).sort(),
+    [operations]
+  );
+
+  const filteredOperations = useMemo(() => {
+    const referenceTime = operations.reduce((latest, op) => {
+      const requested = op.requested_at_utc ? new Date(op.requested_at_utc).getTime() : 0;
+      return requested > latest ? requested : latest;
+    }, 0);
+    const since = referenceTime - TIME_RANGE_HOURS[timeRange] * 60 * 60 * 1000;
+    return operations.filter((op) => {
+      const requested = op.requested_at_utc ? new Date(op.requested_at_utc).getTime() : 0;
+      if (requested && requested < since) return false;
+      if (orgFilter !== "all" && op.org_id !== orgFilter) return false;
+      if (providerFilter !== "all" && op.provider !== providerFilter) return false;
+      if (domainFilter !== "all" && (op.domain ?? "") !== domainFilter) return false;
+      return true;
+    });
+  }, [operations, orgFilter, providerFilter, domainFilter, timeRange]);
+
+  const healthRows = useMemo<IntegrationHealthSummary[]>(() => {
+    const referenceNow = filteredOperations.reduce((latest, item) => {
+      const requested = item.requested_at_utc ? new Date(item.requested_at_utc).getTime() : 0;
+      return requested > latest ? requested : latest;
+    }, 0);
+    const grouped = new Map<string, IntegrationOperationDiagnostics[]>();
+    for (const operation of filteredOperations) {
+      const key = `${operation.provider}__${operation.domain ?? ""}`;
+      grouped.set(key, [...(grouped.get(key) ?? []), operation]);
+    }
+
+    return Array.from(grouped.entries()).map(([key, rows]) => {
+      const [provider, domainRaw] = key.split("__");
+      const total = rows.length || 1;
+      const success = rows.filter((row) => ["succeeded", "available", "downloaded"].includes(row.status)).length;
+      const timeout = rows.filter((row) => normalizeErrorCode(row) === "TIMEOUT").length;
+      const stuckOps = rows.filter((row) => isStuck(row, referenceNow)).length;
+      const retryCount = rows.reduce((sum, row) => {
+        const retryFromResult = row.result_json["retry_count"];
+        const retryFromPayload = row.payload_json["retry_count"];
+        const next = Number(
+          (typeof retryFromResult === "number" ? retryFromResult : undefined) ??
+          (typeof retryFromPayload === "number" ? retryFromPayload : undefined) ??
+          0
+        );
+        return sum + (Number.isNaN(next) ? 0 : next);
+      }, 0);
+
+      const errorCounts = new Map<string, number>();
+      rows.forEach((row) => {
+        const code = normalizeErrorCode(row);
+        if (code === "NONE") return;
+        errorCounts.set(code, (errorCounts.get(code) ?? 0) + 1);
+      });
+
+      const topNormalizedCodes = Array.from(errorCounts.entries())
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 3)
+        .map(([code, count]) => `${code} (${count})`);
+
+      return {
+        provider,
+        domain: domainRaw || null,
+        successRate: success / total,
+        timeoutRate: timeout / total,
+        stuckOps,
+        retryCount,
+        topNormalizedCodes,
+      };
+    });
+  }, [filteredOperations]);
+
+  const visibleConnections = useMemo(
+    () =>
+      connections.filter((connection) => {
+        if (providerFilter !== "all" && connection.provider !== providerFilter) return false;
+        if (domainFilter !== "all" && (connection.domain ?? "") !== domainFilter) return false;
+        return true;
+      }),
+    [connections, providerFilter, domainFilter]
+  );
+
+  return (
+    <MainLayout title="Integration Settings & Diagnostics">
+      <div className="space-y-5">
+        <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-50">Filters</h2>
+          <div className="mt-3 grid gap-3 md:grid-cols-4">
+            <label className="text-xs">Org
+              <select value={orgFilter} onChange={(e) => setOrgFilter(e.target.value)} className="mt-1 w-full rounded border px-2 py-1 dark:border-gray-600 dark:bg-gray-900">
+                <option value="all">All orgs</option>
+                {orgOptions.map((org) => <option key={org} value={org}>{org}</option>)}
+              </select>
+            </label>
+            <label className="text-xs">Provider
+              <select value={providerFilter} onChange={(e) => setProviderFilter(e.target.value)} className="mt-1 w-full rounded border px-2 py-1 dark:border-gray-600 dark:bg-gray-900">
+                <option value="all">All providers</option>
+                {providerOptions.map((provider) => <option key={provider} value={provider}>{provider}</option>)}
+              </select>
+            </label>
+            <label className="text-xs">Domain
+              <select value={domainFilter} onChange={(e) => setDomainFilter(e.target.value)} className="mt-1 w-full rounded border px-2 py-1 dark:border-gray-600 dark:bg-gray-900">
+                <option value="all">All domains</option>
+                {domainOptions.map((domain) => <option key={domain} value={domain}>{domain}</option>)}
+              </select>
+            </label>
+            <label className="text-xs">Time range
+              <select value={timeRange} onChange={(e) => setTimeRange(e.target.value as keyof typeof TIME_RANGE_HOURS)} className="mt-1 w-full rounded border px-2 py-1 dark:border-gray-600 dark:bg-gray-900">
+                {Object.keys(TIME_RANGE_HOURS).map((range) => <option key={range} value={range}>{range}</option>)}
+              </select>
+            </label>
+          </div>
+          {loading && <p className="mt-3 text-xs text-gray-500">Loading integration diagnostics…</p>}
+          {error && <p className="mt-3 text-xs text-red-600">{error}</p>}
+        </section>
+
+        <section className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+          {visibleConnections.map((connection) => (
+            <IntegrationConnectionCard key={connection.integration_id} connection={connection} />
+          ))}
+          {!loading && visibleConnections.length === 0 && (
+            <div className="rounded-lg border border-dashed p-4 text-xs text-gray-500">No integration connections matched these filters.</div>
+          )}
+        </section>
+
+        <IntegrationHealthTable rows={healthRows} />
+        <IntegrationOperationTable rows={filteredOperations} onSelect={setSelected} />
+      </div>
+      <IntegrationOperationDrawer operation={selected} onClose={() => setSelected(null)} />
+    </MainLayout>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -612,3 +612,85 @@ export function searchOpsAudit(params?: {
   const suffix = query.toString() ? `?${query.toString()}` : "";
   return request<AuditSearchResponseItem[]>(`/admin/ops/audit-search${suffix}`);
 }
+
+export interface IntegrationConnectionHealth {
+  integration_id: string;
+  provider: string;
+  domain: string | null;
+  status: "pending" | "active" | "inactive" | "error";
+  healthy: boolean;
+  reason: string | null;
+  last_synced_at_utc: string | null;
+  updated_at_utc: string | null;
+}
+
+export interface IntegrationOperationDiagnostics {
+  operation_id: string;
+  org_id: string | null;
+  incident_id: string | null;
+  connection_id: string | null;
+  provider: string;
+  domain: string | null;
+  operation_type: string;
+  status: string;
+  correlation_id: string | null;
+  external_reference: string | null;
+  external_reference_id: string | null;
+  payload_json: Record<string, unknown>;
+  result_json: Record<string, unknown>;
+  error_message: string | null;
+  error_code: string | null;
+  error_category: string | null;
+  error_provider_key: string | null;
+  error_retryable: boolean | null;
+  error_user_facing_message: string | null;
+  error_operator_message: string | null;
+  requested_at_utc: string | null;
+  started_at_utc: string | null;
+  completed_at_utc: string | null;
+  updated_at_utc: string | null;
+}
+
+export interface ProviderWebhookEvent {
+  webhook_event_id: string;
+  provider: string;
+  domain: string | null;
+  status: string;
+  received_at_utc: string;
+  correlation_id: string | null;
+  processing_latency_ms: number | null;
+  retry_count: number | null;
+  normalized_error_code: string | null;
+}
+
+export function getIntegrationConnections() {
+  return request<IntegrationConnectionHealth[]>("/org/integrations");
+}
+
+export function getIntegrationOperations(params?: {
+  provider?: string;
+  status?: string;
+  incident_id?: string;
+  limit?: number;
+}) {
+  const query = new URLSearchParams();
+  if (params?.provider) query.set("provider", params.provider);
+  if (params?.status) query.set("status", params.status);
+  if (params?.incident_id) query.set("incident_id", params.incident_id);
+  if (params?.limit) query.set("limit", String(params.limit));
+  const suffix = query.toString() ? `?${query.toString()}` : "";
+  return request<IntegrationOperationDiagnostics[]>(`/integration-operations${suffix}`);
+}
+
+export function getWebhookDiagnostics(params?: {
+  provider?: string;
+  status?: string;
+  limit?: number;
+}) {
+  const query = new URLSearchParams();
+  if (params?.provider) query.set("provider", params.provider);
+  if (params?.status) query.set("status", params.status);
+  if (params?.limit) query.set("limit", String(params.limit));
+  const suffix = query.toString() ? `?${query.toString()}` : "";
+  return request<ProviderWebhookEvent[]>(`/admin/ops/webhook-events${suffix}`);
+}


### PR DESCRIPTION
### Motivation

- Provide operators and admins with a diagnostics surface for integration connections and operations so they can filter by org/provider/domain/time range and inspect health and failures.
- Surface webhook event diagnostics for internal operators to troubleshoot inbound provider webhooks and replay/inspect problematic events.

### Description

- Added an integrations settings page and supporting components at `frontend/app/settings/integrations/` including `page.tsx`, `IntegrationConnectionCard.tsx`, `IntegrationHealthTable.tsx`, `IntegrationOperationTable.tsx`, and `IntegrationOperationDrawer.tsx` which show connection status, last validation/sync, success/timeout rates, stuck ops, retry counts, and normalized error codes.
- Implemented an internal operator webhook diagnostics page at `frontend/app/admin/ops/webhooks/page.tsx` that lists `ProviderWebhookEvent` rows and supports status/provider filters with latency, retries, normalized code, and correlation id columns.
- Extended `frontend/lib/api.ts` with typed interfaces and helper functions: `IntegrationConnectionHealth`, `IntegrationOperationDiagnostics`, `ProviderWebhookEvent`, `getIntegrationConnections()`, `getIntegrationOperations()`, and `getWebhookDiagnostics()` used by the new UI.
- Hardened client logic for computing KPIs (time window handling, normalized error code selection, numeric retry extraction) and added an inspection drawer for operation payload/result/error review.

### Testing

- Ran the frontend linter with `npm run lint` and it completed successfully.
- Ran TypeScript checks with `npm run typecheck` and they passed.
- Ran frontend unit tests with `npm test` and all tests passed (5/5).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da21deedf08321a3ff7edc8617c86e)