### PR TITLE
Add integration reliability metrics, emissions, dashboards, and alerts

### DIFF
--- a/backend/app/api/routes/routes_webhooks.py
+++ b/backend/app/api/routes/routes_webhooks.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, Request, Response
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
-from app.core.metrics import MetricNames, increment, timed
+from app.core.metrics import MetricNames, timed
 from app.db.session import get_db
 from app.integrations.webhooks.handlers import (
     persist_twilio_voice_callback,
@@ -31,7 +31,6 @@ VOICE_MESSAGE = (
 
 @router.post("/voice")
 async def twilio_voice_webhook(request: Request, db: Session = Depends(get_db)):
-    increment(MetricNames.TWILIO_WEBHOOK_ATTEMPTS)
     with timed(MetricNames.TWILIO_WEBHOOK_ATTEMPTS):
         raw_body = await request.body()
         params = parse_form_encoded_body(raw_body)
@@ -49,7 +48,6 @@ async def twilio_voice_webhook(request: Request, db: Session = Depends(get_db)):
             signature_error=signature_error,
         )
         if result.status_code != 200:
-            increment(MetricNames.TWILIO_WEBHOOK_FAILURES)
             logger.warning("Twilio webhook signature validation failed")
             return Response(status_code=result.status_code, content=result.body["detail"])
 

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -1,5 +1,36 @@
-"""Backward-compatible metrics imports."""
+"""Backward-compatible metrics imports and integration metric definitions."""
 
-from app.observability.metrics import MetricNames, increment, timed
+from app.observability.metrics import MetricNames as _BaseMetricNames
+from app.observability.metrics import increment, timed
+
+
+class MetricNames(_BaseMetricNames):
+    """Canonical metric names for integration reliability instrumentation."""
+
+    INTEGRATION_PROVIDER_REQUESTS = "integration.provider.requests"
+    INTEGRATION_PROVIDER_SUCCESS = "integration.provider.success"
+    INTEGRATION_PROVIDER_FAILURE = "integration.provider.failure"
+    INTEGRATION_PROVIDER_TIMEOUT = "integration.provider.timeout"
+    INTEGRATION_PROVIDER_RATE_LIMIT = "integration.provider.rate_limit"
+    INTEGRATION_PROVIDER_AUTH_FAILURE = "integration.provider.auth_failure"
+    INTEGRATION_PROVIDER_LATENCY = "integration.provider.latency"
+
+    EVIDENCE_COMPLETION_TIME = "integration.evidence.completion_time"
+    EVIDENCE_PARTIAL_RESULT = "integration.evidence.partial"
+    EVIDENCE_UNAVAILABLE_RESULT = "integration.evidence.unavailable"
+
+    OTP_DELIVERY_ATTEMPTS = "otp.delivery.attempts"
+    OTP_DELIVERY_SUCCESS = "otp.delivery.success"
+    OTP_DELIVERY_FAILURE = "otp.delivery.failure"
+    OTP_DELIVERY_TIMEOUT = "otp.delivery.timeout"
+    OTP_DELIVERY_RATE_LIMIT = "otp.delivery.rate_limit"
+    OTP_DELIVERY_AUTH_FAILURE = "otp.delivery.auth_failure"
+
+    WEBHOOK_SIGNATURE_FAILURES = "webhook.signature.failures"
+    RETRY_SCHEDULER_QUEUED = "retry.scheduler.queued"
+    RETRY_SCHEDULER_RETRYING = "retry.scheduler.retrying"
+    RETRY_SCHEDULER_TERMINAL_FAILURES = "retry.scheduler.terminal_failures"
+    RETRY_SCHEDULER_STUCK_IN_PROGRESS = "retry.scheduler.stuck_in_progress"
+
 
 __all__ = ["MetricNames", "increment", "timed"]

--- a/backend/app/integrations/providers/samsara.py
+++ b/backend/app/integrations/providers/samsara.py
@@ -9,6 +9,7 @@ from typing import Any
 import httpx
 
 from app.core.config import settings
+from app.core.metrics import MetricNames, increment, timed
 
 
 class SamsaraProvider:
@@ -22,14 +23,35 @@ class SamsaraProvider:
         self._clip_requests: dict[str, dict[str, str | None]] = {}
 
     def _get_json_data(self, path: str, params: Mapping[str, str]) -> list[dict[str, Any]]:
-        with httpx.Client() as client:
-            resp = client.get(
-                f"{self.BASE_URL}/{path}",
-                headers=self.headers,
-                params=params,
-            )
-            resp.raise_for_status()
-            return resp.json().get("data", [])
+        increment(MetricNames.INTEGRATION_PROVIDER_REQUESTS)
+        with timed(MetricNames.INTEGRATION_PROVIDER_LATENCY):
+            try:
+                with httpx.Client() as client:
+                    resp = client.get(
+                        f"{self.BASE_URL}/{path}",
+                        headers=self.headers,
+                        params=params,
+                    )
+                    resp.raise_for_status()
+                    data = resp.json().get("data", [])
+            except httpx.TimeoutException:
+                increment(MetricNames.INTEGRATION_PROVIDER_TIMEOUT)
+                increment(MetricNames.INTEGRATION_PROVIDER_FAILURE)
+                raise
+            except httpx.HTTPStatusError as exc:
+                status_code = exc.response.status_code
+                if status_code in {401, 403}:
+                    increment(MetricNames.INTEGRATION_PROVIDER_AUTH_FAILURE)
+                elif status_code == 429:
+                    increment(MetricNames.INTEGRATION_PROVIDER_RATE_LIMIT)
+                increment(MetricNames.INTEGRATION_PROVIDER_FAILURE)
+                raise
+            except httpx.HTTPError:
+                increment(MetricNames.INTEGRATION_PROVIDER_FAILURE)
+                raise
+
+        increment(MetricNames.INTEGRATION_PROVIDER_SUCCESS)
+        return data
 
     def _window_params(self, start: str | None = None, end: str | None = None) -> dict[str, str]:
         params: dict[str, str] = {}

--- a/backend/app/integrations/providers/twilio.py
+++ b/backend/app/integrations/providers/twilio.py
@@ -33,18 +33,36 @@ class TwilioMessagingProvider:
         return f"{TWILIO_API_BASE}/{account_sid}/{path}"
 
     def _post_twilio(self, path: str, data: dict[str, str]) -> dict[str, Any]:
-        with timed("twilio.http.post"):
+        increment(MetricNames.INTEGRATION_PROVIDER_REQUESTS)
+        with timed(MetricNames.INTEGRATION_PROVIDER_LATENCY):
             url = self._twilio_url(path)
             account_sid, auth_token = self._twilio_auth()
-            with httpx.Client() as client:
-                response = client.post(
-                    url,
-                    data=data,
-                    auth=(account_sid, auth_token),
-                    timeout=10.0,
-                )
-            response.raise_for_status()
-            payload = response.json()
+            try:
+                with httpx.Client() as client:
+                    response = client.post(
+                        url,
+                        data=data,
+                        auth=(account_sid, auth_token),
+                        timeout=10.0,
+                    )
+                response.raise_for_status()
+                payload = response.json()
+            except httpx.TimeoutException:
+                increment(MetricNames.INTEGRATION_PROVIDER_TIMEOUT)
+                increment(MetricNames.INTEGRATION_PROVIDER_FAILURE)
+                raise
+            except httpx.HTTPStatusError as exc:
+                status_code = exc.response.status_code
+                if status_code in {401, 403}:
+                    increment(MetricNames.INTEGRATION_PROVIDER_AUTH_FAILURE)
+                elif status_code == 429:
+                    increment(MetricNames.INTEGRATION_PROVIDER_RATE_LIMIT)
+                increment(MetricNames.INTEGRATION_PROVIDER_FAILURE)
+                raise
+            except httpx.HTTPError:
+                increment(MetricNames.INTEGRATION_PROVIDER_FAILURE)
+                raise
+        increment(MetricNames.INTEGRATION_PROVIDER_SUCCESS)
 
         if not isinstance(payload, dict):
             raise ValueError(
@@ -128,17 +146,37 @@ class TwilioMessagingProvider:
         return f"https://verify.twilio.com/v2/Services/{service_sid}/{resource}"
 
     def start_verification(self, phone_e164: str) -> str:
-        response = httpx.post(
-            self._verify_url("Verifications"),
-            auth=self._twilio_auth(),
-            data={"To": phone_e164, "Channel": "sms"},
-            timeout=10.0,
-        )
-        response.raise_for_status()
+        increment(MetricNames.OTP_DELIVERY_ATTEMPTS)
+        try:
+            response = httpx.post(
+                self._verify_url("Verifications"),
+                auth=self._twilio_auth(),
+                data={"To": phone_e164, "Channel": "sms"},
+                timeout=10.0,
+            )
+            response.raise_for_status()
+        except httpx.TimeoutException:
+            increment(MetricNames.OTP_DELIVERY_TIMEOUT)
+            increment(MetricNames.OTP_DELIVERY_FAILURE)
+            raise
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            if status_code in {401, 403}:
+                increment(MetricNames.OTP_DELIVERY_AUTH_FAILURE)
+            elif status_code == 429:
+                increment(MetricNames.OTP_DELIVERY_RATE_LIMIT)
+            increment(MetricNames.OTP_DELIVERY_FAILURE)
+            raise
+        except httpx.HTTPError:
+            increment(MetricNames.OTP_DELIVERY_FAILURE)
+            raise
+
         payload = response.json()
         sid = payload.get("sid")
         if not isinstance(sid, str) or not sid:
+            increment(MetricNames.OTP_DELIVERY_FAILURE)
             raise RuntimeError(f"Twilio Verify response missing sid: {payload!r}")
+        increment(MetricNames.OTP_DELIVERY_SUCCESS)
         logger.info("Twilio verification started sid=%s", sid)
         return sid
 

--- a/backend/app/integrations/webhooks/handlers.py
+++ b/backend/app/integrations/webhooks/handlers.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from sqlalchemy.orm import Session
 
+from app.core.metrics import MetricNames, increment
 from app.db.repo.message_operations import (
     get_message_operation_by_provider_message_id,
     update_message_operation_status,
@@ -44,6 +45,7 @@ def process_twilio_status_callback(
     signature_valid: bool,
     signature_error: str | None,
 ) -> WebhookResult:
+    increment(MetricNames.TWILIO_WEBHOOK_ATTEMPTS)
     message_sid = payload.get("MessageSid")
     idempotency_key = build_idempotency_key(
         provider="twilio",
@@ -75,6 +77,7 @@ def process_twilio_status_callback(
             error_message="duplicate_webhook",
             error_details_json={"duplicate_of": str(existing.webhook_event_id)},
         )
+        increment("webhook.twilio.duplicate")
         return WebhookResult(status_code=200, body={"status": "duplicate"})
 
     event = create_provider_webhook_event(
@@ -92,6 +95,8 @@ def process_twilio_status_callback(
     )
 
     if not signature_valid:
+        increment(MetricNames.WEBHOOK_SIGNATURE_FAILURES)
+        increment(MetricNames.TWILIO_WEBHOOK_FAILURES)
         update_provider_webhook_event(
             db,
             event,
@@ -112,6 +117,7 @@ def process_twilio_status_callback(
         )
 
     if operation is None:
+        increment("webhook.twilio.orphaned")
         update_provider_webhook_event(
             db,
             event,
@@ -131,6 +137,7 @@ def process_twilio_status_callback(
     }
     mapped = status_map.get(message_status)
     if mapped is None:
+        increment("webhook.twilio.unsupported_status")
         update_provider_webhook_event(
             db,
             event,
@@ -148,6 +155,10 @@ def process_twilio_status_callback(
         normalized_error_code=f"TWILIO_{error_code}" if error_code else None,
         details_json=payload,
     )
+    if mapped in {"failed", "undelivered"}:
+        increment(MetricNames.OTP_DELIVERY_FAILURE)
+    if mapped == "delivered":
+        increment(MetricNames.OTP_DELIVERY_SUCCESS)
     update_provider_webhook_event(
         db,
         event,
@@ -166,6 +177,7 @@ def persist_twilio_voice_callback(
     signature_valid: bool,
     signature_error: str | None,
 ) -> WebhookResult:
+    increment(MetricNames.TWILIO_WEBHOOK_ATTEMPTS)
     idempotency_key = build_idempotency_key(
         provider="twilio",
         event_type="voice_callback",
@@ -192,4 +204,6 @@ def persist_twilio_voice_callback(
     )
     if signature_valid:
         return WebhookResult(status_code=200, body={"status": "ok"})
+    increment(MetricNames.WEBHOOK_SIGNATURE_FAILURES)
+    increment(MetricNames.TWILIO_WEBHOOK_FAILURES)
     return WebhookResult(status_code=403, body={"detail": "Invalid Twilio signature"})

--- a/backend/app/jobs/tracking.py
+++ b/backend/app/jobs/tracking.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from app.core.metrics import MetricNames, increment
 from app.db.repo.job_execution_meta import upsert_job_execution_meta
 from app.jobs.retry_policy import (
     classify_retry_exception,
@@ -24,6 +25,7 @@ def record_task_queued(
     args: list[Any] | None,
     kwargs: dict[str, Any] | None,
 ) -> None:
+    increment(MetricNames.RETRY_SCHEDULER_QUEUED)
     upsert_job_execution_meta(
         task_id=task_id,
         task_name=task_name,
@@ -36,6 +38,7 @@ def record_task_queued(
 
 
 def record_task_started(*, task_name: str, task_id: str, max_retries: int) -> None:
+    increment(MetricNames.RETRY_SCHEDULER_STUCK_IN_PROGRESS)
     upsert_job_execution_meta(
         task_id=task_id,
         task_name=task_name,
@@ -59,6 +62,10 @@ def record_task_retrying(
     category = classify_retry_exception(exception)
     will_retry = should_retry(task_type, category, retry_count)
     status = "retrying" if will_retry else "failed"
+    if will_retry:
+        increment(MetricNames.RETRY_SCHEDULER_RETRYING)
+    else:
+        increment(MetricNames.RETRY_SCHEDULER_TERMINAL_FAILURES)
     next_retry = utc_now() + timedelta(seconds=30) if will_retry else None
     upsert_job_execution_meta(
         task_id=task_id,
@@ -84,6 +91,7 @@ def record_task_failed(
     max_retries: int,
     exception: BaseException,
 ) -> None:
+    increment(MetricNames.RETRY_SCHEDULER_TERMINAL_FAILURES)
     task_type = resolve_task_type(task_name)
     category = classify_retry_exception(exception)
     upsert_job_execution_meta(

--- a/backend/app/services/incident_evidence_orchestrator.py
+++ b/backend/app/services/incident_evidence_orchestrator.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from sqlalchemy.orm import Session
 
+from app.core.metrics import MetricNames, increment, timed
 from app.db.repo.evidence_requests import create_evidence_request
 from app.domain.system_event_types import SystemEventType
 from app.services.dashcam_capture_service import queue_dashcam_capture
@@ -40,42 +41,46 @@ class IncidentEvidenceOrchestrator:
         window_end: str | None,
         correlation_id: str,
     ) -> IncidentEvidenceOrchestrationResult:
-        dashcam_request_ids = [
-            create_evidence_request(
-                self.db,
-                org_id=org_id,
-                incident_id=incident_id,
-                provider="samsara",
-                domain="dashcam",
-                external_reference=stream,
-                status="open",
-                correlation_id=f"{correlation_id}:dashcam",
-                request_payload_json={
-                    "stream": stream,
-                    "window_start": window_start,
-                    "window_end": window_end,
-                },
-            ).evidence_request_id
-            for stream in ("road_facing", "driver_facing")
-        ]
-        telematics_request_ids = [
-            create_evidence_request(
-                self.db,
-                org_id=org_id,
-                incident_id=incident_id,
-                provider="samsara",
-                domain="telematics",
-                external_reference=dataset,
-                status="open",
-                correlation_id=f"{correlation_id}:telematics",
-                request_payload_json={
-                    "dataset": dataset,
-                    "window_start": window_start,
-                    "window_end": window_end,
-                },
-            ).evidence_request_id
-            for dataset in ("eld", "gps", "safety_events", "vehicle_state")
-        ]
+        with timed(MetricNames.INTEGRATION_PROVIDER_LATENCY):
+            dashcam_request_ids = [
+                create_evidence_request(
+                    self.db,
+                    org_id=org_id,
+                    incident_id=incident_id,
+                    provider="samsara",
+                    domain="dashcam",
+                    external_reference=stream,
+                    status="open",
+                    correlation_id=f"{correlation_id}:dashcam",
+                    request_payload_json={
+                        "stream": stream,
+                        "window_start": window_start,
+                        "window_end": window_end,
+                    },
+                ).evidence_request_id
+                for stream in ("road_facing", "driver_facing")
+            ]
+            telematics_request_ids = [
+                create_evidence_request(
+                    self.db,
+                    org_id=org_id,
+                    incident_id=incident_id,
+                    provider="samsara",
+                    domain="telematics",
+                    external_reference=dataset,
+                    status="open",
+                    correlation_id=f"{correlation_id}:telematics",
+                    request_payload_json={
+                        "dataset": dataset,
+                        "window_start": window_start,
+                        "window_end": window_end,
+                    },
+                ).evidence_request_id
+                for dataset in ("eld", "gps", "safety_events", "vehicle_state")
+            ]
+
+        increment(MetricNames.INTEGRATION_PROVIDER_REQUESTS, len(dashcam_request_ids))
+        increment(MetricNames.INTEGRATION_PROVIDER_REQUESTS, len(telematics_request_ids))
 
         emit_timeline_event(
             self.db,

--- a/backend/app/services/integration_health_service.py
+++ b/backend/app/services/integration_health_service.py
@@ -11,6 +11,13 @@ from app.db.models import EvidenceRequest, IntegrationOperation
 from app.db.repo.integration_operation_status_history import create_operation_status_history
 
 
+def _safe_duration_ms(start: datetime, end: datetime) -> int:
+    """Return non-negative elapsed milliseconds handling naive/aware mismatches."""
+    start_dt = start if start.tzinfo is not None else start.replace(tzinfo=timezone.utc)
+    end_dt = end if end.tzinfo is not None else end.replace(tzinfo=timezone.utc)
+    return max(int((end_dt - start_dt).total_seconds() * 1000), 0)
+
+
 def transition_operation_status(
     db: Session,
     *,
@@ -49,10 +56,10 @@ def transition_operation_status(
         and operation.completed_at_utc is not None
         and to_status in {"succeeded", "downloaded", "failed", "unavailable"}
     ):
-        completion_time_ms = int(
-            (operation.completed_at_utc - operation.started_at_utc).total_seconds() * 1000
+        completion_time_ms = _safe_duration_ms(
+            operation.started_at_utc, operation.completed_at_utc
         )
-        increment(MetricNames.EVIDENCE_COMPLETION_TIME, max(completion_time_ms, 0))
+        increment(MetricNames.EVIDENCE_COMPLETION_TIME, completion_time_ms)
 
     create_operation_status_history(
         db,
@@ -85,11 +92,11 @@ def set_evidence_request_status(
     if status == "fulfilled":
         evidence_request.fulfilled_at_utc = datetime.now(timezone.utc)
         if evidence_request.created_at_utc is not None:
-            completion_time_ms = int(
-                (evidence_request.fulfilled_at_utc - evidence_request.created_at_utc).total_seconds()
-                * 1000
+            completion_time_ms = _safe_duration_ms(
+                evidence_request.created_at_utc,
+                evidence_request.fulfilled_at_utc,
             )
-            increment(MetricNames.EVIDENCE_COMPLETION_TIME, max(completion_time_ms, 0))
+            increment(MetricNames.EVIDENCE_COMPLETION_TIME, completion_time_ms)
     db.add(evidence_request)
     db.commit()
     db.refresh(evidence_request)

--- a/backend/app/services/integration_health_service.py
+++ b/backend/app/services/integration_health_service.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 
+from app.core.metrics import MetricNames, increment
 from app.db.models import EvidenceRequest, IntegrationOperation
 from app.db.repo.integration_operation_status_history import create_operation_status_history
 
@@ -33,11 +34,25 @@ def transition_operation_status(
     operation.status = to_status
     if to_status == "running" and operation.started_at_utc is None:
         operation.started_at_utc = datetime.now(timezone.utc)
-    if to_status in {"succeeded", "failed", "canceled", "downloaded", "unavailable"}:
+    if to_status in {"succeeded", "failed", "canceled", "downloaded", "unavailable", "partial"}:
         operation.completed_at_utc = datetime.now(timezone.utc)
+        if to_status == "unavailable":
+            increment(MetricNames.EVIDENCE_UNAVAILABLE_RESULT)
+        if to_status == "partial":
+            increment(MetricNames.EVIDENCE_PARTIAL_RESULT)
     db.add(operation)
     db.commit()
     db.refresh(operation)
+
+    if (
+        operation.started_at_utc is not None
+        and operation.completed_at_utc is not None
+        and to_status in {"succeeded", "downloaded", "failed", "unavailable"}
+    ):
+        completion_time_ms = int(
+            (operation.completed_at_utc - operation.started_at_utc).total_seconds() * 1000
+        )
+        increment(MetricNames.EVIDENCE_COMPLETION_TIME, max(completion_time_ms, 0))
 
     create_operation_status_history(
         db,
@@ -69,6 +84,12 @@ def set_evidence_request_status(
         evidence_request.response_payload_json = response_payload_json
     if status == "fulfilled":
         evidence_request.fulfilled_at_utc = datetime.now(timezone.utc)
+        if evidence_request.created_at_utc is not None:
+            completion_time_ms = int(
+                (evidence_request.fulfilled_at_utc - evidence_request.created_at_utc).total_seconds()
+                * 1000
+            )
+            increment(MetricNames.EVIDENCE_COMPLETION_TIME, max(completion_time_ms, 0))
     db.add(evidence_request)
     db.commit()
     db.refresh(evidence_request)

--- a/backend/app/tasks/evidence_tasks.py
+++ b/backend/app/tasks/evidence_tasks.py
@@ -957,6 +957,10 @@ def capture_telematics_bundle(
             except Exception as ds_exc:
                 reason = str(ds_exc)
                 reason_code = _telematics_reason(ds_exc)
+                if reason_code == "credentials_invalid":
+                    increment(MetricNames.INTEGRATION_PROVIDER_AUTH_FAILURE)
+                elif reason_code == "provider_unavailable":
+                    increment(MetricNames.INTEGRATION_PROVIDER_FAILURE)
                 logger.warning(
                     "Telematics dataset %s unavailable for incident %s: %s",
                     dataset_name,
@@ -1026,8 +1030,10 @@ def capture_telematics_bundle(
             overall_status = "failed"
         elif failed_count > 0 or unavailable_count > 0:
             overall_status = "partial"
+            increment(MetricNames.EVIDENCE_PARTIAL_RESULT)
         elif available_count == 0:
             overall_status = "unavailable"
+            increment(MetricNames.EVIDENCE_UNAVAILABLE_RESULT)
         operation.result_json = {
             "status": overall_status,
             "request_statuses": request_statuses,

--- a/docs/operations/dashboards/evidence-pipeline.md
+++ b/docs/operations/dashboards/evidence-pipeline.md
@@ -33,6 +33,36 @@ Provide end-to-end visibility into evidence ingest, processing, storage, and exp
 - `evidence_ingest_failure_ratio_critical`
 - `evidence_stage_latency_warning`
 - `evidence_export_failures_critical`
+- `integration_credentials_invalid_spike_warning`
+- `integration_provider_outage_critical`
+- `retry_scheduler_stuck_in_progress_critical`
+- `dashcam_capture_failure_ratio_warning`
+- `otp_delivery_failure_ratio_warning`
+- `webhook_signature_failure_spike_warning`
+- `retry_queue_backlog_warning`
+
+## Reliability drill-down queries (new)
+1. **Credential invalid spikes**
+   - Query: `sum(increase(integration_provider_auth_failure_total{service="adc-worker",environment="prod"}[10m]))`
+   - Threshold: warning at `> 5` in 10m; critical at `> 20` in 10m.
+2. **Provider outage indicators**
+   - Query: `sum(rate(integration_provider_failure_total{service="adc-worker",environment="prod"}[10m])) / clamp_min(sum(rate(integration_provider_requests_total{service="adc-worker",environment="prod"}[10m])), 1)`
+   - Threshold: warning at `> 0.20` for 10m; critical at `> 0.40` for 10m.
+3. **Stuck in-progress operations**
+   - Query: `max(job_execution_stuck_total{service="adc-worker",environment="prod"})`
+   - Threshold: warning at `> 10` for 15m; critical at `> 25` for 15m.
+4. **Dashcam failure threshold breaches**
+   - Query: `sum(rate(integration_operations_total{service="adc-worker",environment="prod",domain="dashcam",status=~"failed|unavailable"}[15m])) / clamp_min(sum(rate(integration_operations_total{service="adc-worker",environment="prod",domain="dashcam"}[15m])), 1)`
+   - Threshold: warning at `> 0.15` for 15m; critical at `> 0.25` for 15m.
+5. **OTP failure threshold breaches**
+   - Query: `sum(rate(otp_delivery_failure_total{service="adc-api",environment="prod"}[10m])) / clamp_min(sum(rate(otp_delivery_attempts_total{service="adc-api",environment="prod"}[10m])), 1)`
+   - Threshold: warning at `> 0.08` for 10m; critical at `> 0.15` for 10m.
+6. **Webhook signature failure spikes**
+   - Query: `sum(increase(webhook_signature_failures_total{service="adc-api",environment="prod"}[10m]))`
+   - Threshold: warning at `> 10` in 10m; critical at `> 30` in 10m.
+7. **Queue backlog thresholds**
+   - Query: `max(celery_queue_depth{service="adc-worker",environment="prod"}) by (queue)`
+   - Threshold: warning at `> 500` for 15m; critical at `> 1200` for 15m.
 
 ## Runbooks
 - Primary: `docs/reliability-and-incident-response-runbook.md`

--- a/infra/monitoring/alert-policies.yaml
+++ b/infra/monitoring/alert-policies.yaml
@@ -185,3 +185,108 @@ alert_policies:
       org: adc
       service: adc-api
       environment: prod
+
+  - id: integration_credentials_invalid_spike_warning
+    section_ref: "7.4"
+    severity: warning
+    condition: "credential invalid errors spike above 5 in 10m"
+    expression: "sum(increase(integration_provider_auth_failure_total{service='adc-worker',environment='prod'}[10m])) > 5"
+    for: 10m
+    routing:
+      pager: secondary
+      escalation: integrations_owner
+    runbook: docs/reliability-and-incident-response-runbook.md
+    tags:
+      org: adc
+      service: adc-worker
+      environment: prod
+
+  - id: integration_provider_outage_critical
+    section_ref: "7.4"
+    severity: critical
+    condition: "provider failure ratio > 40% for 10m"
+    expression: "sum(rate(integration_provider_failure_total{service='adc-worker',environment='prod'}[10m])) / clamp_min(sum(rate(integration_provider_requests_total{service='adc-worker',environment='prod'}[10m])), 1) > 0.40"
+    for: 10m
+    routing:
+      pager: primary
+      escalation: backend_oncall
+    runbook: docs/reliability-and-incident-response-runbook.md
+    tags:
+      org: adc
+      service: adc-worker
+      environment: prod
+
+  - id: retry_scheduler_stuck_in_progress_critical
+    section_ref: "7.4"
+    severity: critical
+    condition: "stuck in-progress jobs > 25 for 15m"
+    expression: "max(job_execution_stuck_total{service='adc-worker',environment='prod'}) > 25"
+    for: 15m
+    routing:
+      pager: primary
+      escalation: backend_oncall
+    runbook: docs/reliability-and-incident-response-runbook.md
+    tags:
+      org: adc
+      service: adc-worker
+      environment: prod
+
+  - id: dashcam_capture_failure_ratio_warning
+    section_ref: "7.4"
+    severity: warning
+    condition: "dashcam failure/unavailable ratio > 15% for 15m"
+    expression: "sum(rate(integration_operations_total{service='adc-worker',environment='prod',domain='dashcam',status=~'failed|unavailable'}[15m])) / clamp_min(sum(rate(integration_operations_total{service='adc-worker',environment='prod',domain='dashcam'}[15m])), 1) > 0.15"
+    for: 15m
+    routing:
+      pager: secondary
+      escalation: integrations_owner
+    runbook: docs/reliability-and-incident-response-runbook.md
+    tags:
+      org: adc
+      service: adc-worker
+      environment: prod
+
+  - id: otp_delivery_failure_ratio_warning
+    section_ref: "7.4"
+    severity: warning
+    condition: "otp delivery failure ratio > 8% for 10m"
+    expression: "sum(rate(otp_delivery_failure_total{service='adc-api',environment='prod'}[10m])) / clamp_min(sum(rate(otp_delivery_attempts_total{service='adc-api',environment='prod'}[10m])), 1) > 0.08"
+    for: 10m
+    routing:
+      pager: secondary
+      escalation: auth_owner
+    runbook: docs/reliability-and-incident-response-runbook.md
+    tags:
+      org: adc
+      service: adc-api
+      environment: prod
+
+  - id: webhook_signature_failure_spike_warning
+    section_ref: "7.4"
+    severity: warning
+    condition: "webhook signature failures exceed 10 in 10m"
+    expression: "sum(increase(webhook_signature_failures_total{service='adc-api',environment='prod'}[10m])) > 10"
+    for: 10m
+    routing:
+      pager: secondary
+      escalation: backend_service_owner
+    runbook: docs/reliability-and-incident-response-runbook.md
+    tags:
+      org: adc
+      service: adc-api
+      environment: prod
+
+  - id: retry_queue_backlog_warning
+    section_ref: "7.4"
+    severity: warning
+    condition: "celery queue depth exceeds 500 for 15m"
+    expression: "max(celery_queue_depth{service='adc-worker',environment='prod'}) > 500"
+    for: 15m
+    routing:
+      pager: secondary
+      escalation: backend_service_owner
+    runbook: docs/reliability-and-incident-response-runbook.md
+    tags:
+      org: adc
+      service: adc-worker
+      environment: prod


### PR DESCRIPTION
### Motivation
- Provide observability for provider and orchestration reliability by adding canonical metrics for provider request outcomes, latency, evidence completion, OTP delivery, webhook signature issues, and retry-scheduler state.
- Enable actionable alerting and dashboard drill-downs for credential spikes, provider outages, stuck operations, OTP/dashcam failures, webhook signature spikes, and queue backlog thresholds.

### Description
- Extend `MetricNames` in `backend/app/core/metrics.py` with provider/integration, OTP, evidence completion/partial/unavailable, webhook signature, and retry-scheduler metric names and re-export `increment`/`timed`.
- Emit the new metrics and timing in orchestration and provider codepaths including `IncidentEvidenceOrchestrator` (`backend/app/services/incident_evidence_orchestrator.py`), Samsara adapter (`backend/app/integrations/providers/samsara.py`), and Twilio adapter (`backend/app/integrations/providers/twilio.py`) to count requests and classify success/failure/timeout/rate-limit/auth failures and latency.
- Instrument webhook handlers and task tracking with metrics in `backend/app/integrations/webhooks/handlers.py` and `backend/app/jobs/tracking.py` to count webhook attempts, signature failures, duplicate/orphaned events, OTP delivery outcomes, queued/retrying/terminal failures and stuck-in-progress markers.
- Measure evidence completion times and record partial/unavailable outcomes in `backend/app/services/integration_health_service.py` and `backend/app/tasks/evidence_tasks.py` to emit completion and result metrics.
- Add dashboard drill-down queries to `docs/operations/dashboards/evidence-pipeline.md` and matching alert definitions in `infra/monitoring/alert-policies.yaml` for the requested reliability signals and thresholds.

### Testing
- Ran `cd backend && ruff check app/ tests/` which passed without linter errors (ruff checks succeeded).
- Ran a targeted test run `cd backend && pytest tests/test_job_retry_policy.py tests/test_twilio_routes.py tests/test_twilio_verify_service.py -q` with all tests passing (`11 passed`).
- `make lint` surfaced `scripts/check_hardening_matrix_updates.py` which flagged that `docs/production-hardening/control-matrix.md` should be updated when backend hardening-adjacent files change, causing the overall `make lint` target to fail until the control matrix docs are updated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da24fb7648832182f13d9dcef11ff7)