### PR TITLE
Enforce guarded incident case-status transitions

### DIFF
--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -15,11 +15,14 @@ from app.api.schemas import (
     ExportSummary,
     IncidentDetailResponse,
     IncidentListItem,
+    IncidentStatusPatchRequest,
+    IncidentStatusPatchResponse,
 )
+from app.audit.emitter import emit_audit_event
 from app.core.deps import get_current_user
 from app.core.logging import get_request_id, set_log_context
 from app.core.metrics import MetricNames, increment, timed
-from app.case_ops.service import build_case_snapshot
+from app.case_ops.service import build_case_snapshot, validate_case_status_transition
 from app.db.models import User
 from app.db.repo.artifacts import get_artifacts_by_incident
 from app.db.repo.events import create_event, get_events_by_incident
@@ -30,7 +33,10 @@ from app.db.session import get_db
 from app.domain.system_event_types import SystemEventType
 from app.domain.packet_profiles import get_default_packet_profile
 from app.tasks.export_tasks import build_export
-from app.services.idempotency_service import optional_idempotency_key, find_event_by_idempotency
+from app.services.idempotency_service import (
+    optional_idempotency_key,
+    find_event_by_idempotency,
+)
 from app.services.incident_evidence_orchestrator import IncidentEvidenceOrchestrator
 from app.services.dashcam_reason_codes import dashcam_reason_message
 from app.services.rate_limit_service import enforce_rate_limit
@@ -38,14 +44,28 @@ from app.core.config import settings
 from app.security.authn import build_user_auth_context
 from app.security.authz import (
     can_create_incident,
+    can_modify_incident,
     can_request_export,
     can_view_incident,
     require_policy,
 )
+from app.security.permissions import Capability, has_capability
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _required_transition_capability(
+    from_status: str, to_status: str
+) -> Capability | None:
+    if to_status == "closed":
+        return Capability.INCIDENT_CLOSE
+    if from_status == "closed" and to_status == "in_review":
+        return Capability.INCIDENT_REOPEN
+    if to_status == "escalated":
+        return Capability.INCIDENT_ESCALATE
+    return None
 
 
 @router.get("/", response_model=list[IncidentListItem])
@@ -149,7 +169,9 @@ def create_incident_endpoint(
         window_start = body.window_start
         window_end = body.window_end
         request_correlation_id = (
-            request.headers.get("x-correlation-id") or get_request_id() or str(uuid.uuid4())
+            request.headers.get("x-correlation-id")
+            or get_request_id()
+            or str(uuid.uuid4())
         )
         logger.info(
             "Queueing orchestrated evidence capture",
@@ -254,9 +276,15 @@ def get_incident_endpoint(
                 completed_at_utc=e.completed_at_utc.isoformat()
                 if e.completed_at_utc
                 else None,
-                expires_at_utc=e.expires_at_utc.isoformat() if e.expires_at_utc else None,
-                created_at_utc=e.created_at_utc.isoformat() if e.created_at_utc else None,
-                updated_at_utc=e.updated_at_utc.isoformat() if e.updated_at_utc else None,
+                expires_at_utc=e.expires_at_utc.isoformat()
+                if e.expires_at_utc
+                else None,
+                created_at_utc=e.created_at_utc.isoformat()
+                if e.created_at_utc
+                else None,
+                updated_at_utc=e.updated_at_utc.isoformat()
+                if e.updated_at_utc
+                else None,
             )
             for e in exports
         ],
@@ -292,6 +320,79 @@ def get_incident_endpoint(
             }
             for blocker in snapshot.blockers.items
         ],
+    )
+
+
+@router.patch("/{incident_id}/status", response_model=IncidentStatusPatchResponse)
+def patch_incident_status(
+    incident_id: uuid.UUID,
+    body: IncidentStatusPatchRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    org_ids = list(context.org_ids)
+    incident = get_incident(db, incident_id, org_ids=org_ids)
+    if incident is None:
+        raise HTTPException(status_code=404, detail="Incident not found")
+    require_policy(can_modify_incident(context, incident))
+
+    transition_capability = _required_transition_capability(
+        str(incident.case_status), body.case_status
+    )
+    if transition_capability is not None and not has_capability(
+        current_user.role, transition_capability
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Transition requires capability '{transition_capability.value}'.",
+        )
+
+    transition_validation = validate_case_status_transition(
+        from_status=str(incident.case_status),
+        to_status=body.case_status,
+        allow_privileged=transition_capability is not None,
+    )
+    if not transition_validation.allowed:
+        raise HTTPException(
+            status_code=409,
+            detail=transition_validation.reason or "Invalid case status transition",
+        )
+
+    from_case_status = str(incident.case_status)
+    incident.case_status = body.case_status
+    transition_payload = {
+        "from_case_status": from_case_status,
+        "to_case_status": body.case_status,
+        "transition_reason": body.reason,
+        "privileged_transition": transition_capability is not None,
+    }
+    db.flush()
+    create_event(
+        db,
+        incident_id=incident_id,
+        event_type=SystemEventType.INCIDENT_UPDATED,
+        actor_type="user",
+        actor_id=str(current_user.id),
+        payload=transition_payload,
+    )
+    emit_audit_event(
+        db,
+        org_id=incident.org_id,
+        actor_type="user",
+        actor_id=str(current_user.id),
+        action="incident.case_status.patch",
+        event_type="incident_case_status_updated",
+        outcome="success",
+        incident_id=incident.incident_id,
+        metadata=transition_payload,
+    )
+    db.commit()
+
+    return IncidentStatusPatchResponse(
+        incident_id=incident.incident_id,
+        case_status=incident.case_status,
+        transition_reason=body.reason,
     )
 
 
@@ -393,4 +494,8 @@ def request_export_endpoint(
         },
     )
 
-    return CreateExportResponse(export_id=export.export_id, status=export.status, progress_stage=export.progress_stage)
+    return CreateExportResponse(
+        export_id=export.export_id,
+        status=export.status,
+        progress_stage=export.progress_stage,
+    )

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -58,6 +58,9 @@ UserRole = Literal["system_admin", "org_admin", "safety_manager"]
 CapabilityName = Literal[
     "incident:read",
     "incident:write",
+    "incident:close",
+    "incident:reopen",
+    "incident:escalate",
     "export:read",
     "export:write",
     "driver_protocol:read",
@@ -69,6 +72,9 @@ assert set(CANONICAL_ROLES) == {"system_admin", "org_admin", "safety_manager"}
 assert set(ALL_RECOMMENDED_CAPABILITIES) == {
     "incident:read",
     "incident:write",
+    "incident:close",
+    "incident:reopen",
+    "incident:escalate",
     "export:read",
     "export:write",
     "driver_protocol:read",
@@ -79,6 +85,16 @@ assert set(ALL_RECOMMENDED_CAPABILITIES) == {
 InstructionScope = Literal["default", "company", "insurer"]
 IncidentSeverity = Literal["minor", "serious", "critical"]
 IncidentStatus = Literal["open", "evidence_capturing", "closed"]
+IncidentCaseStatus = Literal[
+    "new",
+    "in_review",
+    "awaiting_evidence",
+    "awaiting_follow_up",
+    "ready_for_export",
+    "exported",
+    "escalated",
+    "closed",
+]
 ArtifactStatus = Literal["pending", "captured", "unavailable"]
 ExportType = Literal[
     "court_defense", "insurer_packet", "internal_review", "compliance_audit"
@@ -147,12 +163,18 @@ ApiErrorCode = Literal[
 class ApiErrorDetail(BaseModel):
     message: Annotated[str, StringConstraints(min_length=1, max_length=300)]
     code: ApiErrorCode
-    retry_hint: Annotated[str, StringConstraints(min_length=1, max_length=300)] | None = None
-    correlation_id: Annotated[str, StringConstraints(min_length=8, max_length=128)] | None = None
+    retry_hint: (
+        Annotated[str, StringConstraints(min_length=1, max_length=300)] | None
+    ) = None
+    correlation_id: (
+        Annotated[str, StringConstraints(min_length=8, max_length=128)] | None
+    ) = None
 
 
 class ApiErrorResponse(BaseModel):
     detail: ApiErrorDetail
+
+
 DriverTimelineEventName = Literal[
     "driver_protocol_launch_confirmed",
     "driver_safety_gate_viewed",
@@ -313,6 +335,17 @@ class IncidentDetailResponse(BaseModel):
     readiness_state: str = "not_ready"
     completeness_missing_items: list[str] = Field(default_factory=list)
     blockers: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class IncidentStatusPatchRequest(BaseModel):
+    case_status: IncidentCaseStatus
+    reason: LongText
+
+
+class IncidentStatusPatchResponse(BaseModel):
+    incident_id: uuid.UUID
+    case_status: IncidentCaseStatus
+    transition_reason: LongText
 
 
 class MessagingReliabilityResponse(BaseModel):
@@ -794,7 +827,9 @@ IntegrationOperationStatus = Literal[
     "failed",
     "canceled",
 ]
-EvidenceRequestStatus = Literal["open", "in_progress", "fulfilled", "failed", "canceled"]
+EvidenceRequestStatus = Literal[
+    "open", "in_progress", "fulfilled", "failed", "canceled"
+]
 
 
 class IntegrationConnectionHealthResponse(BaseModel):

--- a/backend/app/case_ops/service.py
+++ b/backend/app/case_ops/service.py
@@ -7,13 +7,21 @@ from datetime import datetime, timezone
 from app.case_ops.blockers import detect_blockers
 from app.case_ops.completeness import calculate_completeness
 from app.case_ops.metrics import calculate_dashboard_metrics
-from app.case_ops.models import CaseOpsSnapshot, DashboardMetrics, TransitionValidationResult
+from app.case_ops.models import (
+    CaseOpsSnapshot,
+    DashboardMetrics,
+    TransitionValidationResult,
+)
 from app.case_ops.readiness import derive_readiness_state
 from app.case_ops.workflow import validate_transition
 
 
-def build_case_snapshot(*, incident, artifacts: list, events: list, exports: list) -> CaseOpsSnapshot:
-    completeness = calculate_completeness(artifacts=artifacts, events=events, exports=exports)
+def build_case_snapshot(
+    *, incident, artifacts: list, events: list, exports: list
+) -> CaseOpsSnapshot:
+    completeness = calculate_completeness(
+        artifacts=artifacts, events=events, exports=exports
+    )
     blockers = detect_blockers(artifacts=artifacts, events=events, exports=exports)
     readiness = derive_readiness_state(
         case_status=getattr(incident, "case_status", "new") or "new",
@@ -21,7 +29,9 @@ def build_case_snapshot(*, incident, artifacts: list, events: list, exports: lis
         completeness_status=completeness.status,
         blockers=blockers,
     )
-    return CaseOpsSnapshot(completeness=completeness, blockers=blockers, readiness=readiness)
+    return CaseOpsSnapshot(
+        completeness=completeness, blockers=blockers, readiness=readiness
+    )
 
 
 def build_dashboard_snapshot(
@@ -47,8 +57,18 @@ def build_dashboard_snapshot(
         if created_at is not None:
             created_at_values.append(created_at)
 
-    return calculate_dashboard_metrics(snapshots=snapshots, created_at_values=created_at_values, now=datetime.now(timezone.utc))
+    return calculate_dashboard_metrics(
+        snapshots=snapshots,
+        created_at_values=created_at_values,
+        now=datetime.now(timezone.utc),
+    )
 
 
-def validate_case_status_transition(*, from_status: str, to_status: str) -> TransitionValidationResult:
-    return validate_transition(from_status=from_status, to_status=to_status)
+def validate_case_status_transition(
+    *, from_status: str, to_status: str, allow_privileged: bool = False
+) -> TransitionValidationResult:
+    return validate_transition(
+        from_status=from_status,
+        to_status=to_status,
+        allow_privileged=allow_privileged,
+    )

--- a/backend/app/case_ops/workflow.py
+++ b/backend/app/case_ops/workflow.py
@@ -7,18 +7,31 @@ from datetime import datetime, timezone
 from app.case_ops.models import TransitionValidationResult
 
 _ALLOWED_TRANSITIONS: dict[str, set[str]] = {
-    "new": {"in_review", "awaiting_evidence", "closed", "escalated"},
-    "in_review": {"awaiting_evidence", "awaiting_follow_up", "ready_for_export", "escalated", "closed"},
-    "awaiting_evidence": {"in_review", "awaiting_follow_up", "closed", "escalated"},
-    "awaiting_follow_up": {"in_review", "ready_for_export", "closed", "escalated"},
-    "ready_for_export": {"exported", "awaiting_follow_up", "closed", "escalated"},
-    "exported": {"closed", "escalated"},
-    "escalated": {"in_review", "awaiting_follow_up", "ready_for_export", "closed"},
+    "new": {"in_review", "awaiting_evidence"},
+    "in_review": {"awaiting_evidence", "awaiting_follow_up", "ready_for_export"},
+    "awaiting_evidence": {"in_review", "awaiting_follow_up"},
+    "awaiting_follow_up": {"in_review", "ready_for_export"},
+    "ready_for_export": {"exported", "awaiting_follow_up"},
+    "exported": set(),
+    "escalated": {"in_review", "awaiting_follow_up", "ready_for_export"},
     "closed": set(),
 }
 
+_PRIVILEGED_TRANSITIONS: dict[str, set[str]] = {
+    "new": {"closed", "escalated"},
+    "in_review": {"closed", "escalated"},
+    "awaiting_evidence": {"closed", "escalated"},
+    "awaiting_follow_up": {"closed", "escalated"},
+    "ready_for_export": {"closed", "escalated"},
+    "exported": {"closed", "escalated"},
+    "escalated": {"closed"},
+    "closed": {"in_review"},
+}
 
-def validate_transition(from_status: str, to_status: str) -> TransitionValidationResult:
+
+def validate_transition(
+    from_status: str, to_status: str, *, allow_privileged: bool = False
+) -> TransitionValidationResult:
     source = str(from_status)
     target = str(to_status)
 
@@ -41,7 +54,28 @@ def validate_transition(from_status: str, to_status: str) -> TransitionValidatio
             validated_at_utc=datetime.now(timezone.utc),
         )
 
-    if target not in allowed_targets:
+    if target in allowed_targets:
+        return TransitionValidationResult(
+            allowed=True,
+            from_status=source,
+            to_status=target,
+            validated_at_utc=datetime.now(timezone.utc),
+        )
+
+    privileged_targets = _PRIVILEGED_TRANSITIONS.get(source, set())
+    if target in privileged_targets and not allow_privileged:
+        return TransitionValidationResult(
+            allowed=False,
+            from_status=source,
+            to_status=target,
+            reason=(
+                f"Transition from '{source}' to '{target}' is privileged and requires "
+                "explicit permission."
+            ),
+            validated_at_utc=datetime.now(timezone.utc),
+        )
+
+    if target not in privileged_targets:
         return TransitionValidationResult(
             allowed=False,
             from_status=source,

--- a/backend/app/security/permissions.py
+++ b/backend/app/security/permissions.py
@@ -14,6 +14,9 @@ class Role(str, Enum):
 class Capability(str, Enum):
     INCIDENT_READ = "incident:read"
     INCIDENT_WRITE = "incident:write"
+    INCIDENT_CLOSE = "incident:close"
+    INCIDENT_REOPEN = "incident:reopen"
+    INCIDENT_ESCALATE = "incident:escalate"
     EXPORT_READ = "export:read"
     EXPORT_WRITE = "export:write"
     DRIVER_PROTOCOL_READ = "driver_protocol:read"
@@ -68,5 +71,7 @@ def get_user_capabilities(raw_role: str | None) -> frozenset[Capability]:
 
 
 def has_capability(raw_role: str | None, capability: Capability | str) -> bool:
-    resolved = capability if isinstance(capability, Capability) else Capability(capability)
+    resolved = (
+        capability if isinstance(capability, Capability) else Capability(capability)
+    )
     return resolved in get_user_capabilities(raw_role)

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -13,6 +13,7 @@ from app.db.models import (
     Base,
     Incident,
     Artifact,
+    AuditEvent,
     Event,
     Export,
     User,
@@ -260,7 +261,9 @@ class TestGetIncident:
 
 
 class TestIntegrationDiagnosticsRoutes:
-    def test_org_integrations_and_details(self, client, db_session, test_org, auth_headers):
+    def test_org_integrations_and_details(
+        self, client, db_session, test_org, auth_headers
+    ):
         connection = IntegrationConnection(
             org_id=test_org.id,
             provider="samsara",
@@ -276,7 +279,9 @@ class TestIntegrationDiagnosticsRoutes:
         assert list_resp.status_code == 200
         assert len(list_resp.json()) == 1
 
-        detail_resp = client.get(f"/org/integrations/{connection.connection_id}", headers=auth_headers)
+        detail_resp = client.get(
+            f"/org/integrations/{connection.connection_id}", headers=auth_headers
+        )
         assert detail_resp.status_code == 200
         assert detail_resp.json()["provider"] == "samsara"
 
@@ -328,7 +333,9 @@ class TestIntegrationDiagnosticsRoutes:
         test_user.role = "org_admin"
         db_session.add(test_user)
         db_session.commit()
-        org_admin_token = create_access_token({"sub": str(test_user.id), "role": "org_admin"})
+        org_admin_token = create_access_token(
+            {"sub": str(test_user.id), "role": "org_admin"}
+        )
         org_admin_headers = {"Authorization": f"Bearer {org_admin_token}"}
         ops_resp = client.get("/integration-operations", headers=org_admin_headers)
         assert ops_resp.status_code == 200
@@ -380,7 +387,9 @@ class TestIntegrationDiagnosticsRoutes:
         test_user.role = "org_admin"
         db_session.add(test_user)
         db_session.commit()
-        org_admin_token = create_access_token({"sub": str(test_user.id), "role": "org_admin"})
+        org_admin_token = create_access_token(
+            {"sub": str(test_user.id), "role": "org_admin"}
+        )
         org_admin_headers = {"Authorization": f"Bearer {org_admin_token}"}
         allowed = client.post(
             f"/org/integrations/{connection.connection_id}/validate",
@@ -463,6 +472,127 @@ class TestIntegrationDiagnosticsRoutes:
 
         resp = client.get(f"/incidents/{inc.incident_id}", headers=auth_headers)
         assert resp.status_code == 404
+
+
+# ── PATCH /incidents/{incident_id}/status ───────────────────────────
+
+
+class TestPatchIncidentStatus:
+    def _create_incident(self, client, auth_headers) -> str:
+        create_resp = client.post(
+            "/incidents/",
+            json={
+                "severity": "minor",
+                "adc_vehicle_id": "v1",
+                "samsara_vehicle_id": "s1",
+                "adc_driver_id": "d1",
+            },
+            headers=auth_headers,
+        )
+        assert create_resp.status_code == 201
+        return create_resp.json()["incident_id"]
+
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
+    def test_patch_incident_status_allows_standard_transition(
+        self, mock_begin_capture, client, db_session, auth_headers
+    ):
+        incident_id = self._create_incident(client, auth_headers)
+        incident = (
+            db_session.query(Incident)
+            .filter(Incident.incident_id == uuid.UUID(incident_id))
+            .one()
+        )
+        incident.case_status = "new"
+        db_session.add(incident)
+        db_session.commit()
+
+        response = client.patch(
+            f"/incidents/{incident_id}/status",
+            json={"case_status": "in_review", "reason": "Ready for triage"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["case_status"] == "in_review"
+
+        latest_event = (
+            db_session.query(Event)
+            .filter(
+                Event.incident_id == uuid.UUID(incident_id),
+                Event.event_type == "incident_updated",
+            )
+            .order_by(Event.created_at_utc.desc())
+            .first()
+        )
+        assert latest_event is not None
+        assert latest_event.payload["transition_reason"] == "Ready for triage"
+        assert latest_event.payload["from_case_status"] == "new"
+        assert latest_event.payload["to_case_status"] == "in_review"
+
+        latest_audit = (
+            db_session.query(AuditEvent)
+            .filter(AuditEvent.incident_id == uuid.UUID(incident_id))
+            .order_by(AuditEvent.created_at_utc.desc())
+            .first()
+        )
+        assert latest_audit is not None
+        assert latest_audit.metadata_json["transition_reason"] == "Ready for triage"
+
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
+    def test_patch_incident_status_rejects_privileged_transition_without_permission(
+        self, mock_begin_capture, client, db_session, auth_headers
+    ):
+        incident_id = self._create_incident(client, auth_headers)
+        incident = (
+            db_session.query(Incident)
+            .filter(Incident.incident_id == uuid.UUID(incident_id))
+            .one()
+        )
+        incident.case_status = "in_review"
+        db_session.add(incident)
+        db_session.commit()
+
+        response = client.patch(
+            f"/incidents/{incident_id}/status",
+            json={"case_status": "closed", "reason": "Investigation complete"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 403
+
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
+    def test_patch_incident_status_allows_reopen_for_org_admin(
+        self, mock_begin_capture, client, db_session, test_org, auth_headers
+    ):
+        incident_id = self._create_incident(client, auth_headers)
+        incident = (
+            db_session.query(Incident)
+            .filter(Incident.incident_id == uuid.UUID(incident_id))
+            .one()
+        )
+        incident.case_status = "closed"
+        db_session.add(incident)
+        org_admin = User(
+            email="org-admin-status@example.com",
+            password_hash=hash_password("testpass"),
+            role="org_admin",
+        )
+        db_session.add(org_admin)
+        db_session.commit()
+        db_session.refresh(org_admin)
+        db_session.add(UserOrg(user_id=org_admin.id, org_id=test_org.id))
+        db_session.commit()
+
+        org_admin_headers = {
+            "Authorization": f"Bearer {create_access_token({'sub': str(org_admin.id), 'role': 'org_admin'})}"
+        }
+
+        response = client.patch(
+            f"/incidents/{incident_id}/status",
+            json={"case_status": "in_review", "reason": "Reopened for legal review"},
+            headers=org_admin_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["case_status"] == "in_review"
+        assert response.json()["transition_reason"] == "Reopened for legal review"
 
 
 # ── GET /incidents (list) ───────────────────────────────────────────
@@ -607,7 +737,9 @@ class TestRequestExport:
         )
         assert resp.status_code == 403
 
-    def test_request_export_invalid_type(self, client, db_session, test_org, auth_headers):
+    def test_request_export_invalid_type(
+        self, client, db_session, test_org, auth_headers
+    ):
         incident = Incident(status="open", org_id=test_org.id)
         db_session.add(incident)
         db_session.commit()
@@ -691,7 +823,9 @@ class TestRequestExport:
         db_session.commit()
         db_session.refresh(failed)
 
-        resp = client.post(f"/exports/{failed.export_id}/retry", json={}, headers=auth_headers)
+        resp = client.post(
+            f"/exports/{failed.export_id}/retry", json={}, headers=auth_headers
+        )
         assert resp.status_code == 201
         payload = resp.json()
         assert payload["status"] == "queued"
@@ -706,7 +840,11 @@ class TestRequestExport:
         assert created.retry_parent_export_id == failed.export_id
         assert created.export_type == failed.export_type
         assert created.options_json == failed.options_json
-        refreshed_failed = db_session.query(Export).filter(Export.export_id == failed.export_id).first()
+        refreshed_failed = (
+            db_session.query(Export)
+            .filter(Export.export_id == failed.export_id)
+            .first()
+        )
         assert refreshed_failed.status == "failed"
         retry_event = (
             db_session.query(Event)
@@ -724,7 +862,9 @@ class TestRequestExport:
         )
 
     @patch("app.api.routes_exports.build_export")
-    def test_retry_failed_export_accepts_overrides(self, mock_gen, client, db_session, test_org, auth_headers):
+    def test_retry_failed_export_accepts_overrides(
+        self, mock_gen, client, db_session, test_org, auth_headers
+    ):
         mock_gen.delay = MagicMock()
         incident = Incident(status="open", org_id=test_org.id)
         db_session.add(incident)
@@ -743,11 +883,18 @@ class TestRequestExport:
 
         resp = client.post(
             f"/exports/{failed.export_id}/retry",
-            json={"export_type": "court_defense", "options_json": {"profile_id": "court_defense_v1"}},
+            json={
+                "export_type": "court_defense",
+                "options_json": {"profile_id": "court_defense_v1"},
+            },
             headers=auth_headers,
         )
         assert resp.status_code == 201
-        created = db_session.query(Export).filter(Export.export_id == uuid.UUID(resp.json()["export_id"])).first()
+        created = (
+            db_session.query(Export)
+            .filter(Export.export_id == uuid.UUID(resp.json()["export_id"]))
+            .first()
+        )
         assert created.export_type == "court_defense"
         assert created.options_json["profile_id"] == "court_defense_v1"
         assert created.options_json["include_media"] is True
@@ -771,7 +918,9 @@ class TestRequestExport:
         db_session.commit()
         db_session.refresh(ready)
 
-        resp = client.post(f"/exports/{ready.export_id}/retry", json={}, headers=auth_headers)
+        resp = client.post(
+            f"/exports/{ready.export_id}/retry", json={}, headers=auth_headers
+        )
         assert resp.status_code == 409
         db_session.refresh(ready)
         assert ready.status == "ready"
@@ -795,7 +944,9 @@ class TestDownloadExport:
         db_session.commit()
         db_session.refresh(inc)
 
-        exp = Export(incident_id=inc.incident_id, org_id=test_org.id, status="requested")
+        exp = Export(
+            incident_id=inc.incident_id, org_id=test_org.id, status="requested"
+        )
         db_session.add(exp)
         db_session.commit()
         db_session.refresh(exp)
@@ -805,7 +956,12 @@ class TestDownloadExport:
 
     @patch("app.api.routes_exports.generate_presigned_download_url")
     def test_download_export_ready(
-        self, mock_generate_presigned_download_url, client, db_session, test_org, auth_headers
+        self,
+        mock_generate_presigned_download_url,
+        client,
+        db_session,
+        test_org,
+        auth_headers,
     ):
         inc = Incident(status="open", org_id=test_org.id)
         db_session.add(inc)
@@ -827,7 +983,6 @@ class TestDownloadExport:
             "https://signed.example.com/exports/test.zip"
         )
 
-
         resp = client.get(f"/exports/{exp.export_id}/download", headers=auth_headers)
         assert resp.status_code == 200
         data = resp.json()
@@ -841,7 +996,12 @@ class TestDownloadExport:
 
     @patch("app.api.routes_exports.generate_presigned_download_url")
     def test_download_export_logs_event(
-        self, mock_generate_presigned_download_url, client, db_session, test_org, auth_headers
+        self,
+        mock_generate_presigned_download_url,
+        client,
+        db_session,
+        test_org,
+        auth_headers,
     ):
         inc = Incident(status="open", org_id=test_org.id)
         db_session.add(inc)
@@ -859,7 +1019,9 @@ class TestDownloadExport:
         db_session.commit()
         db_session.refresh(exp)
 
-        mock_generate_presigned_download_url.return_value = "https://signed.example.com/k"
+        mock_generate_presigned_download_url.return_value = (
+            "https://signed.example.com/k"
+        )
 
         client.get(f"/exports/{exp.export_id}/download", headers=auth_headers)
 
@@ -911,7 +1073,12 @@ class TestDownloadExport:
 
     @patch("app.api.routes_exports.generate_presigned_download_url")
     def test_download_export_uses_incident_org_for_legacy_null_org_export(
-        self, mock_generate_presigned_download_url, client, db_session, auth_headers, test_org
+        self,
+        mock_generate_presigned_download_url,
+        client,
+        db_session,
+        auth_headers,
+        test_org,
     ):
         inc = Incident(status="open", org_id=test_org.id)
         db_session.add(inc)
@@ -938,7 +1105,12 @@ class TestDownloadExport:
 
     @patch("app.api.routes_exports.generate_presigned_download_url")
     def test_download_export_missing_bucket_or_key_returns_422(
-        self, mock_generate_presigned_download_url, client, db_session, test_org, auth_headers
+        self,
+        mock_generate_presigned_download_url,
+        client,
+        db_session,
+        test_org,
+        auth_headers,
     ):
         inc = Incident(status="open", org_id=test_org.id)
         db_session.add(inc)
@@ -971,7 +1143,12 @@ class TestDownloadExport:
 
     @patch("app.api.routes_exports.generate_presigned_download_url")
     def test_download_export_presign_failure_returns_502(
-        self, mock_generate_presigned_download_url, client, db_session, test_org, auth_headers
+        self,
+        mock_generate_presigned_download_url,
+        client,
+        db_session,
+        test_org,
+        auth_headers,
     ):
         inc = Incident(status="open", org_id=test_org.id)
         db_session.add(inc)
@@ -1070,7 +1247,12 @@ class TestDownloadExport:
 
     @patch("app.api.routes_exports.generate_presigned_download_url")
     def test_download_export_rejects_non_presigned_url(
-        self, mock_generate_presigned_download_url, client, db_session, test_org, auth_headers
+        self,
+        mock_generate_presigned_download_url,
+        client,
+        db_session,
+        test_org,
+        auth_headers,
     ):
         inc = Incident(status="open", org_id=test_org.id)
         db_session.add(inc)
@@ -1185,9 +1367,7 @@ class TestGetExport:
         resp = client.get(f"/exports/{fake_id}")
         assert resp.status_code in (401, 403)
 
-    def test_get_export_forbidden_for_other_org(
-        self, client, db_session, auth_headers
-    ):
+    def test_get_export_forbidden_for_other_org(self, client, db_session, auth_headers):
         other_org = Org(name="Other Org")
         db_session.add(other_org)
         db_session.commit()
@@ -1365,7 +1545,9 @@ class TestExportStatusAndContents:
         db_session.commit()
         db_session.refresh(exp)
 
-        status_resp = client.get(f"/exports/{exp.export_id}/status", headers=auth_headers)
+        status_resp = client.get(
+            f"/exports/{exp.export_id}/status", headers=auth_headers
+        )
         contents_resp = client.get(
             f"/exports/{exp.export_id}/contents", headers=auth_headers
         )
@@ -1390,7 +1572,9 @@ class TestExportStatusAndContents:
         db_session.commit()
         db_session.refresh(exp)
 
-        status_resp = client.get(f"/exports/{exp.export_id}/status", headers=auth_headers)
+        status_resp = client.get(
+            f"/exports/{exp.export_id}/status", headers=auth_headers
+        )
         contents_resp = client.get(
             f"/exports/{exp.export_id}/contents", headers=auth_headers
         )

--- a/backend/tests/test_case_ops_service.py
+++ b/backend/tests/test_case_ops_service.py
@@ -21,7 +21,11 @@ def _export(status: str):
     return SimpleNamespace(status=status)
 
 
-def _incident(incident_id: str, case_status: str = "in_review", created_at_utc: datetime | None = None):
+def _incident(
+    incident_id: str,
+    case_status: str = "in_review",
+    created_at_utc: datetime | None = None,
+):
     return SimpleNamespace(
         incident_id=incident_id,
         case_status=case_status,
@@ -45,7 +49,9 @@ def test_build_case_snapshot_derives_readiness_and_blockers():
 def test_build_dashboard_snapshot_aggregates_metrics():
     now = datetime.now(timezone.utc)
     inc_a = _incident("inc-a", created_at_utc=now - timedelta(days=2))
-    inc_b = _incident("inc-b", case_status="closed", created_at_utc=now - timedelta(days=9))
+    inc_b = _incident(
+        "inc-b", case_status="closed", created_at_utc=now - timedelta(days=9)
+    )
 
     metrics = build_dashboard_snapshot(
         incidents=[inc_a, inc_b],
@@ -55,7 +61,11 @@ def test_build_dashboard_snapshot_aggregates_metrics():
         },
         events_by_incident={
             "inc-a": [_event("incident_started"), _event("hash_validated")],
-            "inc-b": [_event("incident_started"), _event("hash_validated"), _event("export_ready")],
+            "inc-b": [
+                _event("incident_started"),
+                _event("hash_validated"),
+                _event("export_ready"),
+            ],
         },
         exports_by_incident={
             "inc-a": [_export("ready")],
@@ -70,15 +80,44 @@ def test_build_dashboard_snapshot_aggregates_metrics():
 
 def test_validate_case_status_transition_blocks_invalid_hops():
     blocked = validate_case_status_transition(from_status="new", to_status="exported")
-    allowed = validate_case_status_transition(from_status="ready_for_export", to_status="exported")
+    allowed = validate_case_status_transition(
+        from_status="ready_for_export", to_status="exported"
+    )
 
     assert blocked.allowed is False
     assert allowed.allowed is True
 
 
+def test_validate_case_status_transition_requires_privilege_for_close_and_reopen():
+    close_blocked = validate_case_status_transition(
+        from_status="in_review", to_status="closed"
+    )
+    close_allowed = validate_case_status_transition(
+        from_status="in_review",
+        to_status="closed",
+        allow_privileged=True,
+    )
+    reopen_blocked = validate_case_status_transition(
+        from_status="closed", to_status="in_review"
+    )
+    reopen_allowed = validate_case_status_transition(
+        from_status="closed",
+        to_status="in_review",
+        allow_privileged=True,
+    )
+
+    assert close_blocked.allowed is False
+    assert close_allowed.allowed is True
+    assert reopen_blocked.allowed is False
+    assert reopen_allowed.allowed is True
+
+
 def test_detect_blockers_classifies_dashcam_and_readiness_linkage():
     summary = detect_blockers(
-        artifacts=[_artifact("pending", "dash_cam_video_front"), _artifact("captured", "telematics_gps")],
+        artifacts=[
+            _artifact("pending", "dash_cam_video_front"),
+            _artifact("captured", "telematics_gps"),
+        ],
         events=[_event("incident_started"), _event("capture_completed")],
         exports=[],
     )
@@ -102,6 +141,8 @@ def test_detect_blockers_classifies_driver_input_and_telematics_unavailable():
         exports=[_export("ready")],
     )
 
-    blocker = next(item for item in summary.items if item.code == "evidence_unavailable")
+    blocker = next(
+        item for item in summary.items if item.code == "evidence_unavailable"
+    )
     assert blocker.missing_item.category == "driver_input"
     assert blocker.missing_item.severity == "important"

--- a/contracts/schemas/runtime_api_contracts.json
+++ b/contracts/schemas/runtime_api_contracts.json
@@ -1088,6 +1088,9 @@
             "enum": [
               "incident:read",
               "incident:write",
+              "incident:close",
+              "incident:reopen",
+              "incident:escalate",
               "export:read",
               "export:write",
               "driver_protocol:read",


### PR DESCRIPTION
### Motivation
- Introduce explicit, auditable guards around case-management transitions so privileged actions (close/reopen/escalate) require explicit permission and are recorded with reason and audit metadata.
- Make the case workflow validator aware of standard vs privileged transition paths and expose a flag to allow privileged hops when the caller has explicit capability.

### Description
- Added a guarded transition model in `app/case_ops/workflow.py` with `_ALLOWED_TRANSITIONS` for normal hops and `_PRIVILEGED_TRANSITIONS` for close/reopen/escalate paths, and extended `validate_transition` to accept `allow_privileged: bool`.
- Exposed `allow_privileged` through the facade `validate_case_status_transition` in `app/case_ops/service.py`.
- Added new capabilities to `app/security/permissions.py`: `incident:close`, `incident:reopen`, and `incident:escalate` and kept role capability mappings intact.
- Extended API schemas in `app/api/schemas.py` with `IncidentCaseStatus`, `IncidentStatusPatchRequest`, and `IncidentStatusPatchResponse` to model case-status patches and transition reason.
- Implemented `PATCH /incidents/{incident_id}/status` in `app/api/routes_incidents.py` which:
  - enforces org-scoped incident write access via existing auth checks,
  - checks for required privileged capability for close/reopen/escalate transitions,
  - validates the transition using the case workflow rules (with `allow_privileged` when appropriate),
  - persists the transition reason in the appended timeline event payload (`incident_updated`), and
  - emits an audit event with the same transition payload for traceability.
- Added and updated tests in `backend/tests/test_case_ops_service.py` and `backend/tests/test_api_endpoints.py` covering allowed/forbidden transitions, privileged behavior, reason persistence, and reopen flow for org-admin.

### Testing
- Ran code formatting and lint checks on touched files with `ruff format` and `ruff check`; checks passed.
- Ran the affected test suites with `pytest tests/test_case_ops_service.py tests/test_api_endpoints.py -q`; all tests passed (`68 passed`, with 3 warnings about deprecations).
- No failures observed after changes; transition validation and API behavior verified by unit/integration tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd9b2ef3cc8321aefd1ed4686d475c)