### PR TITLE
Add incident ownership API, service, enums, and tests

### DIFF
--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -15,6 +15,8 @@ from app.api.schemas import (
     ExportSummary,
     IncidentDetailResponse,
     IncidentListItem,
+    IncidentOwnerPatchRequest,
+    IncidentOwnerPatchResponse,
     IncidentStatusPatchRequest,
     IncidentStatusPatchResponse,
 )
@@ -40,6 +42,7 @@ from app.services.idempotency_service import (
 from app.services.incident_evidence_orchestrator import IncidentEvidenceOrchestrator
 from app.services.dashcam_reason_codes import dashcam_reason_message
 from app.services.rate_limit_service import enforce_rate_limit
+from app.services.incident_ownership_service import patch_incident_owner
 from app.core.config import settings
 from app.security.authn import build_user_auth_context
 from app.security.authz import (
@@ -393,6 +396,40 @@ def patch_incident_status(
         incident_id=incident.incident_id,
         case_status=incident.case_status,
         transition_reason=body.reason,
+    )
+
+
+@router.patch("/{incident_id}/owner", response_model=IncidentOwnerPatchResponse)
+def patch_incident_owner_endpoint(
+    incident_id: uuid.UUID,
+    body: IncidentOwnerPatchRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    org_ids = list(context.org_ids)
+    incident = get_incident(db, incident_id, org_ids=org_ids)
+    if incident is None:
+        raise HTTPException(status_code=404, detail="Incident not found")
+    require_policy(can_modify_incident(context, incident))
+
+    incident = patch_incident_owner(
+        db=db,
+        incident=incident,
+        org_ids=org_ids,
+        actor_user_id=current_user.id,
+        operation=body.operation,
+        owner_user_id=body.owner_user_id,
+    )
+    db.commit()
+
+    return IncidentOwnerPatchResponse(
+        incident_id=incident.incident_id,
+        owner_user_id=incident.owner_user_id,
+        assigned_at=incident.owner_assigned_at_utc,
+        assigned_by=incident.owner_assigned_by_user_id,
+        team_queue=incident.team_queue,
+        last_activity_at_utc=incident.last_activity_at_utc,
     )
 
 

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -95,6 +95,13 @@ IncidentCaseStatus = Literal[
     "escalated",
     "closed",
 ]
+IncidentQueue = Literal[
+    "Unassigned",
+    "Safety Review",
+    "Claims Review",
+    "Escalated",
+    "Export Queue",
+]
 ArtifactStatus = Literal["pending", "captured", "unavailable"]
 ExportType = Literal[
     "court_defense", "insurer_packet", "internal_review", "compliance_audit"
@@ -346,6 +353,31 @@ class IncidentStatusPatchResponse(BaseModel):
     incident_id: uuid.UUID
     case_status: IncidentCaseStatus
     transition_reason: LongText
+
+
+IncidentOwnerPatchOperation = Literal["assign", "reassign", "clear"]
+
+
+class IncidentOwnerPatchRequest(BaseModel):
+    operation: IncidentOwnerPatchOperation
+    owner_user_id: Optional[uuid.UUID] = None
+
+    @model_validator(mode="after")
+    def validate_operation(self):
+        if self.operation == "clear" and self.owner_user_id is not None:
+            raise ValueError("owner_user_id must be null when operation is 'clear'.")
+        if self.operation in {"assign", "reassign"} and self.owner_user_id is None:
+            raise ValueError("owner_user_id is required for assign/reassign.")
+        return self
+
+
+class IncidentOwnerPatchResponse(BaseModel):
+    incident_id: uuid.UUID
+    owner_user_id: Optional[uuid.UUID] = None
+    assigned_at: Optional[datetime] = None
+    assigned_by: Optional[uuid.UUID] = None
+    team_queue: Optional[IncidentQueue] = None
+    last_activity_at_utc: Optional[datetime] = None
 
 
 class MessagingReliabilityResponse(BaseModel):

--- a/backend/app/services/incident_ownership_service.py
+++ b/backend/app/services/incident_ownership_service.py
@@ -1,0 +1,48 @@
+"""Service logic for incident ownership assignment workflows."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.db.models import Incident, UserOrg
+
+
+def patch_incident_owner(
+    *,
+    db: Session,
+    incident: Incident,
+    org_ids: list[uuid.UUID],
+    actor_user_id: uuid.UUID,
+    operation: str,
+    owner_user_id: uuid.UUID | None,
+) -> Incident:
+    """Apply owner assign/reassign/clear operation and mutate queue metadata."""
+    now = datetime.now(timezone.utc)
+
+    if operation in {"assign", "reassign"}:
+        assert owner_user_id is not None
+        is_user_in_org = (
+            db.query(UserOrg)
+            .filter(UserOrg.user_id == owner_user_id, UserOrg.org_id.in_(org_ids))
+            .first()
+            is not None
+        )
+        if not is_user_in_org:
+            raise HTTPException(status_code=404, detail="Owner user not found")
+
+        incident.owner_user_id = owner_user_id
+        incident.owner_assigned_at_utc = now
+        incident.owner_assigned_by_user_id = actor_user_id
+    else:
+        incident.owner_user_id = None
+        incident.owner_assigned_at_utc = None
+        incident.owner_assigned_by_user_id = None
+        incident.team_queue = "Unassigned"
+
+    incident.last_activity_at_utc = now
+    db.flush()
+    return incident

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -595,6 +595,127 @@ class TestPatchIncidentStatus:
         assert response.json()["transition_reason"] == "Reopened for legal review"
 
 
+# ── PATCH /incidents/{incident_id}/owner ───────────────────────────
+
+
+class TestPatchIncidentOwner:
+    def _create_incident(self, client, auth_headers) -> str:
+        create_resp = client.post(
+            "/incidents/",
+            json={
+                "severity": "minor",
+                "adc_vehicle_id": "owner-v1",
+                "samsara_vehicle_id": "owner-s1",
+                "adc_driver_id": "owner-d1",
+            },
+            headers=auth_headers,
+        )
+        assert create_resp.status_code == 201
+        return create_resp.json()["incident_id"]
+
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
+    def test_patch_owner_assign_reassign_clear(
+        self, mock_begin_capture, client, db_session, test_org, auth_headers
+    ):
+        incident_id = self._create_incident(client, auth_headers)
+
+        owner_one = User(
+            email="owner-one@example.com",
+            password_hash=hash_password("testpass"),
+            role="safety_manager",
+        )
+        owner_two = User(
+            email="owner-two@example.com",
+            password_hash=hash_password("testpass"),
+            role="safety_manager",
+        )
+        db_session.add_all([owner_one, owner_two])
+        db_session.commit()
+        db_session.refresh(owner_one)
+        db_session.refresh(owner_two)
+        db_session.add_all(
+            [
+                UserOrg(user_id=owner_one.id, org_id=test_org.id),
+                UserOrg(user_id=owner_two.id, org_id=test_org.id),
+            ]
+        )
+        db_session.commit()
+
+        assign_resp = client.patch(
+            f"/incidents/{incident_id}/owner",
+            json={"operation": "assign", "owner_user_id": str(owner_one.id)},
+            headers=auth_headers,
+        )
+        assert assign_resp.status_code == 200
+        assign_payload = assign_resp.json()
+        assert assign_payload["owner_user_id"] == str(owner_one.id)
+        assert assign_payload["assigned_by"] is not None
+        assert assign_payload["assigned_at"] is not None
+        assert assign_payload["last_activity_at_utc"] is not None
+
+        reassign_resp = client.patch(
+            f"/incidents/{incident_id}/owner",
+            json={"operation": "reassign", "owner_user_id": str(owner_two.id)},
+            headers=auth_headers,
+        )
+        assert reassign_resp.status_code == 200
+        reassign_payload = reassign_resp.json()
+        assert reassign_payload["owner_user_id"] == str(owner_two.id)
+        assert reassign_payload["assigned_by"] is not None
+        assert reassign_payload["assigned_at"] is not None
+        assert reassign_payload["last_activity_at_utc"] is not None
+
+        clear_resp = client.patch(
+            f"/incidents/{incident_id}/owner",
+            json={"operation": "clear"},
+            headers=auth_headers,
+        )
+        assert clear_resp.status_code == 200
+        clear_payload = clear_resp.json()
+        assert clear_payload["owner_user_id"] is None
+        assert clear_payload["assigned_by"] is None
+        assert clear_payload["assigned_at"] is None
+        assert clear_payload["team_queue"] == "Unassigned"
+        assert clear_payload["last_activity_at_utc"] is not None
+
+        incident = (
+            db_session.query(Incident)
+            .filter(Incident.incident_id == uuid.UUID(incident_id))
+            .one()
+        )
+        assert incident.owner_user_id is None
+        assert incident.owner_assigned_at_utc is None
+        assert incident.owner_assigned_by_user_id is None
+        assert incident.team_queue == "Unassigned"
+        assert incident.last_activity_at_utc is not None
+
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
+    def test_patch_owner_enforces_org_isolation(
+        self, mock_begin_capture, client, db_session, auth_headers
+    ):
+        incident_id = self._create_incident(client, auth_headers)
+        other_org = Org(name="Other Owner Org")
+        foreign_owner = User(
+            email="foreign-owner@example.com",
+            password_hash=hash_password("testpass"),
+            role="safety_manager",
+        )
+        db_session.add_all([other_org, foreign_owner])
+        db_session.commit()
+        db_session.refresh(other_org)
+        db_session.refresh(foreign_owner)
+        db_session.add(UserOrg(user_id=foreign_owner.id, org_id=other_org.id))
+        db_session.commit()
+
+        response = client.patch(
+            f"/incidents/{incident_id}/owner",
+            json={"operation": "assign", "owner_user_id": str(foreign_owner.id)},
+            headers=auth_headers,
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Owner user not found"
+
+
 # ── GET /incidents (list) ───────────────────────────────────────────
 
 


### PR DESCRIPTION
### Motivation
- Provide an API and service to assign, reassign, and clear incident owners while recording assignment metadata and ensuring org-scoped ownership.
- Ensure that clearing an owner auto-routes the incident to the `Unassigned` queue and that ownership updates bump `last_activity_at_utc`.

### Description
- Added an `IncidentQueue` literal with values `Unassigned`, `Safety Review`, `Claims Review`, `Escalated`, and `Export Queue` and new owner request/response schemas in `app/api/schemas.py` (`IncidentOwnerPatchRequest`, `IncidentOwnerPatchResponse`, and operation validation). 
- Implemented `PATCH /incidents/{incident_id}/owner` in `app/api/routes_incidents.py` wired to authorization, org-scoped incident lookup, and the ownership service. 
- Added `app/services/incident_ownership_service.py` with `patch_incident_owner` which validates that assigned users belong to the caller org, sets `owner_user_id`, `owner_assigned_at_utc`, and `owner_assigned_by_user_id` for assigns/reassigns, clears owner fields and sets `team_queue` to `Unassigned` on clear, and updates `last_activity_at_utc`. 
- Added integration tests in `backend/tests/test_api_endpoints.py` that exercise assign → reassign → clear flows, assert assignment metadata and queue behavior, and verify org isolation for owner assignment. 

### Testing
- Ran `ruff check app tests` and the linter checks passed. 
- Ran `pytest tests/test_api_endpoints.py -k "patch_owner or patch_incident_status" -q` and the targeted tests passed (all tests in the selection succeeded).
- The new ownership integration tests (assign/reassign/clear and org isolation) were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dda8d41fc4832186670643f8e0d836)