### PR TITLE
Add Sections 24–26 QA scenarios, runbook script, and go‑live validation checklist

### DIFF
--- a/docs/operations/section-24-26-go-live-validation-checklist.md
+++ b/docs/operations/section-24-26-go-live-validation-checklist.md
@@ -1,0 +1,54 @@
+# Sections 24–26 Go-Live Validation Checklist
+
+Use this checklist during release readiness sign-off for integration reliability, callback safety, and diagnostics/export integrity.
+
+## Pre-flight
+
+- [ ] Confirm staging environment has representative orgs, incidents, mappings, and provider sandbox credentials.
+- [ ] Confirm worker queue and webhook ingress are enabled.
+- [ ] Confirm on-call engineer has access to diagnostics endpoints and logs.
+
+## Section 24 — Integration reliability
+
+- [ ] **Invalid credentials (AC-24.1)**
+  - Validate `reauth_required` behavior and integration connection error state.
+  - Evidence: attach output from `bash scripts/run_section24_26_qa.sh invalid_credentials`.
+- [ ] **Mapping missing/stale (AC-24.2)**
+  - Validate mapping failure reason and admin-action guidance.
+  - Evidence: attach output from `bash scripts/run_section24_26_qa.sh mapping_missing_or_stale`.
+- [ ] **Provider timeout and rate limiting (AC-24.3)**
+  - Validate retry classification/backoff and API 429 protections.
+  - Evidence: attach output from `bash scripts/run_section24_26_qa.sh provider_timeout_rate_limit`.
+- [ ] **Partial telematics success (AC-24.4)**
+  - Validate export is non-blocking with warning records.
+  - Evidence: attach output from `bash scripts/run_section24_26_qa.sh partial_telematics_success`.
+
+## Section 25 — Async callbacks and webhook safety
+
+- [ ] **Async dashcam ready/state transitions (AC-25.1)**
+  - Validate operation transitions + external reference observability.
+  - Evidence: attach output from `bash scripts/run_section24_26_qa.sh dashcam_async_ready`.
+- [ ] **OTP undelivered callback (AC-25.2)**
+  - Validate message status reconciliation from callback payload.
+  - Evidence: attach output from `bash scripts/run_section24_26_qa.sh otp_undelivered_callback`.
+- [ ] **Invalid webhook signature paths (AC-25.3)**
+  - Validate HTTP 403 and failed webhook-event persistence.
+  - Evidence: attach output from `bash scripts/run_section24_26_qa.sh invalid_webhook_signature`.
+
+## Section 26 — Diagnostics isolation and export warning fidelity
+
+- [ ] **Org isolation in diagnostics (AC-26.1)**
+  - Validate cross-org operations are not visible to caller org.
+  - Evidence: attach output from `bash scripts/run_section24_26_qa.sh diagnostics_org_isolation`.
+- [ ] **Export warnings from missing evidence (AC-26.2)**
+  - Validate missing evidence produces warnings instead of hard-fail package generation.
+  - Evidence: attach output from `bash scripts/run_section24_26_qa.sh export_missing_evidence_warnings`.
+
+## Sign-off
+
+- Release version/tag:
+- Date (UTC):
+- Environment:
+- QA lead:
+- SRE/on-call approver:
+- Result summary (include blockers, waivers, and follow-ups):

--- a/docs/section-24-26-integration-acceptance-checklist.md
+++ b/docs/section-24-26-integration-acceptance-checklist.md
@@ -1,0 +1,45 @@
+# Sections 24–26 Integration & Diagnostics Acceptance Checklist
+
+This checklist adds explicit QA scenarios for Sections 24–26 and ties each scenario to automated coverage (API/integration tests) plus go-live runbook validation.
+
+## Section 24 acceptance criteria (integration reliability)
+
+- [ ] **AC-24.1 Invalid credentials are treated as intervention-required**
+  - Expected behavior: integration connection moves to `error`, operation result requires re-auth, retries do not loop indefinitely.
+- [ ] **AC-24.2 Missing/stale mappings are surfaced as mapping-fix-required**
+  - Expected behavior: telematics capture fails with `vehicle_mapping_missing`-style reasoning and admin action guidance.
+- [ ] **AC-24.3 Provider timeout and provider-side rate limiting are retry-classified**
+  - Expected behavior: transient dependency failures are classified retryable with capability backoff policy.
+- [ ] **AC-24.4 Partial telematics success is non-blocking for export workflows**
+  - Expected behavior: capture/export can complete with warnings when optional evidence is unavailable.
+
+## Section 25 acceptance criteria (async callbacks & webhook safety)
+
+- [ ] **AC-25.1 Async dashcam readiness/state transition is persisted for diagnostics**
+  - Expected behavior: operation transitions and external reference IDs are persisted for asynchronous provider flows.
+- [ ] **AC-25.2 OTP undelivered callback is reconciled into message operation state**
+  - Expected behavior: Twilio status callback updates message operation to `undelivered`/`failed` and records webhook event.
+- [ ] **AC-25.3 Invalid webhook signatures are denied and auditable**
+  - Expected behavior: webhook returns 403, records a failed webhook event, and surfaces signature validation reason.
+
+## Section 26 acceptance criteria (diagnostics isolation & export warning fidelity)
+
+- [ ] **AC-26.1 Org isolation is enforced in diagnostics and evidence views**
+  - Expected behavior: integration diagnostics only show rows from caller org scope.
+- [ ] **AC-26.2 Export packages preserve warning/missing evidence diagnostics**
+  - Expected behavior: export build remains resilient, writes warnings/missing items for unavailable evidence.
+
+## Scenario-to-acceptance mapping
+
+| Requested QA scenario | Section acceptance criteria | Automated coverage | Go-live validation command/script |
+| --- | --- | --- | --- |
+| invalid credentials | AC-24.1 | `backend/tests/test_celery_tasks.py::TestCaptureTelematicsBundle::test_credentials_invalid_marks_connection_for_reauth` | `bash scripts/run_section24_26_qa.sh invalid_credentials` |
+| mapping missing/stale | AC-24.2 | `backend/tests/test_job_retry_policy.py::test_classify_normalized_error_non_retryable_for_mapping` | `bash scripts/run_section24_26_qa.sh mapping_missing_or_stale` |
+| provider timeout and rate limiting | AC-24.3 | `backend/tests/test_job_retry_policy.py::test_classify_retry_exception_transient_dependency`, `backend/tests/test_production_hardening_suite.py::test_rate_limit_enforcement_returns_429_when_threshold_hit` | `bash scripts/run_section24_26_qa.sh provider_timeout_rate_limit` |
+| partial telematics success | AC-24.4 | `backend/tests/test_export_section23_acceptance.py::test_partial_artifact_soft_fail_behavior` | `bash scripts/run_section24_26_qa.sh partial_telematics_success` |
+| async dashcam ready callback | AC-25.1 | `backend/tests/test_celery_tasks.py::TestCaptureDashcam::test_dashcam_operation_state_machine_and_external_reference_id` | `bash scripts/run_section24_26_qa.sh dashcam_async_ready` |
+| OTP undelivered callback | AC-25.2 | `backend/tests/test_twilio_routes.py::test_twilio_status_callback_reconciles_message_operation` | `bash scripts/run_section24_26_qa.sh otp_undelivered_callback` |
+| webhook signature invalid paths | AC-25.3 | `backend/tests/test_twilio_routes.py::test_twilio_voice_rejects_missing_signature`, `backend/tests/test_twilio_routes.py::test_twilio_voice_persists_invalid_signature_event` | `bash scripts/run_section24_26_qa.sh invalid_webhook_signature` |
+| org isolation in diagnostics | AC-26.1 | `backend/tests/test_api_endpoints.py::TestIntegrationDiagnosticsRoutes::test_integration_operations_and_evidence_summary` | `bash scripts/run_section24_26_qa.sh diagnostics_org_isolation` |
+| export warnings from missing evidence | AC-26.2 | `backend/tests/test_celery_tasks.py::TestBuildExport::test_export_soft_fail_persists_warnings`, `backend/tests/test_production_hardening_suite.py::test_storage_outage_simulation_keeps_export_zip_generation_resilient` | `bash scripts/run_section24_26_qa.sh export_missing_evidence_warnings` |
+

--- a/scripts/run_section24_26_qa.sh
+++ b/scripts/run_section24_26_qa.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCENARIO="${1:-all}"
+
+cat <<'USAGE' >&2
+Section 24–26 QA runbook helper.
+
+Usage:
+  bash scripts/run_section24_26_qa.sh <scenario>
+
+Scenarios:
+  invalid_credentials
+  mapping_missing_or_stale
+  provider_timeout_rate_limit
+  partial_telematics_success
+  dashcam_async_ready
+  otp_undelivered_callback
+  invalid_webhook_signature
+  diagnostics_org_isolation
+  export_missing_evidence_warnings
+  all
+USAGE
+
+print_step() {
+  local scenario_name="$1"
+  shift
+  if [[ "$SCENARIO" == "all" || "$SCENARIO" == "$scenario_name" ]]; then
+    echo
+    echo "=== ${scenario_name} ==="
+    "$@"
+  fi
+}
+
+invalid_credentials() {
+  cat <<'EOF_STEP'
+1) Deactivate or rotate integration credentials in non-prod.
+2) Trigger telematics capture for a known incident.
+3) Verify operation outcome includes admin action `reauth_required`.
+4) Verify integration connection transitions to status `error`.
+Reference test: backend/tests/test_celery_tasks.py::TestCaptureTelematicsBundle::test_credentials_invalid_marks_connection_for_reauth
+EOF_STEP
+}
+
+mapping_missing_or_stale() {
+  cat <<'EOF_STEP'
+1) Remove vehicle mapping for a test incident's vehicle/provider pair.
+2) Trigger telematics capture.
+3) Confirm response/reason includes mapping issue (`vehicle_mapping_missing`).
+4) Confirm diagnostics indicate admin action `mapping_fix_required`.
+Reference test: backend/tests/test_job_retry_policy.py::test_classify_normalized_error_non_retryable_for_mapping
+EOF_STEP
+}
+
+provider_timeout_rate_limit() {
+  cat <<'EOF_STEP'
+1) Inject provider timeout (e.g., proxy delay/fault) and trigger capture.
+2) Confirm retry classification is transient and backoff policy is applied.
+3) Send API calls beyond configured threshold and confirm HTTP 429 + Retry-After.
+Reference tests:
+- backend/tests/test_job_retry_policy.py::test_classify_retry_exception_transient_dependency
+- backend/tests/test_production_hardening_suite.py::test_rate_limit_enforcement_returns_429_when_threshold_hit
+EOF_STEP
+}
+
+partial_telematics_success() {
+  cat <<'EOF_STEP'
+1) Simulate one optional telematics artifact unavailable while others are present.
+2) Build export package.
+3) Confirm export remains `ready` with warning entries.
+Reference test: backend/tests/test_export_section23_acceptance.py::test_partial_artifact_soft_fail_behavior
+EOF_STEP
+}
+
+dashcam_async_ready() {
+  cat <<'EOF_STEP'
+1) Trigger dashcam capture with provider external reference recorded.
+2) Verify integration operation status transitions are persisted.
+3) Validate external reference is visible in diagnostics output.
+Reference test: backend/tests/test_celery_tasks.py::TestCaptureDashcam::test_dashcam_operation_state_machine_and_external_reference_id
+EOF_STEP
+}
+
+otp_undelivered_callback() {
+  cat <<'EOF_STEP'
+1) Submit Twilio status callback with MessageStatus=undelivered for a known MessageSid.
+2) Confirm MessageOperation status updates to `undelivered` and webhook event is persisted.
+Reference test: backend/tests/test_twilio_routes.py::test_twilio_status_callback_reconciles_message_operation
+EOF_STEP
+}
+
+invalid_webhook_signature() {
+  cat <<'EOF_STEP'
+1) Submit webhook callback with missing/invalid X-Twilio-Signature.
+2) Confirm endpoint returns HTTP 403.
+3) Confirm ProviderWebhookEvent is persisted with invalid signature outcome.
+Reference tests:
+- backend/tests/test_twilio_routes.py::test_twilio_voice_rejects_missing_signature
+- backend/tests/test_twilio_routes.py::test_twilio_voice_persists_invalid_signature_event
+EOF_STEP
+}
+
+diagnostics_org_isolation() {
+  cat <<'EOF_STEP'
+1) Create integration operations in Org A and Org B.
+2) Query diagnostics as Org A admin.
+3) Confirm only Org A operations and evidence summaries are returned.
+Reference test: backend/tests/test_api_endpoints.py::TestIntegrationDiagnosticsRoutes::test_integration_operations_and_evidence_summary
+EOF_STEP
+}
+
+export_missing_evidence_warnings() {
+  cat <<'EOF_STEP'
+1) Force artifact download failure during export build.
+2) Confirm export zip still generates and includes warning/missing-item records.
+Reference tests:
+- backend/tests/test_celery_tasks.py::TestBuildExport::test_export_soft_fail_persists_warnings
+- backend/tests/test_production_hardening_suite.py::test_storage_outage_simulation_keeps_export_zip_generation_resilient
+EOF_STEP
+}
+
+print_step "invalid_credentials" invalid_credentials
+print_step "mapping_missing_or_stale" mapping_missing_or_stale
+print_step "provider_timeout_rate_limit" provider_timeout_rate_limit
+print_step "partial_telematics_success" partial_telematics_success
+print_step "dashcam_async_ready" dashcam_async_ready
+print_step "otp_undelivered_callback" otp_undelivered_callback
+print_step "invalid_webhook_signature" invalid_webhook_signature
+print_step "diagnostics_org_isolation" diagnostics_org_isolation
+print_step "export_missing_evidence_warnings" export_missing_evidence_warnings


### PR DESCRIPTION
### Motivation

- Provide explicit QA scenarios and operator runbook steps covering integration reliability, async callbacks, webhook safety, diagnostics isolation, and export warning fidelity mapped to Sections 24–26 acceptance criteria. 
- Ensure each requested scenario is traceable to existing automated tests so release validation can be automated or executed from a reproducible runbook. 

### Description

- Add `docs/section-24-26-integration-acceptance-checklist.md` which enumerates AC-24/25/26 criteria and maps the requested QA scenarios (invalid credentials, mapping missing/stale, provider timeout/rate limiting, partial telematics success, async dashcam ready callback, OTP undelivered callback, invalid webhook signatures, diagnostics org isolation, export missing-evidence warnings) to specific test references and a runbook command. 
- Add a go‑live checklist at `docs/operations/section-24-26-go-live-validation-checklist.md` containing pre-flight checks, per-scenario validation steps, and sign-off fields for release approval. 
- Add a reusable runbook helper script `scripts/run_section24_26_qa.sh` (executable) that prints scenario-specific validation steps and links to the corresponding automated tests for on‑demand operator execution. 

### Testing

- Ran linting with `make lint` which completed successfully and passed hardening matrix lint checks. 
- Executed targeted pytest invocations for the mapped scenarios using `cd backend && pytest ...` which ran the selected tests and reported `12 passed` with warnings only. 
- Performed runbook smoke checks with `bash -n scripts/run_section24_26_qa.sh` and `bash scripts/run_section24_26_qa.sh invalid_webhook_signature`, which validated script syntax and printed the expected scenario instructions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc47fc7d50832190526eaba85c9726)