### PR TITLE
Harden integration diagnostics and redact sensitive provider/webhook payloads

### DIFF
--- a/backend/app/api/routes_integrations.py
+++ b/backend/app/api/routes_integrations.py
@@ -18,7 +18,7 @@ from app.api.schemas import (
     IntegrationOperationDiagnosticsResponse,
 )
 from app.core.config import settings
-from app.core.deps import get_current_user
+from app.core.deps import get_current_user, require_user_role
 from app.core.logging import get_request_id
 from app.db.models import (
     EvidenceRequest,
@@ -36,10 +36,13 @@ from app.integrations.webhooks.signatures import (
     validate_twilio_signature,
 )
 from app.security.authn import build_user_auth_context
+from app.observability.redaction import redact_payload_for_storage
 from app.services.dashcam_capture_service import queue_dashcam_capture
 from app.services.telematics_capture_service import queue_telematics_capture
 
 router = APIRouter()
+
+_integration_admin = require_user_role("system_admin", "org_admin")
 
 
 @router.get("/org/integrations", response_model=list[IntegrationConnectionHealthResponse])
@@ -105,7 +108,7 @@ def get_org_integration(
 def validate_org_integration(
     integration_id: uuid.UUID,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(_integration_admin),
 ):
     context = build_user_auth_context(db, current_user)
     row = (
@@ -208,7 +211,7 @@ def list_integration_operations(
     status: str | None = None,
     provider: str | None = None,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(_integration_admin),
 ):
     context = build_user_auth_context(db, current_user)
     query = db.query(IntegrationOperation).filter(IntegrationOperation.org_id.in_(context.org_ids))
@@ -219,7 +222,7 @@ def list_integration_operations(
     if provider is not None:
         query = query.filter(IntegrationOperation.provider == provider)
     rows = query.order_by(IntegrationOperation.requested_at_utc.desc()).all()
-    return [IntegrationOperationDiagnosticsResponse.model_validate(row, from_attributes=True) for row in rows]
+    return [_to_diagnostics_response(row) for row in rows]
 
 
 @router.get(
@@ -229,7 +232,7 @@ def list_integration_operations(
 def get_integration_operation(
     operation_id: uuid.UUID,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(_integration_admin),
 ):
     context = build_user_auth_context(db, current_user)
     row = (
@@ -242,7 +245,14 @@ def get_integration_operation(
     )
     if row is None:
         raise HTTPException(status_code=404, detail="Integration operation not found")
-    return IntegrationOperationDiagnosticsResponse.model_validate(row, from_attributes=True)
+    return _to_diagnostics_response(row)
+
+
+def _to_diagnostics_response(row: IntegrationOperation) -> IntegrationOperationDiagnosticsResponse:
+    response = IntegrationOperationDiagnosticsResponse.model_validate(row, from_attributes=True)
+    response.payload_json = redact_payload_for_storage(response.payload_json)
+    response.result_json = redact_payload_for_storage(response.result_json)
+    return response
 
 
 @router.get(

--- a/backend/app/db/repo/integration_operations.py
+++ b/backend/app/db/repo/integration_operations.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.db.models import IntegrationOperation
 from app.integrations.errors import NormalizedIntegrationError
+from app.observability.redaction import redact_payload_for_storage
 
 
 def create_integration_operation(
@@ -35,7 +36,7 @@ def create_integration_operation(
         correlation_id=correlation_id,
         external_reference=external_reference,
         external_reference_id=external_reference_id or external_reference,
-        payload_json=payload_json or {},
+        payload_json=redact_payload_for_storage(payload_json),
         error_code=normalized_payload["code"] if normalized_payload else None,
         error_category=normalized_payload["category"] if normalized_payload else None,
         error_provider_key=(
@@ -85,9 +86,10 @@ def list_integration_operations(
     external_reference: str | None = None,
     external_reference_id: str | None = None,
 ):
+    if org_id is None:
+        raise ValueError("org_id is required for integration operation queries")
     query = db.query(IntegrationOperation)
-    if org_id is not None:
-        query = query.filter(IntegrationOperation.org_id == org_id)
+    query = query.filter(IntegrationOperation.org_id == org_id)
     if incident_id is not None:
         query = query.filter(IntegrationOperation.incident_id == incident_id)
     if status is not None:

--- a/backend/app/db/repo/provider_webhook_events.py
+++ b/backend/app/db/repo/provider_webhook_events.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from sqlalchemy.orm import Session
 
 from app.db.models import ProviderWebhookEvent
+from app.observability.redaction import redact_payload_for_storage, redact_raw_payload
 
 
 def create_provider_webhook_event(
@@ -40,8 +41,8 @@ def create_provider_webhook_event(
         idempotency_key=idempotency_key,
         signature_valid=signature_valid,
         processing_outcome=processing_outcome,
-        raw_payload=raw_payload or "",
-        payload_json=payload_json or {},
+        raw_payload=redact_raw_payload(raw_payload),
+        payload_json=redact_payload_for_storage(payload_json),
         error_message=error_message,
         error_details_json=error_details_json or {},
     )
@@ -107,9 +108,10 @@ def list_provider_webhook_events(
     correlation_id: str | None = None,
     external_reference: str | None = None,
 ):
+    if org_id is None:
+        raise ValueError("org_id is required for provider webhook event queries")
     query = db.query(ProviderWebhookEvent)
-    if org_id is not None:
-        query = query.filter(ProviderWebhookEvent.org_id == org_id)
+    query = query.filter(ProviderWebhookEvent.org_id == org_id)
     if incident_id is not None:
         query = query.filter(ProviderWebhookEvent.incident_id == incident_id)
     if status is not None:

--- a/backend/app/integrations/providers/twilio.py
+++ b/backend/app/integrations/providers/twilio.py
@@ -90,7 +90,7 @@ class TwilioMessagingProvider:
         sid = payload.get("sid")
         if not sid:
             increment(MetricNames.TWILIO_SEND_SMS_FAILURES)
-            raise ValueError(f"Twilio SMS response missing SID. Response: {payload}")
+            raise ValueError("Twilio SMS response missing SID")
         return sid
 
     def lookup_delivery_status(self, message_id: str) -> str | None:
@@ -128,7 +128,7 @@ class TwilioMessagingProvider:
         sid = payload.get("sid")
         if not sid:
             increment(MetricNames.TWILIO_PLACE_CALL_FAILURES)
-            raise ValueError(f"Twilio call response missing SID. Response: {payload}")
+            raise ValueError("Twilio call response missing SID")
         return sid
 
     def build_voice_twiml(self, message: str) -> str:
@@ -175,7 +175,7 @@ class TwilioMessagingProvider:
         sid = payload.get("sid")
         if not isinstance(sid, str) or not sid:
             increment(MetricNames.OTP_DELIVERY_FAILURE)
-            raise RuntimeError(f"Twilio Verify response missing sid: {payload!r}")
+            raise RuntimeError("Twilio Verify response missing sid")
         increment(MetricNames.OTP_DELIVERY_SUCCESS)
         logger.info("Twilio verification started sid=%s", sid)
         return sid

--- a/backend/app/integrations/webhooks/handlers.py
+++ b/backend/app/integrations/webhooks/handlers.py
@@ -17,6 +17,7 @@ from app.db.repo.provider_webhook_events import (
     get_provider_webhook_event_by_idempotency_key,
     update_provider_webhook_event,
 )
+from app.observability.redaction import redact_payload_for_storage, redact_raw_payload
 
 
 @dataclass
@@ -46,6 +47,8 @@ def process_twilio_status_callback(
     signature_error: str | None,
 ) -> WebhookResult:
     increment(MetricNames.TWILIO_WEBHOOK_ATTEMPTS)
+    sanitized_payload = redact_payload_for_storage(payload)
+    sanitized_raw_payload = redact_raw_payload(raw_payload)
     message_sid = payload.get("MessageSid")
     idempotency_key = build_idempotency_key(
         provider="twilio",
@@ -72,8 +75,8 @@ def process_twilio_status_callback(
             idempotency_key=idempotency_key,
             signature_valid=signature_valid,
             processing_outcome="duplicate",
-            raw_payload=raw_payload,
-            payload_json=payload,
+            raw_payload=sanitized_raw_payload,
+            payload_json=sanitized_payload,
             error_message="duplicate_webhook",
             error_details_json={"duplicate_of": str(existing.webhook_event_id)},
         )
@@ -90,8 +93,8 @@ def process_twilio_status_callback(
         external_reference=message_sid,
         idempotency_key=idempotency_key,
         signature_valid=signature_valid,
-        raw_payload=raw_payload,
-        payload_json=payload,
+        raw_payload=sanitized_raw_payload,
+        payload_json=sanitized_payload,
     )
 
     if not signature_valid:
@@ -153,7 +156,7 @@ def process_twilio_status_callback(
         operation,
         to_status=mapped,
         normalized_error_code=f"TWILIO_{error_code}" if error_code else None,
-        details_json=payload,
+        details_json=sanitized_payload,
     )
     if mapped in {"failed", "undelivered"}:
         increment(MetricNames.OTP_DELIVERY_FAILURE)
@@ -178,6 +181,8 @@ def persist_twilio_voice_callback(
     signature_error: str | None,
 ) -> WebhookResult:
     increment(MetricNames.TWILIO_WEBHOOK_ATTEMPTS)
+    sanitized_payload = redact_payload_for_storage(payload)
+    sanitized_raw_payload = redact_raw_payload(raw_payload)
     idempotency_key = build_idempotency_key(
         provider="twilio",
         event_type="voice_callback",
@@ -197,8 +202,8 @@ def persist_twilio_voice_callback(
         idempotency_key=idempotency_key,
         signature_valid=signature_valid,
         processing_outcome=outcome,
-        raw_payload=raw_payload,
-        payload_json=payload,
+        raw_payload=sanitized_raw_payload,
+        payload_json=sanitized_payload,
         error_message=None if signature_valid else "twilio_signature_validation_failed",
         error_details_json={} if signature_valid else {"reason": signature_error},
     )

--- a/backend/app/observability/redaction.py
+++ b/backend/app/observability/redaction.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from typing import Any
+from urllib.parse import parse_qsl, urlencode
 
 SENSITIVE_CLASS_A_KEYS = frozenset(
     {
@@ -30,6 +31,7 @@ _RE_OTP_INLINE = re.compile(
     r"(?i)\b(otp(?:_code)?|mfa(?:_code)?|verification(?:_code)?)\b([^\d]{0,20})(\d{4,8})"
 )
 _RE_NOTE_KV = re.compile(r"(?i)\b(note|notes|narrative)\b\s*([:=])\s*([^,;\n]+)")
+_RE_AUTH_HEADER = re.compile(r"(?im)^(authorization|x-api-key)\s*:\s*.+$")
 
 
 REDACTED = "[REDACTED]"
@@ -39,6 +41,7 @@ REDACTED_NOTE = "[REDACTED_NOTE]"
 
 def _redact_string(text: str) -> str:
     value = _RE_BEARER.sub("Bearer [REDACTED]", text)
+    value = _RE_AUTH_HEADER.sub(lambda m: f"{m.group(1)}: {REDACTED}", value)
     value = _RE_SECRET_ASSIGN.sub(lambda m: f"{m.group(1)}{m.group(2)}{REDACTED}", value)
     value = _RE_OTP_INLINE.sub(lambda m: f"{m.group(1)}{m.group(2)}{REDACTED_OTP}", value)
     value = _RE_NOTE_KV.sub(lambda m: f"{m.group(1)}{m.group(2)}{REDACTED_NOTE}", value)
@@ -62,3 +65,21 @@ def redact_log_data(value: Any, *, key: str | None = None) -> Any:
     if isinstance(value, tuple):
         return tuple(redact_log_data(item) for item in value)
     return value
+
+
+def redact_payload_for_storage(payload: dict[str, Any] | None) -> dict[str, Any]:
+    """Return a copy of payload safe for DB persistence and diagnostics."""
+    return redact_log_data(payload or {})
+
+
+def redact_raw_payload(raw_payload: str | None) -> str:
+    """Redact webhook/provider raw payload bodies while preserving structure."""
+    value = (raw_payload or "").strip()
+    if not value:
+        return ""
+
+    maybe_form = parse_qsl(value, keep_blank_values=True)
+    if maybe_form and ("=" in value or "&" in value):
+        sanitized_pairs = [(k, str(redact_log_data(v, key=k))) for k, v in maybe_form]
+        return urlencode(sanitized_pairs)
+    return str(redact_log_data(value))

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -31,6 +31,7 @@ from app.jobs.tracking import (
     record_task_started,
     record_task_succeeded,
 )
+from app.observability.redaction import redact_log_data
 
 logger = logging.getLogger(__name__)
 
@@ -191,7 +192,7 @@ def hello_world():
 @celery_app.task(name="app.tasks.celery_app.record_dead_letter")
 def record_dead_letter(payload: dict):
     """Persist terminal task failure payload to a dead-letter queue."""
-    logger.error("Dead-letter task received: %s", payload)
+    logger.error("Dead-letter task received: %s", redact_log_data(payload))
     return {"status": "recorded", "task_name": payload.get("task_name")}
 
 
@@ -220,7 +221,7 @@ def route_terminal_failures_to_dead_letter(
         "kwargs": kwargs or {},
         "exception": str(exception),
     }
-    logger.error("Routing task failure to dead-letter queue: %s", payload)
+    logger.error("Routing task failure to dead-letter queue: %s", redact_log_data(payload))
     celery_app.send_task(
         "app.tasks.celery_app.record_dead_letter",
         kwargs={"payload": payload},

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -280,7 +280,9 @@ class TestIntegrationDiagnosticsRoutes:
         assert detail_resp.status_code == 200
         assert detail_resp.json()["provider"] == "samsara"
 
-    def test_integration_operations_and_evidence_summary(self, client, db_session, test_org, auth_headers):
+    def test_integration_operations_and_evidence_summary(
+        self, client, db_session, test_org, test_user, auth_headers
+    ):
         incident = Incident(
             org_id=test_org.id,
             status="evidence_capturing",
@@ -300,8 +302,8 @@ class TestIntegrationDiagnosticsRoutes:
             domain="dashcam",
             operation_type="capture_dashcam",
             status="failed",
-            payload_json={},
-            result_json={},
+            payload_json={"token": "abc123", "nested": {"api_key": "very-secret"}},
+            result_json={"authorization": "Bearer asdf"},
         )
         db_session.add(operation)
         db_session.commit()
@@ -322,8 +324,20 @@ class TestIntegrationDiagnosticsRoutes:
         db_session.commit()
 
         ops_resp = client.get("/integration-operations", headers=auth_headers)
+        assert ops_resp.status_code == 403
+        test_user.role = "org_admin"
+        db_session.add(test_user)
+        db_session.commit()
+        org_admin_token = create_access_token({"sub": str(test_user.id), "role": "org_admin"})
+        org_admin_headers = {"Authorization": f"Bearer {org_admin_token}"}
+        ops_resp = client.get("/integration-operations", headers=org_admin_headers)
         assert ops_resp.status_code == 200
         assert len(ops_resp.json()) == 1
+        payload = ops_resp.json()[0]["payload_json"]
+        result_payload = ops_resp.json()[0]["result_json"]
+        assert payload["token"] == "[REDACTED]"
+        assert payload["nested"]["api_key"] == "[REDACTED]"
+        assert result_payload["authorization"] == "[REDACTED]"
 
         evidence_list = client.get(
             f"/incidents/{incident.incident_id}/evidence-requests",
@@ -338,6 +352,41 @@ class TestIntegrationDiagnosticsRoutes:
         )
         assert summary_resp.status_code == 200
         assert summary_resp.json()["retryable_failures"] == 1
+
+    def test_integration_validate_requires_admin_role(
+        self,
+        client,
+        db_session,
+        test_org,
+        test_user,
+        auth_headers,
+    ):
+        connection = IntegrationConnection(
+            org_id=test_org.id,
+            provider="twilio",
+            domain="messaging",
+            status="active",
+            credentials_ref="vault://twilio",
+        )
+        db_session.add(connection)
+        db_session.commit()
+
+        denied = client.post(
+            f"/org/integrations/{connection.connection_id}/validate",
+            headers=auth_headers,
+        )
+        assert denied.status_code == 403
+
+        test_user.role = "org_admin"
+        db_session.add(test_user)
+        db_session.commit()
+        org_admin_token = create_access_token({"sub": str(test_user.id), "role": "org_admin"})
+        org_admin_headers = {"Authorization": f"Bearer {org_admin_token}"}
+        allowed = client.post(
+            f"/org/integrations/{connection.connection_id}/validate",
+            headers=org_admin_headers,
+        )
+        assert allowed.status_code == 200
 
     @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_get_incident_returns_created_at(

--- a/backend/tests/test_observability_privacy.py
+++ b/backend/tests/test_observability_privacy.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 
 from app.observability.detection import AuditActivityDetector
 from app.observability.logging import JsonFormatter
+from app.observability.redaction import redact_payload_for_storage, redact_raw_payload
 
 
 def _format_log(message: str, **extra) -> dict:
@@ -109,3 +110,26 @@ def test_detection_rules_cover_expected_suspicious_behaviors():
         now=now,
     )
     assert any(a.rule == "cross_org_access_attempt" for a in cross_org_alerts)
+
+
+def test_raw_payload_redaction_masks_auth_and_otp():
+    payload = "Authorization=Bearer abc123&otp_code=123456&note=driver%20said%20ok"
+    redacted = redact_raw_payload(payload)
+    assert "abc123" not in redacted
+    assert "123456" not in redacted
+    assert "driver%20said%20ok" not in redacted
+    assert "%5BREDACTED%5D" in redacted
+    assert "%5BREDACTED_OTP%5D" in redacted
+
+
+def test_payload_storage_redaction_masks_nested_tokens():
+    redacted = redact_payload_for_storage(
+        {
+            "Authorization": "Bearer token-value",
+            "otp_code": "777888",
+            "nested": {"api_key": "secret-key"},
+        }
+    )
+    assert redacted["Authorization"] == "[REDACTED]"
+    assert redacted["otp_code"] == "[REDACTED_OTP]"
+    assert redacted["nested"]["api_key"] == "[REDACTED]"

--- a/docs/production-hardening/control-matrix.md
+++ b/docs/production-hardening/control-matrix.md
@@ -17,7 +17,7 @@
 
 ## CI requirement for hardening-related pull requests
 
-Last update: added dashcam provider-state transitions (`requested` → `submitted_to_provider` → `processing_at_provider` → terminal `downloaded|unavailable|failed`) and canonical missing-reason mappings in evidence/export flows.
+Last update: hardened integration/webhook diagnostics by enforcing admin-only integration validation + operation diagnostics access, mandatory org-scoped integration query helpers, and redaction of webhook raw payloads/logged dead-letter task payloads.
 
 Any pull request that touches hardening-related code **must** update `docs/production-hardening/control-matrix.md` in the same change.
 


### PR DESCRIPTION
### Motivation
- Prevent accidental disclosure of provider secrets, tokens, OTPs and auth headers in UI responses, DB rows and logs for integration and webhook flows.
- Restrict sensitive integration validation and diagnostics operations to admin roles and ensure org isolation for all integration queries.
- Standardize redaction logic for structured payloads and raw webhook bodies to centralize masking rules and make persisted/logged data safe for diagnostics.

### Description
- Added redaction utilities `redact_payload_for_storage` and `redact_raw_payload` and enhanced `_redact_string` to mask bearer tokens, auth headers, OTPs, notes and common secret keys in `app.observability.redaction`. 
- Applied redaction when persisting webhook events via `create_provider_webhook_event` and when handling Twilio webhooks in `app.integrations.webhooks.handlers` to store sanitized `raw_payload` and `payload_json`.
- Enforced admin-only access for integration validation and diagnostics endpoints by requiring `require_user_role("system_admin", "org_admin")` in `app.api.routes_integrations`, and redacted `payload_json` / `result_json` before serializing diagnostics responses via `_to_diagnostics_response`.
- Hardened repository APIs by redacting integration operation payloads on creation (`app.db.repo.integration_operations.create_integration_operation`) and by requiring an explicit `org_id` for integration operation and provider webhook event list queries to enforce org-scoped access.
- Sanitized sensitive logging in worker code by redacting dead-letter and routed task payloads in `app.tasks.celery_app`, and removed raw provider payload dumps from Twilio exception messages in `app.integrations.providers.twilio`.
- Added/updated tests to validate payload redaction and admin-role access for integration diagnostics and updated the hardening control matrix entry required by the repo lint policy.

### Testing
- Ran lint: `make lint` completed successfully and the hardening matrix check passed.
- Ran the full test suite: `make test` (which runs `pytest tests/` under `backend`) and all tests passed: 379 passed, 0 failed.
- Verified the added unit tests for payload redaction and integration diagnostics access are included and passing as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da30e0b2b883218aefff5b115c4790)