### PR TITLE
Add case-ops queue, alerts, summary metrics, and task widget endpoints

### DIFF
--- a/backend/app/api/routes/routes_case_ops.py
+++ b/backend/app/api/routes/routes_case_ops.py
@@ -1,0 +1,141 @@
+"""Case operations queue, KPI, alert, and task widget routes."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.api.schemas import (
+    CaseOpsAlertsResponse,
+    CaseOpsBlockerFilter,
+    CaseOpsQueueResponse,
+    CaseOpsQueueSort,
+    CaseOpsSummaryMetricsResponse,
+    CaseTaskWidgetItem,
+    CaseTaskWidgetResponse,
+)
+from app.case_ops.metrics import query_case_alerts, query_incident_queue, query_summary_metrics
+from app.core.deps import get_current_user
+from app.db.models import User
+from app.db.repo.case_tasks import list_my_open_tasks, list_overdue_tasks
+from app.db.session import get_db
+from app.security.authn import build_user_auth_context
+
+router = APIRouter()
+
+
+@router.get("/incidents/queue", response_model=CaseOpsQueueResponse)
+def get_incident_queue(
+    status: str | None = Query(default=None),
+    owner_user_id: uuid.UUID | None = Query(default=None),
+    readiness_state: str | None = Query(default=None),
+    created_from_utc: datetime | None = Query(default=None),
+    created_to_utc: datetime | None = Query(default=None),
+    blockers: CaseOpsBlockerFilter | None = Query(default=None),
+    search: str | None = Query(default=None),
+    sort: CaseOpsQueueSort = Query(default="newest"),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=25, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    payload = query_incident_queue(
+        db,
+        org_ids=list(context.org_ids),
+        case_status=status,
+        owner_user_id=owner_user_id,
+        readiness_state=readiness_state,
+        created_from_utc=created_from_utc,
+        created_to_utc=created_to_utc,
+        blockers=blockers,
+        search=search,
+        sort=sort,
+        page=page,
+        page_size=page_size,
+    )
+    return CaseOpsQueueResponse(**payload)
+
+
+@router.get("/incidents/summary-metrics", response_model=CaseOpsSummaryMetricsResponse)
+def get_summary_metrics(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    payload = query_summary_metrics(db, org_ids=list(context.org_ids))
+    return CaseOpsSummaryMetricsResponse(**payload)
+
+
+@router.get("/incidents/alerts", response_model=CaseOpsAlertsResponse)
+def get_case_alerts(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    payload = query_case_alerts(db, org_ids=list(context.org_ids))
+    return CaseOpsAlertsResponse(**payload)
+
+
+@router.get("/tasks/my-open", response_model=CaseTaskWidgetResponse)
+def get_my_open_tasks(
+    limit: int = Query(default=20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    tasks = list_my_open_tasks(
+        db,
+        org_ids=list(context.org_ids),
+        user_id=current_user.id,
+        now_utc=datetime.now(timezone.utc),
+        limit=limit,
+    )
+    return CaseTaskWidgetResponse(
+        items=[
+            CaseTaskWidgetItem(
+                task_id=task.task_id,
+                incident_id=task.incident_id,
+                title=task.title,
+                status=task.status,
+                priority=task.priority,
+                due_at_utc=task.due_at_utc,
+                assigned_to_user_id=task.assigned_to_user_id,
+                created_at_utc=task.created_at_utc,
+            )
+            for task in tasks
+        ]
+    )
+
+
+@router.get("/tasks/overdue", response_model=CaseTaskWidgetResponse)
+def get_overdue_tasks(
+    limit: int = Query(default=20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    tasks = list_overdue_tasks(
+        db,
+        org_ids=list(context.org_ids),
+        now_utc=datetime.now(timezone.utc),
+        limit=limit,
+    )
+    return CaseTaskWidgetResponse(
+        items=[
+            CaseTaskWidgetItem(
+                task_id=task.task_id,
+                incident_id=task.incident_id,
+                title=task.title,
+                status=task.status,
+                priority=task.priority,
+                due_at_utc=task.due_at_utc,
+                assigned_to_user_id=task.assigned_to_user_id,
+                created_at_utc=task.created_at_utc,
+            )
+            for task in tasks
+        ]
+    )

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -380,6 +380,70 @@ class IncidentOwnerPatchResponse(BaseModel):
     last_activity_at_utc: Optional[datetime] = None
 
 
+CaseOpsQueueSort = Literal["urgency", "readiness", "newest"]
+CaseOpsBlockerFilter = Literal["any", "critical", "important", "none"]
+
+
+class CaseOpsQueueBlockerCounts(BaseModel):
+    total: int = 0
+    critical: int = 0
+    important: int = 0
+    optional: int = 0
+
+
+class CaseOpsQueueItem(BaseModel):
+    incident_id: uuid.UUID
+    case_status: IncidentCaseStatus
+    owner_user_id: Optional[uuid.UUID] = None
+    readiness_state: str = "not_ready"
+    created_at_utc: Optional[datetime] = None
+    last_activity_at_utc: Optional[datetime] = None
+    severity: Optional[IncidentSeverity] = None
+    adc_vehicle_id: Optional[VehicleId] = None
+    adc_driver_id: Optional[DriverId] = None
+    completeness_percent: int = Field(default=0, ge=0, le=100)
+    blockers: CaseOpsQueueBlockerCounts = Field(default_factory=CaseOpsQueueBlockerCounts)
+
+
+class CaseOpsQueueResponse(BaseModel):
+    items: list[CaseOpsQueueItem] = Field(default_factory=list)
+    total: int = 0
+    page: int = 1
+    page_size: int = 25
+
+
+class CaseOpsSummaryMetricsResponse(BaseModel):
+    open_incidents: int = 0
+    unassigned_incidents: int = 0
+    blocked_incidents: int = 0
+    export_aging_incidents: int = 0
+    stalled_incidents: int = 0
+    overdue_tasks: int = 0
+
+
+class CaseOpsAlertsResponse(BaseModel):
+    stalled: int = 0
+    unassigned: int = 0
+    overdue: int = 0
+    blocked: int = 0
+    export_aging: int = 0
+
+
+class CaseTaskWidgetItem(BaseModel):
+    task_id: uuid.UUID
+    incident_id: uuid.UUID
+    title: str
+    status: str
+    priority: str
+    due_at_utc: Optional[datetime] = None
+    assigned_to_user_id: Optional[uuid.UUID] = None
+    created_at_utc: Optional[datetime] = None
+
+
+class CaseTaskWidgetResponse(BaseModel):
+    items: list[CaseTaskWidgetItem] = Field(default_factory=list)
+
+
 class MessagingReliabilityResponse(BaseModel):
     total: int = Field(default=0, ge=0)
     delivered: int = Field(default=0, ge=0)

--- a/backend/app/case_ops/metrics.py
+++ b/backend/app/case_ops/metrics.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime, timezone
+from typing import Literal
 
+from sqlalchemy.orm import Session
+
+from app.case_ops.blockers import detect_blockers
+from app.case_ops.completeness import calculate_completeness
 from app.case_ops.models import AgingMetrics, DashboardMetrics, CaseOpsSnapshot
+from app.case_ops.readiness import derive_readiness_state
+from app.db.models import Artifact, Event, Export, Incident
+from app.db.repo.case_tasks import count_overdue_tasks
+from app.db.repo.incidents import count_incident_alerts, count_incident_queue, list_incident_queue
 
 
 def _percentile(values: list[float], percentile: float) -> float:
@@ -51,3 +61,162 @@ def calculate_dashboard_metrics(*, snapshots: list[CaseOpsSnapshot], created_at_
             over_7d=sum(1 for age in ages_days if age >= 7),
         ),
     )
+
+
+def query_incident_queue(
+    db: Session,
+    *,
+    org_ids: list[uuid.UUID],
+    case_status: str | None = None,
+    owner_user_id: uuid.UUID | None = None,
+    readiness_state: str | None = None,
+    created_from_utc: datetime | None = None,
+    created_to_utc: datetime | None = None,
+    blockers: Literal["any", "critical", "important", "none"] | None = None,
+    search: str | None = None,
+    sort: Literal["urgency", "readiness", "newest"] = "newest",
+    page: int = 1,
+    page_size: int = 25,
+) -> dict:
+    skip = max(page - 1, 0) * page_size
+    incidents = list_incident_queue(
+        db,
+        org_ids=org_ids,
+        case_status=case_status,
+        owner_user_id=owner_user_id,
+        readiness_state=readiness_state,
+        created_from_utc=created_from_utc,
+        created_to_utc=created_to_utc,
+        search=search,
+        sort=sort,
+        skip=skip,
+        limit=page_size,
+    )
+    total = count_incident_queue(
+        db,
+        org_ids=org_ids,
+        case_status=case_status,
+        owner_user_id=owner_user_id,
+        readiness_state=readiness_state,
+        created_from_utc=created_from_utc,
+        created_to_utc=created_to_utc,
+        search=search,
+    )
+    if not incidents:
+        return {"items": [], "total": total, "page": page, "page_size": page_size}
+
+    incident_ids = [incident.incident_id for incident in incidents]
+    artifacts_by_incident: dict[uuid.UUID, list[Artifact]] = {}
+    events_by_incident: dict[uuid.UUID, list[Event]] = {}
+    exports_by_incident: dict[uuid.UUID, list[Export]] = {}
+    for artifact in db.query(Artifact).filter(Artifact.incident_id.in_(incident_ids)).all():
+        artifacts_by_incident.setdefault(artifact.incident_id, []).append(artifact)
+    for event in db.query(Event).filter(Event.incident_id.in_(incident_ids)).all():
+        events_by_incident.setdefault(event.incident_id, []).append(event)
+    for export in db.query(Export).filter(Export.incident_id.in_(incident_ids)).all():
+        exports_by_incident.setdefault(export.incident_id, []).append(export)
+
+    queue_items: list[dict] = []
+    for incident in incidents:
+        snapshot = _build_snapshot(
+            incident=incident,
+            artifacts=artifacts_by_incident.get(incident.incident_id, []),
+            events=events_by_incident.get(incident.incident_id, []),
+            exports=exports_by_incident.get(incident.incident_id, []),
+        )
+        queue_item = _build_queue_item(incident=incident, snapshot=snapshot)
+        if _matches_blocker_filter(snapshot=snapshot, blockers=blockers):
+            queue_items.append(queue_item)
+
+    return {"items": queue_items, "total": total, "page": page, "page_size": page_size}
+
+
+def query_summary_metrics(
+    db: Session,
+    *,
+    org_ids: list[uuid.UUID],
+    now_utc: datetime | None = None,
+) -> dict:
+    now = now_utc or datetime.now(timezone.utc)
+    open_incident_count = count_incident_queue(
+        db,
+        org_ids=org_ids,
+    )
+    alert_counts = count_incident_alerts(db, org_ids=org_ids, now_utc=now)
+    overdue_tasks = count_overdue_tasks(db, org_ids=org_ids, now_utc=now)
+    return {
+        "open_incidents": open_incident_count,
+        "unassigned_incidents": alert_counts["unassigned"],
+        "blocked_incidents": alert_counts["blocked"],
+        "export_aging_incidents": alert_counts["export_aging"],
+        "stalled_incidents": alert_counts["stalled"],
+        "overdue_tasks": overdue_tasks,
+    }
+
+
+def query_case_alerts(
+    db: Session,
+    *,
+    org_ids: list[uuid.UUID],
+    now_utc: datetime | None = None,
+) -> dict:
+    now = now_utc or datetime.now(timezone.utc)
+    alert_counts = count_incident_alerts(db, org_ids=org_ids, now_utc=now)
+    return {
+        "stalled": alert_counts["stalled"],
+        "unassigned": alert_counts["unassigned"],
+        "blocked": alert_counts["blocked"],
+        "overdue": count_overdue_tasks(db, org_ids=org_ids, now_utc=now),
+        "export_aging": alert_counts["export_aging"],
+    }
+
+
+def _matches_blocker_filter(
+    *,
+    snapshot: CaseOpsSnapshot,
+    blockers: Literal["any", "critical", "important", "none"] | None,
+) -> bool:
+    if blockers is None:
+        return True
+    if blockers == "any":
+        return snapshot.blockers.total > 0
+    if blockers == "critical":
+        return snapshot.blockers.critical_count > 0
+    if blockers == "important":
+        return snapshot.blockers.important_count > 0
+    if blockers == "none":
+        return snapshot.blockers.total == 0
+    return True
+
+
+def _build_queue_item(*, incident: Incident, snapshot: CaseOpsSnapshot) -> dict:
+    return {
+        "incident_id": incident.incident_id,
+        "case_status": incident.case_status,
+        "owner_user_id": incident.owner_user_id,
+        "readiness_state": snapshot.readiness.state,
+        "created_at_utc": incident.created_at_utc,
+        "last_activity_at_utc": incident.last_activity_at_utc,
+        "severity": incident.severity,
+        "adc_vehicle_id": incident.adc_vehicle_id,
+        "adc_driver_id": incident.adc_driver_id,
+        "completeness_percent": snapshot.completeness.percent,
+        "blockers": {
+            "total": snapshot.blockers.total,
+            "critical": snapshot.blockers.critical_count,
+            "important": snapshot.blockers.important_count,
+            "optional": snapshot.blockers.optional_count,
+        },
+    }
+
+
+def _build_snapshot(*, incident, artifacts: list, events: list, exports: list) -> CaseOpsSnapshot:
+    completeness = calculate_completeness(artifacts=artifacts, events=events, exports=exports)
+    blockers = detect_blockers(artifacts=artifacts, events=events, exports=exports)
+    readiness = derive_readiness_state(
+        case_status=getattr(incident, "case_status", "new") or "new",
+        completeness_percent=completeness.percent,
+        completeness_status=completeness.status,
+        blockers=blockers,
+    )
+    return CaseOpsSnapshot(completeness=completeness, blockers=blockers, readiness=readiness)

--- a/backend/app/db/repo/case_tasks.py
+++ b/backend/app/db/repo/case_tasks.py
@@ -1,0 +1,78 @@
+"""Repository helpers for case task dashboard queries."""
+
+from __future__ import annotations
+
+import uuid as _uuid
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from app.db.models import CaseTask
+
+OPEN_TASK_STATUSES: tuple[str, ...] = ("open", "in_progress", "blocked")
+
+
+def list_my_open_tasks(
+    db: Session,
+    *,
+    org_ids: list[_uuid.UUID],
+    user_id: _uuid.UUID,
+    now_utc: datetime,
+    limit: int = 20,
+) -> list[CaseTask]:
+    if not org_ids:
+        return []
+    return (
+        db.query(CaseTask)
+        .filter(
+            CaseTask.org_id.in_(org_ids),
+            CaseTask.assigned_to_user_id == user_id,
+            CaseTask.status.in_(OPEN_TASK_STATUSES),
+        )
+        .order_by(CaseTask.due_at_utc.asc().nullslast(), CaseTask.created_at_utc.desc())
+        .limit(limit)
+        .all()
+    )
+
+
+def list_overdue_tasks(
+    db: Session,
+    *,
+    org_ids: list[_uuid.UUID],
+    now_utc: datetime,
+    limit: int = 20,
+) -> list[CaseTask]:
+    if not org_ids:
+        return []
+    return (
+        db.query(CaseTask)
+        .filter(
+            CaseTask.org_id.in_(org_ids),
+            CaseTask.status.in_(OPEN_TASK_STATUSES),
+            CaseTask.due_at_utc.is_not(None),
+            CaseTask.due_at_utc < now_utc,
+        )
+        .order_by(CaseTask.due_at_utc.asc(), CaseTask.created_at_utc.desc())
+        .limit(limit)
+        .all()
+    )
+
+
+def count_overdue_tasks(
+    db: Session,
+    *,
+    org_ids: list[_uuid.UUID],
+    now_utc: datetime,
+) -> int:
+    if not org_ids:
+        return 0
+    return (
+        db.query(CaseTask)
+        .filter(
+            CaseTask.org_id.in_(org_ids),
+            CaseTask.status.in_(OPEN_TASK_STATUSES),
+            CaseTask.due_at_utc.is_not(None),
+            CaseTask.due_at_utc < now_utc,
+        )
+        .count()
+    )

--- a/backend/app/db/repo/incidents.py
+++ b/backend/app/db/repo/incidents.py
@@ -1,7 +1,9 @@
 """Repository layer for incidents."""
 
 import uuid as _uuid
+from datetime import datetime, timedelta
 
+from sqlalchemy import Text, case, cast, or_
 from sqlalchemy.orm import Session
 
 from app.db.models import Incident
@@ -51,3 +53,156 @@ def create_incident(
     db.commit()
     db.refresh(incident)
     return incident
+
+
+def list_incident_queue(
+    db: Session,
+    *,
+    org_ids: list[_uuid.UUID],
+    case_status: str | None = None,
+    owner_user_id: _uuid.UUID | None = None,
+    readiness_state: str | None = None,
+    created_from_utc: datetime | None = None,
+    created_to_utc: datetime | None = None,
+    search: str | None = None,
+    sort: str = "newest",
+    skip: int = 0,
+    limit: int = 50,
+) -> list[Incident]:
+    """List case queue incidents with filters, pagination, and sorting."""
+    if not org_ids:
+        return []
+
+    query = db.query(Incident).filter(Incident.org_id.in_(org_ids))
+    if case_status:
+        query = query.filter(Incident.case_status == case_status)
+    if owner_user_id:
+        query = query.filter(Incident.owner_user_id == owner_user_id)
+    if readiness_state:
+        query = query.filter(Incident.readiness_state == readiness_state)
+    if created_from_utc:
+        query = query.filter(Incident.created_at_utc >= created_from_utc)
+    if created_to_utc:
+        query = query.filter(Incident.created_at_utc <= created_to_utc)
+    if search:
+        pattern = f"%{search.strip()}%"
+        query = query.filter(
+            or_(
+                cast(Incident.incident_id, Text).ilike(pattern),
+                Incident.adc_vehicle_id.ilike(pattern),
+                Incident.samsara_vehicle_id.ilike(pattern),
+                Incident.adc_driver_id.ilike(pattern),
+                Incident.severity.ilike(pattern),
+            )
+        )
+
+    if sort == "urgency":
+        query = query.order_by(
+            case(
+                (Incident.case_status == "escalated", 0),
+                (Incident.case_status == "awaiting_follow_up", 1),
+                (Incident.case_status == "awaiting_evidence", 2),
+                (Incident.case_status == "in_review", 3),
+                (Incident.case_status == "new", 4),
+                (Incident.case_status == "ready_for_export", 5),
+                (Incident.case_status == "exported", 6),
+                (Incident.case_status == "closed", 7),
+                else_=8,
+            ),
+            Incident.last_activity_at_utc.asc().nullsfirst(),
+            Incident.created_at_utc.asc(),
+        )
+    elif sort == "readiness":
+        query = query.order_by(
+            case(
+                (Incident.readiness_state == "not_ready", 0),
+                (Incident.readiness_state == "conditionally_ready", 1),
+                (Incident.readiness_state == "ready_for_export", 2),
+                (Incident.readiness_state == "exported", 3),
+                (Incident.readiness_state == "closed", 4),
+                else_=5,
+            ),
+            Incident.created_at_utc.desc(),
+        )
+    else:
+        query = query.order_by(Incident.created_at_utc.desc())
+
+    return query.offset(skip).limit(limit).all()
+
+
+def count_incident_queue(
+    db: Session,
+    *,
+    org_ids: list[_uuid.UUID],
+    case_status: str | None = None,
+    owner_user_id: _uuid.UUID | None = None,
+    readiness_state: str | None = None,
+    created_from_utc: datetime | None = None,
+    created_to_utc: datetime | None = None,
+    search: str | None = None,
+) -> int:
+    if not org_ids:
+        return 0
+
+    query = db.query(Incident).filter(Incident.org_id.in_(org_ids))
+    if case_status:
+        query = query.filter(Incident.case_status == case_status)
+    if owner_user_id:
+        query = query.filter(Incident.owner_user_id == owner_user_id)
+    if readiness_state:
+        query = query.filter(Incident.readiness_state == readiness_state)
+    if created_from_utc:
+        query = query.filter(Incident.created_at_utc >= created_from_utc)
+    if created_to_utc:
+        query = query.filter(Incident.created_at_utc <= created_to_utc)
+    if search:
+        pattern = f"%{search.strip()}%"
+        query = query.filter(
+            or_(
+                cast(Incident.incident_id, Text).ilike(pattern),
+                Incident.adc_vehicle_id.ilike(pattern),
+                Incident.samsara_vehicle_id.ilike(pattern),
+                Incident.adc_driver_id.ilike(pattern),
+                Incident.severity.ilike(pattern),
+            )
+        )
+    return query.count()
+
+
+def count_incident_alerts(
+    db: Session,
+    *,
+    org_ids: list[_uuid.UUID],
+    now_utc: datetime,
+) -> dict[str, int]:
+    """Count incidents requiring queue alerts."""
+    if not org_ids:
+        return {
+            "stalled": 0,
+            "unassigned": 0,
+            "blocked": 0,
+            "export_aging": 0,
+        }
+
+    base = db.query(Incident).filter(
+        Incident.org_id.in_(org_ids), Incident.case_status != "closed"
+    )
+    stalled_cutoff = now_utc - timedelta(hours=72)
+    export_aging_cutoff = now_utc - timedelta(hours=48)
+
+    return {
+        "stalled": base.filter(
+            Incident.last_activity_at_utc.is_not(None),
+            Incident.last_activity_at_utc <= stalled_cutoff,
+        ).count(),
+        "unassigned": base.filter(Incident.owner_user_id.is_(None)).count(),
+        "blocked": base.filter(Incident.readiness_state == "not_ready").count(),
+        "export_aging": db.query(Incident)
+        .filter(
+            Incident.org_id.in_(org_ids),
+            Incident.case_status == "ready_for_export",
+            Incident.ready_for_export_at_utc.is_not(None),
+            Incident.ready_for_export_at_utc <= export_aging_cutoff,
+        )
+        .count(),
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from app.api.routes_exports import router as exports_router
 from app.api.routes_driver import router as driver_router
 from app.api.routes_integrations import router as integrations_router
 from app.api.routes.routes_driver_artifacts import router as driver_artifacts_router
+from app.api.routes.routes_case_ops import router as case_ops_router
 from app.api.routes.routes_driver_report import router as driver_report_router
 from app.api.routes_admin import router as admin_router
 from app.api.routes_twilio import router as twilio_router
@@ -45,6 +46,7 @@ app.include_router(driver_auth_router, prefix="/driver/auth", tags=["driver-auth
 app.include_router(driver_router, prefix="/driver", tags=["driver"])
 app.include_router(driver_artifacts_router, prefix="/driver", tags=["driver-artifacts"])
 app.include_router(driver_report_router, prefix="/driver", tags=["driver-report"])
+app.include_router(case_ops_router, tags=["case-ops"])
 app.include_router(admin_router, prefix="/admin", tags=["admin"])
 app.include_router(twilio_router, prefix="/twilio", tags=["twilio"])
 app.include_router(integrations_router, tags=["integrations"])


### PR DESCRIPTION
### Motivation
- Provide case-ops UI primitives: a filtered/paginated case queue, KPI summary cards, case alerts, and task widgets so the frontend can render operational dashboards and drive workflows.
- Centralize query logic for these views in the case-ops query layer and repository helpers to keep database access efficient and reusable.

### Description
- Add a new router `backend/app/api/routes/routes_case_ops.py` exposing `GET /incidents/queue`, `GET /incidents/summary-metrics`, `GET /incidents/alerts`, `GET /tasks/my-open`, and `GET /tasks/overdue` with auth and request validation.
- Implement query-layer functions in `backend/app/case_ops/metrics.py`: `query_incident_queue`, `query_summary_metrics`, and `query_case_alerts`, plus blocker filtering and queue-item shaping using existing readiness/blocker/completeness logic.
- Add repository helpers in `backend/app/db/repo/incidents.py`: `list_incident_queue`, `count_incident_queue`, and `count_incident_alerts` supporting filters, search, pagination, and sorting by `urgency`, `readiness`, and `newest`.
- Add task repo helpers in new `backend/app/db/repo/case_tasks.py` for `list_my_open_tasks`, `list_overdue_tasks`, and `count_overdue_tasks`, and new API schemas in `backend/app/api/schemas.py` for queue items, KPI cards, alerts, and task widgets.
- Register the router in `backend/app/main.py` so endpoints are available at startup and use timezone-aware UTC timestamps for task queries.

### Testing
- Ran linting with `make lint` (`ruff`) and the linter passed with no errors.
- Ran the full test suite with `make test` and all automated tests passed (`406 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddacd92c608321b4f92efa05435d91)