### PR TITLE
Add MissingItem blocker classifier and readiness linkage

### DIFF
--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -285,6 +285,10 @@ def get_incident_endpoint(
                 "code": blocker.code,
                 "message": blocker.message,
                 "severity": blocker.severity,
+                "category": blocker.missing_item.category,
+                "resolvableBy": blocker.missing_item.resolvableBy,
+                "actionHint": blocker.missing_item.actionHint,
+                "blocksReadiness": blocker.blocks_readiness,
             }
             for blocker in snapshot.blockers.items
         ],

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -312,7 +312,7 @@ class IncidentDetailResponse(BaseModel):
     completeness_status: str = "incomplete"
     readiness_state: str = "not_ready"
     completeness_missing_items: list[str] = Field(default_factory=list)
-    blockers: list[dict[str, str]] = Field(default_factory=list)
+    blockers: list[dict[str, Any]] = Field(default_factory=list)
 
 
 class MessagingReliabilityResponse(BaseModel):

--- a/backend/app/case_ops/blockers.py
+++ b/backend/app/case_ops/blockers.py
@@ -2,7 +2,49 @@
 
 from __future__ import annotations
 
-from app.case_ops.models import BlockerSummary, CaseBlocker
+from app.case_ops.models import BlockerSeverity, BlockerSummary, CaseBlocker, MissingItem, MissingItemCategory
+
+
+def _category_for_artifact(artifact_type: str) -> MissingItemCategory:
+    normalized = artifact_type.lower()
+    if "dash" in normalized and "cam" in normalized:
+        return "dashcam"
+    if "telem" in normalized or "gps" in normalized or "can" in normalized:
+        return "telematics"
+    if "driver" in normalized or "statement" in normalized:
+        return "driver_input"
+    if "document" in normalized or "report" in normalized or "pdf" in normalized:
+        return "document"
+    if "video" in normalized or "photo" in normalized or "image" in normalized or "media" in normalized:
+        return "media"
+    return "internal_review"
+
+
+def _build_blocker(
+    *,
+    code: str,
+    message: str,
+    severity: BlockerSeverity,
+    category: MissingItemCategory,
+    resolvable_by: str,
+    action_hint: str,
+    blocks_readiness: bool,
+) -> CaseBlocker:
+    missing_item = MissingItem(
+        code=code,
+        category=category,
+        severity=severity,
+        message=message,
+        resolvableBy=resolvable_by,
+        actionHint=action_hint,
+    )
+    return CaseBlocker(
+        code=code,
+        message=message,
+        severity=severity,
+        missing_item=missing_item,
+        blocks_readiness=blocks_readiness,
+    )
 
 
 def detect_blockers(*, artifacts: list, events: list, exports: list) -> BlockerSummary:
@@ -13,27 +55,41 @@ def detect_blockers(*, artifacts: list, events: list, exports: list) -> BlockerS
     captured_count = sum(1 for artifact in artifacts if artifact.status == "captured")
 
     if pending_artifacts:
+        category = _category_for_artifact(str(getattr(pending_artifacts[0], "artifact_type", "internal_review")))
         blockers.append(
-            CaseBlocker(
+            _build_blocker(
                 code="evidence_capture_incomplete",
                 message=f"{len(pending_artifacts)} evidence artifact(s) still pending capture.",
                 severity="critical",
+                category=category,
+                resolvable_by="evidence_ops",
+                action_hint="Capture or ingest pending evidence artifacts before review handoff.",
+                blocks_readiness=True,
             )
         )
     if captured_count == 0 and artifacts:
         blockers.append(
-            CaseBlocker(
+            _build_blocker(
                 code="no_captured_evidence",
                 message="No captured evidence is available yet.",
                 severity="critical",
+                category="internal_review",
+                resolvable_by="incident_response",
+                action_hint="Confirm device connectivity and capture at least one required artifact.",
+                blocks_readiness=True,
             )
         )
     if unavailable_artifacts:
+        category = _category_for_artifact(str(getattr(unavailable_artifacts[0], "artifact_type", "internal_review")))
         blockers.append(
-            CaseBlocker(
+            _build_blocker(
                 code="evidence_unavailable",
                 message=f"{len(unavailable_artifacts)} evidence artifact(s) marked unavailable.",
                 severity="important",
+                category=category,
+                resolvable_by="evidence_ops",
+                action_hint="Retry evidence pull or document alternate source coverage.",
+                blocks_readiness=True,
             )
         )
 
@@ -41,37 +97,51 @@ def detect_blockers(*, artifacts: list, events: list, exports: list) -> BlockerS
     validated = any("hash" in event_type or "validat" in event_type for event_type in event_types)
     if not validated:
         blockers.append(
-            CaseBlocker(
+            _build_blocker(
                 code="timeline_validation_missing",
                 message="No validation/hash timeline event detected.",
                 severity="important",
+                category="internal_review",
+                resolvable_by="case_reviewer",
+                action_hint="Run timeline validation and record hash verification event.",
+                blocks_readiness=True,
             )
         )
 
     if not exports:
         blockers.append(
-            CaseBlocker(
+            _build_blocker(
                 code="export_not_requested",
                 message="No export request has been created yet.",
                 severity="optional",
+                category="document",
+                resolvable_by="case_reviewer",
+                action_hint="Create an export request when legal packet generation is needed.",
+                blocks_readiness=False,
             )
         )
     elif not any(export.status == "ready" for export in exports):
         blockers.append(
-            CaseBlocker(
+            _build_blocker(
                 code="export_not_ready",
                 message="Export exists but no package is marked ready.",
                 severity="optional",
+                category="document",
+                resolvable_by="export_pipeline",
+                action_hint="Allow export processing to complete or retry failed export jobs.",
+                blocks_readiness=False,
             )
         )
 
     critical_count = sum(1 for blocker in blockers if blocker.severity == "critical")
     important_count = sum(1 for blocker in blockers if blocker.severity == "important")
     optional_count = sum(1 for blocker in blockers if blocker.severity == "optional")
+    readiness_blockers = [blocker.code for blocker in blockers if blocker.blocks_readiness]
     return BlockerSummary(
         total=len(blockers),
         critical_count=critical_count,
         important_count=important_count,
         optional_count=optional_count,
+        readiness_blocker_codes=readiness_blockers,
         items=blockers,
     )

--- a/backend/app/case_ops/models.py
+++ b/backend/app/case_ops/models.py
@@ -8,6 +8,14 @@ from typing import Literal
 
 CompletenessStatus = Literal["incomplete", "partial", "mostly_complete", "complete"]
 BlockerSeverity = Literal["critical", "important", "optional"]
+MissingItemCategory = Literal[
+    "driver_input",
+    "media",
+    "telematics",
+    "dashcam",
+    "document",
+    "internal_review",
+]
 ReadinessState = Literal[
     "not_ready",
     "conditionally_ready",
@@ -46,10 +54,22 @@ class CaseCompleteness:
 
 
 @dataclass(slots=True)
+class MissingItem:
+    code: str
+    category: MissingItemCategory
+    severity: BlockerSeverity
+    message: str
+    resolvableBy: str
+    actionHint: str
+
+
+@dataclass(slots=True)
 class CaseBlocker:
     code: str
     message: str
     severity: BlockerSeverity
+    missing_item: MissingItem
+    blocks_readiness: bool = False
 
 
 @dataclass(slots=True)
@@ -58,6 +78,7 @@ class BlockerSummary:
     critical_count: int
     important_count: int
     optional_count: int
+    readiness_blocker_codes: list[str] = field(default_factory=list)
     items: list[CaseBlocker] = field(default_factory=list)
 
 
@@ -68,6 +89,7 @@ class CaseReadiness:
     completeness_percent: int
     completeness_status: CompletenessStatus
     blockers: BlockerSummary
+    blocking_codes: list[str] = field(default_factory=list)
 
 
 @dataclass(slots=True)

--- a/backend/app/case_ops/readiness.py
+++ b/backend/app/case_ops/readiness.py
@@ -18,9 +18,9 @@ def derive_readiness_state(
         state = "closed"
     elif normalized_case_status == "exported":
         state = "exported"
-    elif blockers.critical_count > 0:
+    elif blockers.readiness_blocker_codes and blockers.critical_count > 0:
         state = "not_ready"
-    elif blockers.important_count > 0 or completeness_percent < 90:
+    elif blockers.readiness_blocker_codes or completeness_percent < 90:
         state = "conditionally_ready"
     else:
         state = "ready_for_export"
@@ -31,4 +31,5 @@ def derive_readiness_state(
         completeness_percent=completeness_percent,
         completeness_status=completeness_status,
         blockers=blockers,
+        blocking_codes=list(blockers.readiness_blocker_codes),
     )

--- a/backend/tests/test_case_ops_blockers_classifier.py
+++ b/backend/tests/test_case_ops_blockers_classifier.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.case_ops.blockers import detect_blockers
+
+
+def _artifact(status: str, artifact_type: str):
+    return SimpleNamespace(status=status, artifact_type=artifact_type)
+
+
+@pytest.mark.parametrize(
+    ("artifact_type", "expected_category"),
+    [
+        ("driver_statement", "driver_input"),
+        ("incident_photo", "media"),
+        ("telematics_snapshot", "telematics"),
+        ("dash_cam_video_front", "dashcam"),
+        ("police_document_pdf", "document"),
+        ("unknown_custom_feed", "internal_review"),
+    ],
+)
+def test_pending_artifact_category_classifier(artifact_type: str, expected_category: str):
+    summary = detect_blockers(
+        artifacts=[_artifact("pending", artifact_type)],
+        events=[SimpleNamespace(event_type="incident_started"), SimpleNamespace(event_type="hash_validated")],
+        exports=[SimpleNamespace(status="ready")],
+    )
+
+    pending_blocker = next(item for item in summary.items if item.code == "evidence_capture_incomplete")
+    assert pending_blocker.missing_item.category == expected_category
+    assert pending_blocker.missing_item.resolvableBy
+    assert pending_blocker.missing_item.actionHint

--- a/backend/tests/test_case_ops_service.py
+++ b/backend/tests/test_case_ops_service.py
@@ -6,6 +6,7 @@ from app.case_ops.service import (
     build_dashboard_snapshot,
     validate_case_status_transition,
 )
+from app.case_ops.blockers import detect_blockers
 
 
 def _artifact(status: str, artifact_type: str = "dash_cam_video_front"):
@@ -73,3 +74,34 @@ def test_validate_case_status_transition_blocks_invalid_hops():
 
     assert blocked.allowed is False
     assert allowed.allowed is True
+
+
+def test_detect_blockers_classifies_dashcam_and_readiness_linkage():
+    summary = detect_blockers(
+        artifacts=[_artifact("pending", "dash_cam_video_front"), _artifact("captured", "telematics_gps")],
+        events=[_event("incident_started"), _event("capture_completed")],
+        exports=[],
+    )
+
+    by_code = {blocker.code: blocker for blocker in summary.items}
+    assert by_code["evidence_capture_incomplete"].missing_item.category == "dashcam"
+    assert by_code["evidence_capture_incomplete"].blocks_readiness is True
+    assert "evidence_capture_incomplete" in summary.readiness_blocker_codes
+    assert by_code["export_not_requested"].missing_item.category == "document"
+    assert by_code["export_not_requested"].blocks_readiness is False
+
+
+def test_detect_blockers_classifies_driver_input_and_telematics_unavailable():
+    summary = detect_blockers(
+        artifacts=[
+            _artifact("unavailable", "driver_statement"),
+            _artifact("unavailable", "telematics_snapshot"),
+            _artifact("captured", "incident_photo"),
+        ],
+        events=[_event("incident_started"), _event("hash_validated")],
+        exports=[_export("ready")],
+    )
+
+    blocker = next(item for item in summary.items if item.code == "evidence_unavailable")
+    assert blocker.missing_item.category == "driver_input"
+    assert blocker.missing_item.severity == "important"

--- a/contracts/schemas/runtime_api_contracts.json
+++ b/contracts/schemas/runtime_api_contracts.json
@@ -772,9 +772,7 @@
         },
         "blockers": {
           "items": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": true,
             "type": "object"
           },
           "title": "Blockers",


### PR DESCRIPTION
### Motivation
- Provide structured blocker metadata so case ops can surface why evidence or workflow items are missing and how to resolve them.  
- Classify evidence/workflow gaps into actionable categories (`driver_input`, `media`, `telematics`, `dashcam`, `document`, `internal_review`).  
- Differentiate severity levels and mark which blockers should influence readiness decisions.  
- Expose richer blocker details through the incident response so UIs and downstream services can act on them.

### Description
- Add a `MissingItem` dataclass and extend `CaseBlocker`, `BlockerSummary`, and `CaseReadiness` to carry missing-item metadata and readiness linkage (`readiness_blocker_codes`, `blocking_codes`).  
- Implement `_category_for_artifact` and `_build_blocker` in `backend/app/case_ops/blockers.py` and update `detect_blockers` to emit `MissingItem` objects with fields `code`, `category`, `severity`, `message`, `resolvableBy`, and `actionHint`, and to flag `blocks_readiness`.  
- Update readiness derivation in `backend/app/case_ops/readiness.py` to consider `readiness_blocker_codes` when deciding `not_ready` vs `conditionally_ready` and to return explicit `blocking_codes`.  
- Expose the enriched blocker payload from the incident endpoint and relax the response schema typing to accept additional fields (`category`, `resolvableBy`, `actionHint`, `blocksReadiness`).  
- Add unit tests covering category classification and readiness linkage (`backend/tests/test_case_ops_blockers_classifier.py`) and extend `backend/tests/test_case_ops_service.py` with representative scenarios.

### Testing
- Ran the unit tests for the changed areas with `python -m pytest tests/test_case_ops_service.py tests/test_case_ops_blockers_classifier.py -q`, which completed successfully (`11 passed`).  
- Ran the linter with `python -m ruff check app/case_ops app/api/routes_incidents.py app/api/schemas.py tests/test_case_ops_service.py tests/test_case_ops_blockers_classifier.py`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc527f15b48321b8790ae6ce7b5963)