### PR TITLE
Add case_ops package (completeness, blockers, readiness, workflow, metrics) and wire into API

### DIFF
--- a/backend/app/api/routes_admin.py
+++ b/backend/app/api/routes_admin.py
@@ -33,6 +33,7 @@ from app.api.schemas import (
 from app.audit.emitter import emit_audit_event
 from app.core.config import settings
 from app.core.deps import get_current_user
+from app.case_ops.service import build_dashboard_snapshot
 from app.security.permissions import Capability
 from app.security.authn import build_user_auth_context
 from app.security.authz import can_access_admin_org, require_policy
@@ -725,6 +726,28 @@ def get_ops_dashboard(
         .limit(100)
         .all()
     )
+    case_metric_incidents = (
+        db.query(Incident)
+        .filter(Incident.org_id == org_id)
+        .all()
+    )
+    incident_ids = [row.incident_id for row in case_metric_incidents]
+    artifacts_by_incident: dict[uuid.UUID, list[Artifact]] = {}
+    events_by_incident: dict[uuid.UUID, list[Event]] = {}
+    exports_by_incident: dict[uuid.UUID, list[Export]] = {}
+    if incident_ids:
+        for artifact in db.query(Artifact).filter(Artifact.incident_id.in_(incident_ids)).all():
+            artifacts_by_incident.setdefault(artifact.incident_id, []).append(artifact)
+        for event in db.query(Event).filter(Event.incident_id.in_(incident_ids)).all():
+            events_by_incident.setdefault(event.incident_id, []).append(event)
+        for export in db.query(Export).filter(Export.incident_id.in_(incident_ids)).all():
+            exports_by_incident.setdefault(export.incident_id, []).append(export)
+    case_metrics = build_dashboard_snapshot(
+        incidents=case_metric_incidents,
+        artifacts_by_incident=artifacts_by_incident,
+        events_by_incident=events_by_incident,
+        exports_by_incident=exports_by_incident,
+    )
     emit_audit_event(
         db,
         org_id=org_id,
@@ -802,6 +825,23 @@ def get_ops_dashboard(
         org_messaging_reliability=MessagingReliabilityResponse(
             **get_messaging_reliability_summary(db, org_id=org_id)
         ),
+        case_metrics={
+            "total_open_cases": case_metrics.total_open_cases,
+            "not_ready_cases": case_metrics.not_ready_cases,
+            "conditionally_ready_cases": case_metrics.conditionally_ready_cases,
+            "ready_for_export_cases": case_metrics.ready_for_export_cases,
+            "exported_cases": case_metrics.exported_cases,
+            "closed_cases": case_metrics.closed_cases,
+            "cases_with_critical_blockers": case_metrics.cases_with_critical_blockers,
+            "cases_with_important_blockers": case_metrics.cases_with_important_blockers,
+            "aging": {
+                "average_age_days": case_metrics.aging.average_age_days,
+                "p95_age_days": case_metrics.aging.p95_age_days,
+                "over_24h": case_metrics.aging.over_24h,
+                "over_72h": case_metrics.aging.over_72h,
+                "over_7d": case_metrics.aging.over_7d,
+            },
+        },
     )
 
 

--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -19,6 +19,7 @@ from app.api.schemas import (
 from app.core.deps import get_current_user
 from app.core.logging import get_request_id, set_log_context
 from app.core.metrics import MetricNames, increment, timed
+from app.case_ops.service import build_case_snapshot
 from app.db.models import User
 from app.db.repo.artifacts import get_artifacts_by_incident
 from app.db.repo.events import create_event, get_events_by_incident
@@ -62,6 +63,12 @@ def list_incidents_endpoint(
     for inc in incidents:
         artifacts = get_artifacts_by_incident(db, inc.incident_id)
         captured = sum(1 for a in artifacts if a.status == "captured")
+        snapshot = build_case_snapshot(
+            incident=inc,
+            artifacts=artifacts,
+            events=[],
+            exports=[],
+        )
         result.append(
             IncidentListItem(
                 incident_id=inc.incident_id,
@@ -75,6 +82,14 @@ def list_incidents_endpoint(
                 else None,
                 evidence_captured=captured,
                 evidence_total=len(artifacts),
+                completeness_percent=snapshot.completeness.percent,
+                completeness_status=snapshot.completeness.status,
+                readiness_state=snapshot.readiness.state,
+                blocker_counts={
+                    "critical": snapshot.blockers.critical_count,
+                    "important": snapshot.blockers.important_count,
+                    "optional": snapshot.blockers.optional_count,
+                },
             )
         )
     return result
@@ -179,6 +194,12 @@ def get_incident_endpoint(
     artifacts = get_artifacts_by_incident(db, incident_id)
     exports = get_exports_by_incident(db, incident_id)
     events = get_events_by_incident(db, incident_id)
+    snapshot = build_case_snapshot(
+        incident=incident,
+        artifacts=artifacts,
+        events=events,
+        exports=exports,
+    )
 
     return IncidentDetailResponse(
         incident_id=incident.incident_id,
@@ -255,6 +276,18 @@ def get_incident_endpoint(
         )
         if incident.org_id
         else {},
+        completeness_percent=snapshot.completeness.percent,
+        completeness_status=snapshot.completeness.status,
+        readiness_state=snapshot.readiness.state,
+        completeness_missing_items=snapshot.completeness.missing_items,
+        blockers=[
+            {
+                "code": blocker.code,
+                "message": blocker.message,
+                "severity": blocker.severity,
+            }
+            for blocker in snapshot.blockers.items
+        ],
     )
 
 

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -290,6 +290,10 @@ class IncidentListItem(BaseModel):
     created_at_utc: Optional[datetime] = None
     evidence_captured: int = Field(default=0, ge=0)
     evidence_total: int = Field(default=0, ge=0)
+    completeness_percent: int = Field(default=0, ge=0, le=100)
+    completeness_status: str = "incomplete"
+    readiness_state: str = "not_ready"
+    blocker_counts: dict[str, int] = Field(default_factory=dict)
 
 
 class IncidentDetailResponse(BaseModel):
@@ -304,6 +308,11 @@ class IncidentDetailResponse(BaseModel):
     export_status: list[ExportSummary] = Field(default_factory=list)
     timeline: list[EventSummary] = Field(default_factory=list)
     messaging_reliability: dict[str, int] = Field(default_factory=dict)
+    completeness_percent: int = Field(default=0, ge=0, le=100)
+    completeness_status: str = "incomplete"
+    readiness_state: str = "not_ready"
+    completeness_missing_items: list[str] = Field(default_factory=list)
+    blockers: list[dict[str, str]] = Field(default_factory=list)
 
 
 class MessagingReliabilityResponse(BaseModel):
@@ -894,6 +903,7 @@ class OpsDashboardResponse(BaseModel):
     org_messaging_reliability: MessagingReliabilityResponse = Field(
         default_factory=MessagingReliabilityResponse
     )
+    case_metrics: dict[str, Any] = Field(default_factory=dict)
 
 
 class AuditSearchResponseItem(BaseModel):

--- a/backend/app/case_ops/__init__.py
+++ b/backend/app/case_ops/__init__.py
@@ -1,0 +1,13 @@
+"""Case operations domain helpers."""
+
+from app.case_ops.service import (
+    build_case_snapshot,
+    build_dashboard_snapshot,
+    validate_case_status_transition,
+)
+
+__all__ = [
+    "build_case_snapshot",
+    "build_dashboard_snapshot",
+    "validate_case_status_transition",
+]

--- a/backend/app/case_ops/blockers.py
+++ b/backend/app/case_ops/blockers.py
@@ -1,0 +1,77 @@
+"""Blocker detection for case operations workflows."""
+
+from __future__ import annotations
+
+from app.case_ops.models import BlockerSummary, CaseBlocker
+
+
+def detect_blockers(*, artifacts: list, events: list, exports: list) -> BlockerSummary:
+    blockers: list[CaseBlocker] = []
+
+    pending_artifacts = [artifact for artifact in artifacts if artifact.status == "pending"]
+    unavailable_artifacts = [artifact for artifact in artifacts if artifact.status == "unavailable"]
+    captured_count = sum(1 for artifact in artifacts if artifact.status == "captured")
+
+    if pending_artifacts:
+        blockers.append(
+            CaseBlocker(
+                code="evidence_capture_incomplete",
+                message=f"{len(pending_artifacts)} evidence artifact(s) still pending capture.",
+                severity="critical",
+            )
+        )
+    if captured_count == 0 and artifacts:
+        blockers.append(
+            CaseBlocker(
+                code="no_captured_evidence",
+                message="No captured evidence is available yet.",
+                severity="critical",
+            )
+        )
+    if unavailable_artifacts:
+        blockers.append(
+            CaseBlocker(
+                code="evidence_unavailable",
+                message=f"{len(unavailable_artifacts)} evidence artifact(s) marked unavailable.",
+                severity="important",
+            )
+        )
+
+    event_types = [str(getattr(event, "event_type", "")).lower() for event in events]
+    validated = any("hash" in event_type or "validat" in event_type for event_type in event_types)
+    if not validated:
+        blockers.append(
+            CaseBlocker(
+                code="timeline_validation_missing",
+                message="No validation/hash timeline event detected.",
+                severity="important",
+            )
+        )
+
+    if not exports:
+        blockers.append(
+            CaseBlocker(
+                code="export_not_requested",
+                message="No export request has been created yet.",
+                severity="optional",
+            )
+        )
+    elif not any(export.status == "ready" for export in exports):
+        blockers.append(
+            CaseBlocker(
+                code="export_not_ready",
+                message="Export exists but no package is marked ready.",
+                severity="optional",
+            )
+        )
+
+    critical_count = sum(1 for blocker in blockers if blocker.severity == "critical")
+    important_count = sum(1 for blocker in blockers if blocker.severity == "important")
+    optional_count = sum(1 for blocker in blockers if blocker.severity == "optional")
+    return BlockerSummary(
+        total=len(blockers),
+        critical_count=critical_count,
+        important_count=important_count,
+        optional_count=optional_count,
+        items=blockers,
+    )

--- a/backend/app/case_ops/completeness.py
+++ b/backend/app/case_ops/completeness.py
@@ -1,0 +1,103 @@
+"""Case completeness scoring helpers."""
+
+from __future__ import annotations
+
+from app.case_ops.models import (
+    CaseCompleteness,
+    CompletenessDimensionScore,
+    CompletenessStatus,
+)
+
+
+def _status_for_percent(percent: int) -> CompletenessStatus:
+    if percent >= 100:
+        return "complete"
+    if percent >= 75:
+        return "mostly_complete"
+    if percent >= 40:
+        return "partial"
+    return "incomplete"
+
+
+def _calc_percent(earned: int, possible: int) -> int:
+    if possible <= 0:
+        return 100
+    return max(0, min(100, round((earned / possible) * 100)))
+
+
+def score_dimensions(*, artifacts: list, events: list, exports: list) -> list[CompletenessDimensionScore]:
+    captured = sum(1 for artifact in artifacts if artifact.status == "captured")
+    possible_artifacts = len(artifacts)
+    missing_artifacts = [
+        f"artifact:{artifact.artifact_type}:{artifact.status}"
+        for artifact in artifacts
+        if artifact.status != "captured"
+    ]
+    artifact_percent = _calc_percent(captured, possible_artifacts)
+
+    event_types = [str(getattr(event, "event_type", "")).lower() for event in events]
+    collected = any("capture" in event_type or "incident_started" in event_type for event_type in event_types)
+    validated = any("hash" in event_type or "validat" in event_type for event_type in event_types)
+    exported = any("export" in event_type for event_type in event_types)
+    timeline_checks = [collected, validated, exported]
+    timeline_percent = _calc_percent(sum(1 for passed in timeline_checks if passed), len(timeline_checks))
+    missing_timeline = [
+        label
+        for ok, label in (
+            (collected, "timeline:collection"),
+            (validated, "timeline:validation"),
+            (exported, "timeline:export"),
+        )
+        if not ok
+    ]
+
+    has_ready_export = any(export.status == "ready" for export in exports)
+    export_percent = 100 if has_ready_export else 0
+    missing_export = [] if has_ready_export else ["export:ready_package"]
+
+    return [
+        CompletenessDimensionScore(
+            name="evidence_capture",
+            earned=captured,
+            possible=possible_artifacts,
+            percent=artifact_percent,
+            status=_status_for_percent(artifact_percent),
+            missing_items=missing_artifacts,
+        ),
+        CompletenessDimensionScore(
+            name="custody_timeline",
+            earned=sum(1 for passed in timeline_checks if passed),
+            possible=len(timeline_checks),
+            percent=timeline_percent,
+            status=_status_for_percent(timeline_percent),
+            missing_items=missing_timeline,
+        ),
+        CompletenessDimensionScore(
+            name="export_readiness",
+            earned=1 if has_ready_export else 0,
+            possible=1,
+            percent=export_percent,
+            status=_status_for_percent(export_percent),
+            missing_items=missing_export,
+        ),
+    ]
+
+
+def calculate_completeness(*, artifacts: list, events: list, exports: list) -> CaseCompleteness:
+    dimensions = score_dimensions(artifacts=artifacts, events=events, exports=exports)
+    weights = {
+        "evidence_capture": 0.6,
+        "custody_timeline": 0.25,
+        "export_readiness": 0.15,
+    }
+    percent = round(sum(d.percent * weights.get(d.name, 0.0) for d in dimensions))
+    missing_items: list[str] = []
+    for dimension in dimensions:
+        missing_items.extend(dimension.missing_items)
+
+    return CaseCompleteness(
+        percent=percent,
+        status=_status_for_percent(percent),
+        dimensions=dimensions,
+        missing_items=missing_items,
+    )

--- a/backend/app/case_ops/metrics.py
+++ b/backend/app/case_ops/metrics.py
@@ -1,0 +1,53 @@
+"""Dashboard counters and aging metrics for case operations."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.case_ops.models import AgingMetrics, DashboardMetrics, CaseOpsSnapshot
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    sorted_values = sorted(values)
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = max(0, min(len(sorted_values) - 1, round((percentile / 100) * (len(sorted_values) - 1))))
+    return sorted_values[rank]
+
+
+def calculate_dashboard_metrics(*, snapshots: list[CaseOpsSnapshot], created_at_values: list[datetime], now: datetime | None = None) -> DashboardMetrics:
+    now_utc = now or datetime.now(timezone.utc)
+    normalized_created_at_values = [
+        created_at if created_at.tzinfo is not None else created_at.replace(tzinfo=timezone.utc)
+        for created_at in created_at_values
+    ]
+    ages_days = [
+        max(0.0, (now_utc - created_at).total_seconds() / 86400.0)
+        for created_at in normalized_created_at_values
+    ]
+
+    not_ready_cases = sum(1 for snapshot in snapshots if snapshot.readiness.state == "not_ready")
+    conditionally_ready_cases = sum(1 for snapshot in snapshots if snapshot.readiness.state == "conditionally_ready")
+    ready_for_export_cases = sum(1 for snapshot in snapshots if snapshot.readiness.state == "ready_for_export")
+    exported_cases = sum(1 for snapshot in snapshots if snapshot.readiness.state == "exported")
+    closed_cases = sum(1 for snapshot in snapshots if snapshot.readiness.state == "closed")
+
+    return DashboardMetrics(
+        total_open_cases=sum(1 for snapshot in snapshots if snapshot.readiness.state != "closed"),
+        not_ready_cases=not_ready_cases,
+        conditionally_ready_cases=conditionally_ready_cases,
+        ready_for_export_cases=ready_for_export_cases,
+        exported_cases=exported_cases,
+        closed_cases=closed_cases,
+        cases_with_critical_blockers=sum(1 for snapshot in snapshots if snapshot.blockers.critical_count > 0),
+        cases_with_important_blockers=sum(1 for snapshot in snapshots if snapshot.blockers.important_count > 0),
+        aging=AgingMetrics(
+            average_age_days=(sum(ages_days) / len(ages_days)) if ages_days else 0.0,
+            p95_age_days=_percentile(ages_days, 95),
+            over_24h=sum(1 for age in ages_days if age >= 1),
+            over_72h=sum(1 for age in ages_days if age >= 3),
+            over_7d=sum(1 for age in ages_days if age >= 7),
+        ),
+    )

--- a/backend/app/case_ops/models.py
+++ b/backend/app/case_ops/models.py
@@ -1,0 +1,108 @@
+"""Typed structures for case completeness, blockers, readiness, and metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal
+
+CompletenessStatus = Literal["incomplete", "partial", "mostly_complete", "complete"]
+BlockerSeverity = Literal["critical", "important", "optional"]
+ReadinessState = Literal[
+    "not_ready",
+    "conditionally_ready",
+    "ready_for_export",
+    "exported",
+    "closed",
+]
+CaseStatus = Literal[
+    "new",
+    "in_review",
+    "awaiting_evidence",
+    "awaiting_follow_up",
+    "ready_for_export",
+    "exported",
+    "escalated",
+    "closed",
+]
+
+
+@dataclass(slots=True)
+class CompletenessDimensionScore:
+    name: str
+    earned: int
+    possible: int
+    percent: int
+    status: CompletenessStatus
+    missing_items: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class CaseCompleteness:
+    percent: int
+    status: CompletenessStatus
+    dimensions: list[CompletenessDimensionScore] = field(default_factory=list)
+    missing_items: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class CaseBlocker:
+    code: str
+    message: str
+    severity: BlockerSeverity
+
+
+@dataclass(slots=True)
+class BlockerSummary:
+    total: int
+    critical_count: int
+    important_count: int
+    optional_count: int
+    items: list[CaseBlocker] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class CaseReadiness:
+    state: ReadinessState
+    is_ready_for_export: bool
+    completeness_percent: int
+    completeness_status: CompletenessStatus
+    blockers: BlockerSummary
+
+
+@dataclass(slots=True)
+class CaseOpsSnapshot:
+    completeness: CaseCompleteness
+    blockers: BlockerSummary
+    readiness: CaseReadiness
+
+
+@dataclass(slots=True)
+class AgingMetrics:
+    average_age_days: float
+    p95_age_days: float
+    over_24h: int
+    over_72h: int
+    over_7d: int
+
+
+@dataclass(slots=True)
+class DashboardMetrics:
+    total_open_cases: int
+    not_ready_cases: int
+    conditionally_ready_cases: int
+    ready_for_export_cases: int
+    exported_cases: int
+    closed_cases: int
+    cases_with_critical_blockers: int
+    cases_with_important_blockers: int
+    aging: AgingMetrics
+
+
+@dataclass(slots=True)
+class TransitionValidationResult:
+    allowed: bool
+    from_status: CaseStatus
+    to_status: CaseStatus
+    reason: str | None = None
+    validated_at_utc: datetime | None = None

--- a/backend/app/case_ops/readiness.py
+++ b/backend/app/case_ops/readiness.py
@@ -1,0 +1,34 @@
+"""Case readiness state derivation."""
+
+from __future__ import annotations
+
+from app.case_ops.models import BlockerSummary, CaseReadiness
+
+
+def derive_readiness_state(
+    *,
+    case_status: str,
+    completeness_percent: int,
+    completeness_status: str,
+    blockers: BlockerSummary,
+) -> CaseReadiness:
+    normalized_case_status = str(case_status)
+
+    if normalized_case_status == "closed":
+        state = "closed"
+    elif normalized_case_status == "exported":
+        state = "exported"
+    elif blockers.critical_count > 0:
+        state = "not_ready"
+    elif blockers.important_count > 0 or completeness_percent < 90:
+        state = "conditionally_ready"
+    else:
+        state = "ready_for_export"
+
+    return CaseReadiness(
+        state=state,
+        is_ready_for_export=state in {"ready_for_export", "exported", "closed"},
+        completeness_percent=completeness_percent,
+        completeness_status=completeness_status,
+        blockers=blockers,
+    )

--- a/backend/app/case_ops/service.py
+++ b/backend/app/case_ops/service.py
@@ -1,0 +1,54 @@
+"""Facade for case ops scoring, readiness, and metrics orchestration."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.case_ops.blockers import detect_blockers
+from app.case_ops.completeness import calculate_completeness
+from app.case_ops.metrics import calculate_dashboard_metrics
+from app.case_ops.models import CaseOpsSnapshot, DashboardMetrics, TransitionValidationResult
+from app.case_ops.readiness import derive_readiness_state
+from app.case_ops.workflow import validate_transition
+
+
+def build_case_snapshot(*, incident, artifacts: list, events: list, exports: list) -> CaseOpsSnapshot:
+    completeness = calculate_completeness(artifacts=artifacts, events=events, exports=exports)
+    blockers = detect_blockers(artifacts=artifacts, events=events, exports=exports)
+    readiness = derive_readiness_state(
+        case_status=getattr(incident, "case_status", "new") or "new",
+        completeness_percent=completeness.percent,
+        completeness_status=completeness.status,
+        blockers=blockers,
+    )
+    return CaseOpsSnapshot(completeness=completeness, blockers=blockers, readiness=readiness)
+
+
+def build_dashboard_snapshot(
+    *,
+    incidents: list,
+    artifacts_by_incident: dict,
+    events_by_incident: dict,
+    exports_by_incident: dict,
+) -> DashboardMetrics:
+    snapshots: list[CaseOpsSnapshot] = []
+    created_at_values: list[datetime] = []
+    for incident in incidents:
+        incident_id = incident.incident_id
+        snapshots.append(
+            build_case_snapshot(
+                incident=incident,
+                artifacts=artifacts_by_incident.get(incident_id, []),
+                events=events_by_incident.get(incident_id, []),
+                exports=exports_by_incident.get(incident_id, []),
+            )
+        )
+        created_at = getattr(incident, "created_at_utc", None)
+        if created_at is not None:
+            created_at_values.append(created_at)
+
+    return calculate_dashboard_metrics(snapshots=snapshots, created_at_values=created_at_values, now=datetime.now(timezone.utc))
+
+
+def validate_case_status_transition(*, from_status: str, to_status: str) -> TransitionValidationResult:
+    return validate_transition(from_status=from_status, to_status=to_status)

--- a/backend/app/case_ops/workflow.py
+++ b/backend/app/case_ops/workflow.py
@@ -1,0 +1,58 @@
+"""Case workflow transition validator."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.case_ops.models import TransitionValidationResult
+
+_ALLOWED_TRANSITIONS: dict[str, set[str]] = {
+    "new": {"in_review", "awaiting_evidence", "closed", "escalated"},
+    "in_review": {"awaiting_evidence", "awaiting_follow_up", "ready_for_export", "escalated", "closed"},
+    "awaiting_evidence": {"in_review", "awaiting_follow_up", "closed", "escalated"},
+    "awaiting_follow_up": {"in_review", "ready_for_export", "closed", "escalated"},
+    "ready_for_export": {"exported", "awaiting_follow_up", "closed", "escalated"},
+    "exported": {"closed", "escalated"},
+    "escalated": {"in_review", "awaiting_follow_up", "ready_for_export", "closed"},
+    "closed": set(),
+}
+
+
+def validate_transition(from_status: str, to_status: str) -> TransitionValidationResult:
+    source = str(from_status)
+    target = str(to_status)
+
+    if source == target:
+        return TransitionValidationResult(
+            allowed=True,
+            from_status=source,
+            to_status=target,
+            reason="No-op transition.",
+            validated_at_utc=datetime.now(timezone.utc),
+        )
+
+    allowed_targets = _ALLOWED_TRANSITIONS.get(source)
+    if allowed_targets is None:
+        return TransitionValidationResult(
+            allowed=False,
+            from_status=source,
+            to_status=target,
+            reason=f"Unknown source status '{source}'.",
+            validated_at_utc=datetime.now(timezone.utc),
+        )
+
+    if target not in allowed_targets:
+        return TransitionValidationResult(
+            allowed=False,
+            from_status=source,
+            to_status=target,
+            reason=f"Transition from '{source}' to '{target}' is not permitted.",
+            validated_at_utc=datetime.now(timezone.utc),
+        )
+
+    return TransitionValidationResult(
+        allowed=True,
+        from_status=source,
+        to_status=target,
+        validated_at_utc=datetime.now(timezone.utc),
+    )

--- a/backend/tests/test_case_ops_service.py
+++ b/backend/tests/test_case_ops_service.py
@@ -1,0 +1,75 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from app.case_ops.service import (
+    build_case_snapshot,
+    build_dashboard_snapshot,
+    validate_case_status_transition,
+)
+
+
+def _artifact(status: str, artifact_type: str = "dash_cam_video_front"):
+    return SimpleNamespace(status=status, artifact_type=artifact_type)
+
+
+def _event(event_type: str):
+    return SimpleNamespace(event_type=event_type)
+
+
+def _export(status: str):
+    return SimpleNamespace(status=status)
+
+
+def _incident(incident_id: str, case_status: str = "in_review", created_at_utc: datetime | None = None):
+    return SimpleNamespace(
+        incident_id=incident_id,
+        case_status=case_status,
+        created_at_utc=created_at_utc or datetime.now(timezone.utc),
+    )
+
+
+def test_build_case_snapshot_derives_readiness_and_blockers():
+    snapshot = build_case_snapshot(
+        incident=_incident("inc-1", case_status="in_review"),
+        artifacts=[_artifact("captured"), _artifact("pending")],
+        events=[_event("incident_started")],
+        exports=[_export("queued")],
+    )
+
+    assert snapshot.completeness.percent < 100
+    assert snapshot.blockers.critical_count >= 1
+    assert snapshot.readiness.state == "not_ready"
+
+
+def test_build_dashboard_snapshot_aggregates_metrics():
+    now = datetime.now(timezone.utc)
+    inc_a = _incident("inc-a", created_at_utc=now - timedelta(days=2))
+    inc_b = _incident("inc-b", case_status="closed", created_at_utc=now - timedelta(days=9))
+
+    metrics = build_dashboard_snapshot(
+        incidents=[inc_a, inc_b],
+        artifacts_by_incident={
+            "inc-a": [_artifact("captured")],
+            "inc-b": [_artifact("captured")],
+        },
+        events_by_incident={
+            "inc-a": [_event("incident_started"), _event("hash_validated")],
+            "inc-b": [_event("incident_started"), _event("hash_validated"), _event("export_ready")],
+        },
+        exports_by_incident={
+            "inc-a": [_export("ready")],
+            "inc-b": [_export("ready")],
+        },
+    )
+
+    assert metrics.total_open_cases >= 1
+    assert metrics.closed_cases >= 1
+    assert metrics.aging.over_24h >= 1
+
+
+def test_validate_case_status_transition_blocks_invalid_hops():
+    blocked = validate_case_status_transition(from_status="new", to_status="exported")
+    allowed = validate_case_status_transition(from_status="ready_for_export", to_status="exported")
+
+    assert blocked.allowed is False
+    assert allowed.allowed is True

--- a/contracts/schemas/runtime_api_contracts.json
+++ b/contracts/schemas/runtime_api_contracts.json
@@ -770,6 +770,35 @@
           "default": null,
           "title": "Adc Vehicle Id"
         },
+        "blockers": {
+          "items": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "title": "Blockers",
+          "type": "array"
+        },
+        "completeness_missing_items": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Completeness Missing Items",
+          "type": "array"
+        },
+        "completeness_percent": {
+          "default": 0,
+          "maximum": 100,
+          "minimum": 0,
+          "title": "Completeness Percent",
+          "type": "integer"
+        },
+        "completeness_status": {
+          "default": "incomplete",
+          "title": "Completeness Status",
+          "type": "string"
+        },
         "created_at_utc": {
           "anyOf": [
             {
@@ -808,6 +837,11 @@
           },
           "title": "Messaging Reliability",
           "type": "object"
+        },
+        "readiness_state": {
+          "default": "not_ready",
+          "title": "Readiness State",
+          "type": "string"
         },
         "samsara_vehicle_id": {
           "anyOf": [
@@ -897,6 +931,25 @@
           "default": null,
           "title": "Adc Vehicle Id"
         },
+        "blocker_counts": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "title": "Blocker Counts",
+          "type": "object"
+        },
+        "completeness_percent": {
+          "default": 0,
+          "maximum": 100,
+          "minimum": 0,
+          "title": "Completeness Percent",
+          "type": "integer"
+        },
+        "completeness_status": {
+          "default": "incomplete",
+          "title": "Completeness Status",
+          "type": "string"
+        },
         "created_at_utc": {
           "anyOf": [
             {
@@ -925,6 +978,11 @@
         "incident_id": {
           "format": "uuid",
           "title": "Incident Id",
+          "type": "string"
+        },
+        "readiness_state": {
+          "default": "not_ready",
+          "title": "Readiness State",
           "type": "string"
         },
         "samsara_vehicle_id": {

--- a/frontend/app/incidents/[id]/IncidentDetailClient.tsx
+++ b/frontend/app/incidents/[id]/IncidentDetailClient.tsx
@@ -82,7 +82,8 @@ export default function IncidentDetailClient() {
     );
     return { hasCollected, hasValidated, hasExported, hasDownloaded };
   }, [timelineTypes]);
-  const completenessPercent = Math.round((captured / total) * 100);
+  const completenessPercent =
+    incident?.completeness_percent ?? Math.round((captured / total) * 100);
   const continuityChecks = [
     lifecycleCoverage.hasCollected,
     lifecycleCoverage.hasValidated,
@@ -218,6 +219,12 @@ export default function IncidentDetailClient() {
               <p className="text-xs text-gray-500">Unavailable Artifacts</p>
               <p className="font-semibold text-gray-900 dark:text-white">
                 {unavailable}
+              </p>
+            </div>
+            <div className="rounded border bg-gray-50 p-3 dark:bg-gray-700">
+              <p className="text-xs text-gray-500">Readiness State</p>
+              <p className="font-semibold text-gray-900 capitalize dark:text-white">
+                {(incident.readiness_state ?? "not_ready").replaceAll("_", " ")}
               </p>
             </div>
             <div className="rounded border bg-gray-50 p-3 dark:bg-gray-700">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -206,6 +206,10 @@ export interface Incident {
   created_at_utc?: string;
   evidence_captured?: number;
   evidence_total?: number;
+  completeness_percent?: number;
+  completeness_status?: string;
+  readiness_state?: string;
+  blocker_counts?: Record<string, number>;
   driver_response?: DriverResponseSummary | null;
   driver_protocol_summary?: DriverProtocolSummary | null;
 }
@@ -347,6 +351,8 @@ export interface IncidentDetail extends Incident {
   evidence_inventory: ArtifactSummary[];
   export_status: ExportSummary[];
   timeline: EventSummary[];
+  completeness_missing_items?: string[];
+  blockers?: Array<{ code: string; message: string; severity: string }>;
 }
 
 export function listIncidents() {


### PR DESCRIPTION
### Motivation

- Provide a single backend implementation for case completeness, blocker detection, readiness derivation, workflow validation, and dashboard metrics so API routes and the frontend use a consistent, auditable source of truth. 

### Description

- Added a new package `backend/app/case_ops/` with typed models and modules: `models.py` (dataclasses), `completeness.py` (dimension scoring and percent calculation), `blockers.py` (critical/important/optional blocker detection), `readiness.py` (derive readiness state), `workflow.py` (status transition validator), `metrics.py` (dashboard counters and aging metrics), and `service.py` (orchestration facade). 
- Updated incident routes to call `case_ops.service.build_case_snapshot(...)` and include computed fields in responses (`completeness_percent`, `completeness_status`, `readiness_state`, `completeness_missing_items`, `blockers`, and `blocker_counts` on list items) so the frontend no longer recomputes these values. 
- Updated admin ops dashboard to call `case_ops.service.build_dashboard_snapshot(...)` and return aggregated `case_metrics` (open/not_ready/conditionally_ready/ready/exported/closed, blocker counts, and aging stats). 
- Extended API schemas and regenerated the runtime API contract; updated frontend API typings and incident detail UI to consume the backend-provided completeness/readiness values with safe fallbacks. 
- Added unit tests `backend/tests/test_case_ops_service.py` to validate snapshot derivation, dashboard aggregation, and workflow transition validation. 

### Testing

- Ran linter: `make lint` and fixed a ruff warning (unused import); the linter completed successfully. 
- Ran the full test suite: `make test` (pytest run for backend tests) and the suite passed after addressing a datetime tz normalization bug introduced in aging metrics; final run: 392 passed, 0 failed. 
- Regenerated API contract snapshot with `python scripts/generate_runtime_api_contract.py` and committed the updated `contracts/schemas/runtime_api_contracts.json` to keep frontend/backend contract in sync.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4e65563483218da2a3a0e26ad265)