### PR TITLE
Add case management schema: incident fields, case_notes, case_tasks, readiness overrides, and migration

### DIFF
--- a/backend/app/db/migrations/versions/0018_add_case_management_tables_and_incident_fields.py
+++ b/backend/app/db/migrations/versions/0018_add_case_management_tables_and_incident_fields.py
@@ -1,0 +1,248 @@
+"""add case management tables and incident workflow fields
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-04-13
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0018"
+down_revision: Union[str, None] = "0017"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+incident_case_status = sa.Enum(
+    "new",
+    "in_review",
+    "awaiting_evidence",
+    "awaiting_follow_up",
+    "ready_for_export",
+    "exported",
+    "escalated",
+    "closed",
+    name="incident_case_status",
+)
+
+case_task_type = sa.Enum(
+    "review",
+    "evidence",
+    "follow_up",
+    "export",
+    "other",
+    name="case_task_type",
+)
+
+case_task_status = sa.Enum(
+    "open",
+    "in_progress",
+    "blocked",
+    "completed",
+    "canceled",
+    name="case_task_status",
+)
+
+case_task_priority = sa.Enum(
+    "low",
+    "medium",
+    "high",
+    "urgent",
+    name="case_task_priority",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    incident_case_status.create(bind, checkfirst=True)
+    case_task_type.create(bind, checkfirst=True)
+    case_task_status.create(bind, checkfirst=True)
+    case_task_priority.create(bind, checkfirst=True)
+
+    op.add_column(
+        "incidents",
+        sa.Column("case_status", incident_case_status, nullable=False, server_default="new"),
+    )
+    op.add_column("incidents", sa.Column("owner_user_id", postgresql.UUID(as_uuid=True), nullable=True))
+    op.add_column("incidents", sa.Column("owner_assigned_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True))
+    op.add_column(
+        "incidents",
+        sa.Column("owner_assigned_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.add_column("incidents", sa.Column("team_queue", sa.Text(), nullable=True))
+    op.add_column("incidents", sa.Column("readiness_state", sa.Text(), nullable=True))
+    op.add_column("incidents", sa.Column("completeness_percent", sa.Integer(), nullable=True))
+    op.add_column("incidents", sa.Column("completeness_status", sa.Text(), nullable=True))
+    op.add_column("incidents", sa.Column("first_reviewed_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True))
+    op.add_column("incidents", sa.Column("last_activity_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True))
+    op.add_column("incidents", sa.Column("ready_for_export_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True))
+    op.add_column(
+        "incidents",
+        sa.Column(
+            "updated_at_utc",
+            postgresql.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+
+    op.create_foreign_key("fk_incidents_owner_user_id", "incidents", "users", ["owner_user_id"], ["id"])
+    op.create_foreign_key(
+        "fk_incidents_owner_assigned_by_user_id",
+        "incidents",
+        "users",
+        ["owner_assigned_by_user_id"],
+        ["id"],
+    )
+
+    op.create_index("ix_incidents_org_case_status_owner", "incidents", ["org_id", "case_status", "owner_user_id"], unique=False)
+    op.create_index("ix_incidents_org_readiness_state", "incidents", ["org_id", "readiness_state"], unique=False)
+    op.create_index("ix_incidents_org_updated_at_utc", "incidents", ["org_id", "updated_at_utc"], unique=False)
+    op.create_index("ix_incidents_org_last_activity_at_utc", "incidents", ["org_id", "last_activity_at_utc"], unique=False)
+
+    op.create_table(
+        "case_notes",
+        sa.Column("note_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("incident_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("created_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("edited_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("edited_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("deleted_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("deleted_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("is_deleted", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("created_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["deleted_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["edited_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["incident_id"], ["incidents.incident_id"]),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("note_id"),
+    )
+    op.create_index("ix_case_notes_incident_id", "case_notes", ["incident_id"], unique=False)
+    op.create_index("ix_case_notes_org_id", "case_notes", ["org_id"], unique=False)
+    op.create_index("ix_case_notes_org_incident_created", "case_notes", ["org_id", "incident_id", "created_at_utc"], unique=False)
+    op.create_index(
+        "ix_case_notes_org_incident_deleted_created",
+        "case_notes",
+        ["org_id", "incident_id", "is_deleted", "created_at_utc"],
+        unique=False,
+    )
+
+    op.create_table(
+        "case_tasks",
+        sa.Column("task_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("incident_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("task_type", case_task_type, nullable=False, server_default="other"),
+        sa.Column("status", case_task_status, nullable=False, server_default="open"),
+        sa.Column("priority", case_task_priority, nullable=False, server_default="medium"),
+        sa.Column("due_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("assigned_to_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("assigned_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("assigned_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("completed_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("completed_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("canceled_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("canceled_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("canceled_reason", sa.Text(), nullable=True),
+        sa.Column("created_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["assigned_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["assigned_to_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["canceled_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["completed_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["incident_id"], ["incidents.incident_id"]),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("task_id"),
+    )
+    op.create_index("ix_case_tasks_incident_id", "case_tasks", ["incident_id"], unique=False)
+    op.create_index("ix_case_tasks_org_id", "case_tasks", ["org_id"], unique=False)
+    op.create_index("ix_case_tasks_org_incident_status", "case_tasks", ["org_id", "incident_id", "status"], unique=False)
+    op.create_index("ix_case_tasks_org_status_due_at_utc", "case_tasks", ["org_id", "status", "due_at_utc"], unique=False)
+
+    op.create_table(
+        "case_readiness_overrides",
+        sa.Column("override_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("incident_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("readiness_state", sa.Text(), nullable=True),
+        sa.Column("completeness_percent", sa.Integer(), nullable=True),
+        sa.Column("completeness_status", sa.Text(), nullable=True),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column("created_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("cleared_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("cleared_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("created_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["incident_id"], ["incidents.incident_id"]),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["cleared_by_user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("override_id"),
+    )
+    op.create_index("ix_case_readiness_overrides_incident_id", "case_readiness_overrides", ["incident_id"], unique=False)
+    op.create_index("ix_case_readiness_overrides_org_id", "case_readiness_overrides", ["org_id"], unique=False)
+    op.create_index(
+        "ix_case_readiness_overrides_org_incident_created",
+        "case_readiness_overrides",
+        ["org_id", "incident_id", "created_at_utc"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_case_readiness_overrides_org_incident_created", table_name="case_readiness_overrides")
+    op.drop_index("ix_case_readiness_overrides_org_id", table_name="case_readiness_overrides")
+    op.drop_index("ix_case_readiness_overrides_incident_id", table_name="case_readiness_overrides")
+    op.drop_table("case_readiness_overrides")
+
+    op.drop_index("ix_case_tasks_org_status_due_at_utc", table_name="case_tasks")
+    op.drop_index("ix_case_tasks_org_incident_status", table_name="case_tasks")
+    op.drop_index("ix_case_tasks_org_id", table_name="case_tasks")
+    op.drop_index("ix_case_tasks_incident_id", table_name="case_tasks")
+    op.drop_table("case_tasks")
+
+    op.drop_index("ix_case_notes_org_incident_deleted_created", table_name="case_notes")
+    op.drop_index("ix_case_notes_org_incident_created", table_name="case_notes")
+    op.drop_index("ix_case_notes_org_id", table_name="case_notes")
+    op.drop_index("ix_case_notes_incident_id", table_name="case_notes")
+    op.drop_table("case_notes")
+
+    op.drop_index("ix_incidents_org_last_activity_at_utc", table_name="incidents")
+    op.drop_index("ix_incidents_org_updated_at_utc", table_name="incidents")
+    op.drop_index("ix_incidents_org_readiness_state", table_name="incidents")
+    op.drop_index("ix_incidents_org_case_status_owner", table_name="incidents")
+    op.drop_constraint("fk_incidents_owner_assigned_by_user_id", "incidents", type_="foreignkey")
+    op.drop_constraint("fk_incidents_owner_user_id", "incidents", type_="foreignkey")
+
+    op.drop_column("incidents", "updated_at_utc")
+    op.drop_column("incidents", "ready_for_export_at_utc")
+    op.drop_column("incidents", "last_activity_at_utc")
+    op.drop_column("incidents", "first_reviewed_at_utc")
+    op.drop_column("incidents", "completeness_status")
+    op.drop_column("incidents", "completeness_percent")
+    op.drop_column("incidents", "readiness_state")
+    op.drop_column("incidents", "team_queue")
+    op.drop_column("incidents", "owner_assigned_by_user_id")
+    op.drop_column("incidents", "owner_assigned_at_utc")
+    op.drop_column("incidents", "owner_user_id")
+    op.drop_column("incidents", "case_status")
+
+    bind = op.get_bind()
+    case_task_priority.drop(bind, checkfirst=True)
+    case_task_status.drop(bind, checkfirst=True)
+    case_task_type.drop(bind, checkfirst=True)
+    incident_case_status.drop(bind, checkfirst=True)

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -205,6 +205,208 @@ class Incident(Base):
     samsara_vehicle_id = Column(Text, nullable=True)
     adc_driver_id = Column(Text, nullable=True)
     severity = Column(Text, nullable=True)
+    case_status = Column(
+        Enum(
+            "new",
+            "in_review",
+            "awaiting_evidence",
+            "awaiting_follow_up",
+            "ready_for_export",
+            "exported",
+            "escalated",
+            "closed",
+            name="incident_case_status",
+        ),
+        nullable=False,
+        default="new",
+        server_default="new",
+    )
+    owner_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    owner_assigned_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    owner_assigned_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
+    team_queue = Column(Text, nullable=True)
+    readiness_state = Column(Text, nullable=True)
+    completeness_percent = Column(Integer, nullable=True)
+    completeness_status = Column(Text, nullable=True)
+    first_reviewed_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    last_activity_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    ready_for_export_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_incidents_org_case_status_owner", "org_id", "case_status", "owner_user_id"),
+        Index("ix_incidents_org_readiness_state", "org_id", "readiness_state"),
+        Index("ix_incidents_org_updated_at_utc", "org_id", "updated_at_utc"),
+        Index("ix_incidents_org_last_activity_at_utc", "org_id", "last_activity_at_utc"),
+    )
+
+
+class CaseNote(Base):
+    """Internal-only case notes with edit and soft-delete metadata."""
+
+    __tablename__ = "case_notes"
+
+    note_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
+    )
+    incident_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("incidents.incident_id"),
+        nullable=False,
+        index=True,
+    )
+    body = Column(Text, nullable=False)
+    created_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    edited_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    edited_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    deleted_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    deleted_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    is_deleted = Column(Boolean, nullable=False, default=False, server_default=text("false"))
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_case_notes_org_incident_created", "org_id", "incident_id", "created_at_utc"),
+        Index(
+            "ix_case_notes_org_incident_deleted_created",
+            "org_id",
+            "incident_id",
+            "is_deleted",
+            "created_at_utc",
+        ),
+    )
+
+
+class CaseTask(Base):
+    """Action items tracked for each case."""
+
+    __tablename__ = "case_tasks"
+
+    task_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
+    )
+    incident_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("incidents.incident_id"),
+        nullable=False,
+        index=True,
+    )
+    title = Column(Text, nullable=False)
+    description = Column(Text, nullable=True)
+    task_type = Column(
+        Enum(
+            "review",
+            "evidence",
+            "follow_up",
+            "export",
+            "other",
+            name="case_task_type",
+        ),
+        nullable=False,
+        default="other",
+        server_default="other",
+    )
+    status = Column(
+        Enum(
+            "open",
+            "in_progress",
+            "blocked",
+            "completed",
+            "canceled",
+            name="case_task_status",
+        ),
+        nullable=False,
+        default="open",
+        server_default="open",
+    )
+    priority = Column(
+        Enum("low", "medium", "high", "urgent", name="case_task_priority"),
+        nullable=False,
+        default="medium",
+        server_default="medium",
+    )
+    due_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    assigned_to_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    assigned_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    assigned_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    completed_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    completed_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    canceled_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    canceled_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    canceled_reason = Column(Text, nullable=True)
+    created_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_case_tasks_org_incident_status", "org_id", "incident_id", "status"),
+        Index("ix_case_tasks_org_status_due_at_utc", "org_id", "status", "due_at_utc"),
+    )
+
+
+class CaseReadinessOverride(Base):
+    """Manual readiness override snapshots for cases."""
+
+    __tablename__ = "case_readiness_overrides"
+
+    override_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
+    )
+    incident_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("incidents.incident_id"),
+        nullable=False,
+        index=True,
+    )
+    readiness_state = Column(Text, nullable=True)
+    completeness_percent = Column(Integer, nullable=True)
+    completeness_status = Column(Text, nullable=True)
+    reason = Column(Text, nullable=False)
+    created_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    cleared_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    cleared_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_case_readiness_overrides_org_incident_created",
+            "org_id",
+            "incident_id",
+            "created_at_utc",
+        ),
+    )
 
 
 class Artifact(Base):

--- a/backend/tests/test_model_improvements.py
+++ b/backend/tests/test_model_improvements.py
@@ -8,7 +8,17 @@ from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 
-from app.db.models import Base, Org, Incident, Event, Artifact, Export
+from app.db.models import (
+    Artifact,
+    Base,
+    CaseNote,
+    CaseReadinessOverride,
+    CaseTask,
+    Event,
+    Export,
+    Incident,
+    Org,
+)
 
 
 @pytest.fixture
@@ -77,6 +87,15 @@ class TestForeignKeyConstraints:
         with pytest.raises(IntegrityError):
             db.commit()
 
+    def test_case_note_incident_foreign_key_enforced(self, db):
+        """CaseNote.incident_id must reference a valid Incident."""
+        invalid_incident_id = uuid.uuid4()
+        note = CaseNote(incident_id=invalid_incident_id, body="Internal note")
+        db.add(note)
+
+        with pytest.raises(IntegrityError):
+            db.commit()
+
     def test_foreign_key_allows_valid_incident(self, db):
         """Foreign key constraints allow valid incident references."""
         org = Org(name="Test Org")
@@ -123,6 +142,28 @@ class TestStatusEnums:
             db.add(incident)
             db.commit()
             assert incident.status == status
+
+    def test_incident_case_status_valid_values(self, db):
+        """Incident case_status accepts valid enum values."""
+        org = Org(name="Test Org")
+        db.add(org)
+        db.commit()
+
+        valid_case_statuses = [
+            "new",
+            "in_review",
+            "awaiting_evidence",
+            "awaiting_follow_up",
+            "ready_for_export",
+            "exported",
+            "escalated",
+            "closed",
+        ]
+        for case_status in valid_case_statuses:
+            incident = Incident(status="open", case_status=case_status, org_id=org.id)
+            db.add(incident)
+            db.commit()
+            assert incident.case_status == case_status
 
     def test_artifact_status_valid_values(self, db):
         """Artifact status accepts valid enum values."""
@@ -238,6 +279,27 @@ class TestCompositeIndexes:
         index_names = [idx.name for idx in table_args if hasattr(idx, "name")]
         assert "ix_exports_org_incident" in index_names
 
+    def test_incident_has_case_management_indexes(self):
+        """Incident model has case queue indexes defined."""
+        assert hasattr(Incident, "__table_args__")
+        table_args = Incident.__table_args__
+        assert isinstance(table_args, tuple)
+
+        index_names = [idx.name for idx in table_args if hasattr(idx, "name")]
+        assert "ix_incidents_org_case_status_owner" in index_names
+        assert "ix_incidents_org_readiness_state" in index_names
+        assert "ix_incidents_org_updated_at_utc" in index_names
+        assert "ix_incidents_org_last_activity_at_utc" in index_names
+
+    def test_case_task_has_overdue_index(self):
+        """CaseTask model has overdue query index defined."""
+        assert hasattr(CaseTask, "__table_args__")
+        table_args = CaseTask.__table_args__
+        assert isinstance(table_args, tuple)
+
+        index_names = [idx.name for idx in table_args if hasattr(idx, "name")]
+        assert "ix_case_tasks_org_status_due_at_utc" in index_names
+
 
 class TestDefaultValues:
     """Test default values work correctly."""
@@ -252,6 +314,7 @@ class TestDefaultValues:
         db.add(incident)
         db.commit()
         assert incident.status == "open"
+        assert incident.case_status == "new"
 
     def test_artifact_default_status_is_pending(self, db):
         """Artifact defaults to 'pending' status."""
@@ -279,3 +342,51 @@ class TestDefaultValues:
         db.add(export)
         db.commit()
         assert export.status == "requested"
+
+    def test_case_task_defaults(self, db):
+        """CaseTask defaults status, type, and priority values."""
+        org = Org(name="Test Org")
+        incident = Incident(status="open", org_id=org.id)
+        db.add_all([org, incident])
+        db.commit()
+
+        task = CaseTask(incident_id=incident.incident_id, title="Collect witness statement")
+        db.add(task)
+        db.commit()
+
+        assert task.status == "open"
+        assert task.task_type == "other"
+        assert task.priority == "medium"
+
+    def test_case_note_soft_delete_defaults(self, db):
+        """CaseNote defaults to non-deleted state."""
+        org = Org(name="Test Org")
+        incident = Incident(status="open", org_id=org.id)
+        db.add_all([org, incident])
+        db.commit()
+
+        note = CaseNote(incident_id=incident.incident_id, body="Hidden internal note")
+        db.add(note)
+        db.commit()
+
+        assert note.is_deleted is False
+
+    def test_case_readiness_override_persists(self, db):
+        """CaseReadinessOverride persists manual override snapshots."""
+        org = Org(name="Test Org")
+        incident = Incident(status="open", org_id=org.id)
+        db.add_all([org, incident])
+        db.commit()
+
+        override = CaseReadinessOverride(
+            incident_id=incident.incident_id,
+            reason="Investigator approved manual readiness override.",
+            readiness_state="ready",
+            completeness_percent=100,
+            completeness_status="complete",
+        )
+        db.add(override)
+        db.commit()
+
+        assert override.reason.startswith("Investigator")
+        assert override.completeness_percent == 100


### PR DESCRIPTION
### Motivation
- Add case-management workflow support to incidents including status, ownership, readiness/completeness, and SLA timestamps to enable queueing and operational workflows.
- Provide first-class internal artifacts for case workflows: editable/soft-deletable internal notes, tracked tasks with lifecycle metadata, and optional manual readiness override snapshots.

### Description
- Extended `Incident` model in `backend/app/db/models.py` with a new `case_status` enum (`new`, `in_review`, `awaiting_evidence`, `awaiting_follow_up`, `ready_for_export`, `exported`, `escalated`, `closed`), ownership fields (`owner_user_id`, `owner_assigned_at_utc`, `owner_assigned_by_user_id`, `team_queue`), readiness/completeness snapshots (`readiness_state`, `completeness_percent`, `completeness_status`), SLA/activity timestamps (`first_reviewed_at_utc`, `last_activity_at_utc`, `ready_for_export_at_utc`) and `updated_at_utc` plus org-scoped indexes for queue/filter performance.
- Added `CaseNote`, `CaseTask`, and `CaseReadinessOverride` SQLAlchemy models (tables `case_notes`, `case_tasks`, `case_readiness_overrides`) with appropriate FK relationships, edit/soft-delete metadata for notes, task lifecycle/assignment/completion/cancel fields and enums (`case_task_type`, `case_task_status`, `case_task_priority`), and indexes to support common queries (org+incident, org+status+due date, deleted filtering, and readiness override lookups).
- Added Alembic revision `backend/app/db/migrations/versions/0018_add_case_management_tables_and_incident_fields.py` that creates the new enum types, adds incident columns and foreign keys, creates the three new tables and indexes, and provides a corresponding `downgrade()` path (including enum cleanup via `drop(..., checkfirst=True)`).
- Updated model tests in `backend/tests/test_model_improvements.py` to cover new FK enforcement, enum acceptance and defaults, index presence for incident/task queries, and persistence/soft-delete/default behaviour for new tables.

### Testing
- Ran linter with `make lint` which completed successfully (ruff checks passed). 
- Ran targeted unit tests with `cd backend && pytest tests/test_model_improvements.py tests/test_migration_integrity.py -v`, which completed successfully: all tests passed (`23 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4a810d60832195a7dd41a53f05d8)