### PR TITLE
Add case-ops incident workspace endpoint, schema, and tests

### DIFF
--- a/backend/app/api/routes/routes_case_ops.py
+++ b/backend/app/api/routes/routes_case_ops.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
+import json
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from app.api.schemas import (
@@ -14,15 +16,32 @@ from app.api.schemas import (
     CaseOpsQueueResponse,
     CaseOpsQueueSort,
     CaseOpsSummaryMetricsResponse,
+    CaseOpsWorkspaceActivityItem,
+    CaseOpsWorkspaceCompleteness,
+    CaseOpsWorkspaceCompletenessSection,
+    CaseOpsWorkspaceEvidenceSummary,
+    CaseOpsWorkspaceNoteItem,
+    CaseOpsWorkspaceOwner,
+    CaseOpsWorkspaceResponse,
+    CaseOpsWorkspaceTaskItem,
     CaseTaskWidgetItem,
     CaseTaskWidgetResponse,
 )
-from app.case_ops.metrics import query_case_alerts, query_incident_queue, query_summary_metrics
+from app.case_ops.blockers import detect_blockers
+from app.case_ops.completeness import calculate_completeness
+from app.case_ops.readiness import derive_readiness_state
+from app.case_ops.metrics import (
+    query_case_alerts,
+    query_incident_queue,
+    query_summary_metrics,
+)
 from app.core.deps import get_current_user
-from app.db.models import User
+from app.db.models import Artifact, AuditEvent, CaseNote, CaseTask, Event, Export, User
+from app.db.repo.incidents import get_incident
 from app.db.repo.case_tasks import list_my_open_tasks, list_overdue_tasks
 from app.db.session import get_db
 from app.security.authn import build_user_auth_context
+from app.security.authz import can_view_incident, require_policy
 
 router = APIRouter()
 
@@ -139,3 +158,190 @@ def get_overdue_tasks(
             for task in tasks
         ]
     )
+
+
+@router.get(
+    "/incidents/{incident_id}/workspace", response_model=CaseOpsWorkspaceResponse
+)
+def get_incident_workspace(
+    incident_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    incident = get_incident(db, incident_id=incident_id, org_ids=list(context.org_ids))
+    if incident is None:
+        raise HTTPException(status_code=404, detail="Incident not found")
+    require_policy(can_view_incident(context, incident))
+
+    artifacts = (
+        db.query(Artifact).filter(Artifact.incident_id == incident.incident_id).all()
+    )
+    exports = db.query(Export).filter(Export.incident_id == incident.incident_id).all()
+    events = (
+        db.query(Event)
+        .filter(Event.incident_id == incident.incident_id)
+        .order_by(Event.occurred_at_utc.desc())
+        .all()
+    )
+    audit_events = (
+        db.query(AuditEvent)
+        .filter(AuditEvent.incident_id == incident.incident_id)
+        .order_by(AuditEvent.occurred_at_utc.desc())
+        .all()
+    )
+    open_tasks = (
+        db.query(CaseTask)
+        .filter(
+            CaseTask.incident_id == incident.incident_id,
+            CaseTask.status.in_(("open", "in_progress", "blocked")),
+        )
+        .order_by(CaseTask.due_at_utc.asc().nullslast(), CaseTask.created_at_utc.desc())
+        .all()
+    )
+    recent_notes = (
+        db.query(CaseNote)
+        .filter(
+            CaseNote.incident_id == incident.incident_id,
+            or_(CaseNote.is_deleted.is_(False), CaseNote.is_deleted.is_(None)),
+        )
+        .order_by(CaseNote.created_at_utc.desc())
+        .limit(10)
+        .all()
+    )
+
+    completeness = calculate_completeness(
+        artifacts=artifacts, events=events, exports=exports
+    )
+    blockers = detect_blockers(artifacts=artifacts, events=events, exports=exports)
+    readiness = derive_readiness_state(
+        case_status=str(incident.case_status),
+        completeness_percent=completeness.percent,
+        completeness_status=completeness.status,
+        blockers=blockers,
+    )
+
+    owner = None
+    if incident.owner_user_id is not None:
+        owner_user = db.query(User).filter(User.id == incident.owner_user_id).first()
+        owner = CaseOpsWorkspaceOwner(
+            user_id=incident.owner_user_id,
+            email=(owner_user.email if owner_user is not None else None),
+        )
+
+    activity_entries = [
+        CaseOpsWorkspaceActivityItem(
+            source="event",
+            type=event.event_type,
+            occurred_at_utc=event.occurred_at_utc,
+            actor_type=event.actor_type,
+            actor_id=event.actor_id,
+            detail=_normalize_detail(event.payload),
+        )
+        for event in events
+    ]
+    activity_entries.extend(
+        CaseOpsWorkspaceActivityItem(
+            source="audit",
+            type=audit_event.event_type,
+            occurred_at_utc=audit_event.occurred_at_utc,
+            actor_type=audit_event.actor_type,
+            actor_id=audit_event.actor_id,
+            detail=_normalize_detail(audit_event.metadata_json),
+        )
+        for audit_event in audit_events
+    )
+    activity_entries.sort(key=lambda entry: entry.occurred_at_utc, reverse=True)
+
+    evidence_status_counts = {
+        "captured": sum(1 for artifact in artifacts if artifact.status == "captured"),
+        "pending": sum(1 for artifact in artifacts if artifact.status == "pending"),
+        "unavailable": sum(
+            1 for artifact in artifacts if artifact.status == "unavailable"
+        ),
+    }
+
+    return CaseOpsWorkspaceResponse(
+        incident_id=incident.incident_id,
+        owner=owner,
+        case_status=incident.case_status,
+        readiness_state=readiness.state,
+        completeness=CaseOpsWorkspaceCompleteness(
+            percent=completeness.percent,
+            status=completeness.status,
+            missing_items=list(completeness.missing_items),
+            sections=[
+                CaseOpsWorkspaceCompletenessSection(
+                    name=dimension.name,
+                    earned=dimension.earned,
+                    possible=dimension.possible,
+                    percent=dimension.percent,
+                    status=dimension.status,
+                    missing_items=list(dimension.missing_items),
+                )
+                for dimension in completeness.dimensions
+            ],
+        ),
+        blockers=[
+            {
+                "code": blocker.code,
+                "severity": blocker.severity,
+                "message": blocker.message,
+                "blocks_readiness": blocker.blocks_readiness,
+                "action_hint": blocker.missing_item.actionHint,
+                "missing_item": {
+                    "code": blocker.missing_item.code,
+                    "category": blocker.missing_item.category,
+                    "severity": blocker.missing_item.severity,
+                    "message": blocker.missing_item.message,
+                    "resolvableBy": blocker.missing_item.resolvableBy,
+                    "actionHint": blocker.missing_item.actionHint,
+                },
+            }
+            for blocker in blockers.items
+        ],
+        evidence_summary=CaseOpsWorkspaceEvidenceSummary(
+            total=len(artifacts),
+            captured=evidence_status_counts["captured"],
+            pending=evidence_status_counts["pending"],
+            unavailable=evidence_status_counts["unavailable"],
+        ),
+        missing_items=list(completeness.missing_items),
+        open_tasks=[
+            CaseOpsWorkspaceTaskItem(
+                task_id=task.task_id,
+                title=task.title,
+                status=task.status,
+                priority=task.priority,
+                due_at_utc=task.due_at_utc,
+                assigned_to_user_id=task.assigned_to_user_id,
+                created_at_utc=task.created_at_utc,
+            )
+            for task in open_tasks
+        ],
+        recent_notes=[
+            CaseOpsWorkspaceNoteItem(
+                note_id=note.note_id,
+                body=note.body,
+                created_by_user_id=note.created_by_user_id,
+                created_at_utc=note.created_at_utc,
+                edited_at_utc=note.edited_at_utc,
+            )
+            for note in recent_notes
+        ],
+        activity=activity_entries,
+    )
+
+
+def _normalize_detail(detail: object) -> dict:
+    if detail is None:
+        return {}
+    if isinstance(detail, dict):
+        return detail
+    if isinstance(detail, str):
+        try:
+            loaded = json.loads(detail)
+            return loaded if isinstance(loaded, dict) else {"value": loaded}
+        except json.JSONDecodeError:
+            return {"value": detail}
+    return {"value": str(detail)}

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -402,7 +402,9 @@ class CaseOpsQueueItem(BaseModel):
     adc_vehicle_id: Optional[VehicleId] = None
     adc_driver_id: Optional[DriverId] = None
     completeness_percent: int = Field(default=0, ge=0, le=100)
-    blockers: CaseOpsQueueBlockerCounts = Field(default_factory=CaseOpsQueueBlockerCounts)
+    blockers: CaseOpsQueueBlockerCounts = Field(
+        default_factory=CaseOpsQueueBlockerCounts
+    )
 
 
 class CaseOpsQueueResponse(BaseModel):
@@ -442,6 +444,77 @@ class CaseTaskWidgetItem(BaseModel):
 
 class CaseTaskWidgetResponse(BaseModel):
     items: list[CaseTaskWidgetItem] = Field(default_factory=list)
+
+
+class CaseOpsWorkspaceOwner(BaseModel):
+    user_id: uuid.UUID
+    email: Optional[EmailStrLike] = None
+
+
+class CaseOpsWorkspaceCompletenessSection(BaseModel):
+    name: str
+    earned: int = 0
+    possible: int = 0
+    percent: int = Field(default=0, ge=0, le=100)
+    status: str = "incomplete"
+    missing_items: list[str] = Field(default_factory=list)
+
+
+class CaseOpsWorkspaceCompleteness(BaseModel):
+    percent: int = Field(default=0, ge=0, le=100)
+    status: str = "incomplete"
+    missing_items: list[str] = Field(default_factory=list)
+    sections: list[CaseOpsWorkspaceCompletenessSection] = Field(default_factory=list)
+
+
+class CaseOpsWorkspaceEvidenceSummary(BaseModel):
+    total: int = 0
+    captured: int = 0
+    pending: int = 0
+    unavailable: int = 0
+
+
+class CaseOpsWorkspaceTaskItem(BaseModel):
+    task_id: uuid.UUID
+    title: str
+    status: str
+    priority: str
+    due_at_utc: Optional[datetime] = None
+    assigned_to_user_id: Optional[uuid.UUID] = None
+    created_at_utc: Optional[datetime] = None
+
+
+class CaseOpsWorkspaceNoteItem(BaseModel):
+    note_id: uuid.UUID
+    body: str
+    created_by_user_id: Optional[uuid.UUID] = None
+    created_at_utc: datetime
+    edited_at_utc: Optional[datetime] = None
+
+
+class CaseOpsWorkspaceActivityItem(BaseModel):
+    source: Literal["event", "audit"]
+    type: str
+    occurred_at_utc: datetime
+    actor_type: str
+    actor_id: str
+    detail: dict[str, Any] = Field(default_factory=dict)
+
+
+class CaseOpsWorkspaceResponse(BaseModel):
+    incident_id: uuid.UUID
+    owner: Optional[CaseOpsWorkspaceOwner] = None
+    case_status: IncidentCaseStatus
+    readiness_state: str = "not_ready"
+    completeness: CaseOpsWorkspaceCompleteness
+    blockers: list[dict[str, Any]] = Field(default_factory=list)
+    evidence_summary: CaseOpsWorkspaceEvidenceSummary = Field(
+        default_factory=CaseOpsWorkspaceEvidenceSummary
+    )
+    missing_items: list[str] = Field(default_factory=list)
+    open_tasks: list[CaseOpsWorkspaceTaskItem] = Field(default_factory=list)
+    recent_notes: list[CaseOpsWorkspaceNoteItem] = Field(default_factory=list)
+    activity: list[CaseOpsWorkspaceActivityItem] = Field(default_factory=list)
 
 
 class MessagingReliabilityResponse(BaseModel):

--- a/backend/tests/test_case_ops_workspace_route.py
+++ b/backend/tests/test_case_ops_workspace_route.py
@@ -1,0 +1,225 @@
+"""Tests for case-ops incident workspace route."""
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.security import create_access_token, hash_password
+from app.db.models import (
+    Artifact,
+    AuditEvent,
+    Base,
+    CaseNote,
+    CaseTask,
+    Event,
+    Incident,
+    Org,
+    User,
+    UserOrg,
+)
+from app.db.session import get_db
+from app.main import app
+
+
+@pytest.fixture()
+def db_session():
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine)
+    session = TestSession()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def test_org(db_session):
+    org = Org(name="CaseOps Org")
+    db_session.add(org)
+    db_session.commit()
+    db_session.refresh(org)
+    return org
+
+
+@pytest.fixture()
+def test_user(db_session, test_org):
+    user = User(
+        email="caseops@example.com",
+        password_hash=hash_password("testpass"),
+        role="safety_manager",
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    db_session.add(UserOrg(user_id=user.id, org_id=test_org.id))
+    db_session.commit()
+    return user
+
+
+@pytest.fixture()
+def auth_headers(test_user):
+    token = create_access_token({"sub": str(test_user.id), "role": test_user.role})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_get_workspace_returns_incident_workspace_summary(
+    client: TestClient,
+    db_session,
+    test_org,
+    test_user,
+    auth_headers,
+):
+    incident = Incident(
+        org_id=test_org.id,
+        status="evidence_capturing",
+        case_status="awaiting_evidence",
+        severity="serious",
+        adc_vehicle_id="veh-42",
+        adc_driver_id="drv-42",
+        owner_user_id=test_user.id,
+    )
+    db_session.add(incident)
+    db_session.commit()
+    db_session.refresh(incident)
+
+    db_session.add_all(
+        [
+            Artifact(
+                org_id=test_org.id,
+                incident_id=incident.incident_id,
+                artifact_type="dashcam",
+                status="captured",
+            ),
+            Artifact(
+                org_id=test_org.id,
+                incident_id=incident.incident_id,
+                artifact_type="telemetry",
+                status="pending",
+            ),
+            CaseTask(
+                org_id=test_org.id,
+                incident_id=incident.incident_id,
+                title="Follow up with witness",
+                status="open",
+                priority="high",
+            ),
+            CaseTask(
+                org_id=test_org.id,
+                incident_id=incident.incident_id,
+                title="Already done",
+                status="completed",
+                priority="low",
+            ),
+            CaseNote(
+                org_id=test_org.id,
+                incident_id=incident.incident_id,
+                body="Driver contacted.",
+                created_by_user_id=test_user.id,
+            ),
+            CaseNote(
+                org_id=test_org.id,
+                incident_id=incident.incident_id,
+                body="Deleted note",
+                is_deleted=True,
+                created_by_user_id=test_user.id,
+            ),
+            Event(
+                org_id=test_org.id,
+                incident_id=incident.incident_id,
+                event_type="incident_started",
+                actor_type="system",
+                actor_id="system",
+                occurred_at_utc=datetime.now(timezone.utc),
+                payload={"step": "begin"},
+            ),
+            AuditEvent(
+                org_id=test_org.id,
+                incident_id=incident.incident_id,
+                action="incident.case_status.patch",
+                event_type="incident_case_status_updated",
+                actor_type="user",
+                actor_id=str(test_user.id),
+                occurred_at_utc=datetime.now(timezone.utc),
+                metadata_json={"to": "awaiting_evidence"},
+            ),
+        ]
+    )
+    db_session.commit()
+
+    response = client.get(
+        f"/incidents/{incident.incident_id}/workspace", headers=auth_headers
+    )
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["incident_id"] == str(incident.incident_id)
+    assert payload["owner"]["user_id"] == str(test_user.id)
+    assert payload["case_status"] == "awaiting_evidence"
+    assert "readiness_state" in payload
+    assert payload["completeness"]["percent"] >= 0
+    assert isinstance(payload["blockers"], list)
+    assert payload["evidence_summary"] == {
+        "total": 2,
+        "captured": 1,
+        "pending": 1,
+        "unavailable": 0,
+    }
+    assert len(payload["open_tasks"]) == 1
+    assert payload["open_tasks"][0]["title"] == "Follow up with witness"
+    assert len(payload["recent_notes"]) == 1
+    assert payload["recent_notes"][0]["body"] == "Driver contacted."
+    activity_types = {item["type"] for item in payload["activity"]}
+    assert "incident_started" in activity_types
+    assert "incident_case_status_updated" in activity_types
+
+
+def test_get_workspace_enforces_org_tenancy(
+    client: TestClient,
+    db_session,
+    auth_headers,
+):
+    other_org = Org(name="Other Org")
+    db_session.add(other_org)
+    db_session.commit()
+    db_session.refresh(other_org)
+
+    incident = Incident(
+        org_id=other_org.id,
+        status="open",
+        case_status="new",
+        severity="minor",
+        adc_vehicle_id="veh-other",
+        adc_driver_id="drv-other",
+    )
+    db_session.add(incident)
+    db_session.commit()
+    db_session.refresh(incident)
+
+    response = client.get(
+        f"/incidents/{incident.incident_id}/workspace", headers=auth_headers
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
### Motivation
- Provide a single workspace endpoint for case operators to view a consolidated incident context (header, owner, case status, readiness). 
- Surface completeness, blockers, evidence summary, missing items, open tasks, recent notes, and a merged activity timeline (events + audit) in one response for the UI. 
- Preserve org tenancy and role-based visibility when returning workspace data.

### Description
- Implemented `GET /incidents/{incident_id}/workspace` in `backend/app/api/routes/routes_case_ops.py` with org-scoped incident lookup and `can_view_incident` enforcement. 
- Built the workspace payload: owner, `case_status`, `readiness_state`, `completeness` (with sections), `blockers`, `evidence_summary`, `missing_items`, `open_tasks`, `recent_notes`, and `activity` merged from `events` and `audit_events`. 
- Added new Pydantic response models in `backend/app/api/schemas.py` (`CaseOpsWorkspaceResponse` and nested types) to define the response schema. 
- Added unit tests in `backend/tests/test_case_ops_workspace_route.py` to validate payload content and org tenancy behavior. 

### Testing
- Ran static checks with `ruff check` and formatting with `ruff format`, and they passed. 
- Ran the new route unit tests with `pytest -q tests/test_case_ops_workspace_route.py` and all tests passed (`2 passed`). 
- Ran full repo lint gates via `make lint` and the lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddaf0043a48321aaeb4edd580938d4)