### PR TITLE
Add incident notes CRUD API with permission and soft-delete support

### DIFF
--- a/backend/app/api/routes/routes_case_ops.py
+++ b/backend/app/api/routes/routes_case_ops.py
@@ -323,6 +323,8 @@ def get_incident_workspace(
             CaseOpsWorkspaceNoteItem(
                 note_id=note.note_id,
                 body=note.body,
+                note_type=str(note.note_type or "standard"),
+                tags=list(note.tags_json or []),
                 created_by_user_id=note.created_by_user_id,
                 created_at_utc=note.created_at_utc,
                 edited_at_utc=note.edited_at_utc,

--- a/backend/app/api/routes/routes_notes.py
+++ b/backend/app/api/routes/routes_notes.py
@@ -1,0 +1,175 @@
+"""Incident notes CRUD routes (internal-only)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from app.api.schemas import (
+    IncidentNoteCreateRequest,
+    IncidentNoteDeleteRequest,
+    IncidentNoteItem,
+    IncidentNotePatchRequest,
+    IncidentNotesResponse,
+)
+from app.core.deps import get_current_user
+from app.db.models import CaseNote, User
+from app.db.repo.incidents import get_incident
+from app.db.session import get_db
+from app.security.authn import build_user_auth_context
+from app.security.authz import can_modify_incident, can_view_incident, require_policy
+
+router = APIRouter()
+
+
+@router.get("/incidents/{incident_id}/notes", response_model=IncidentNotesResponse)
+def list_incident_notes(
+    incident_id: uuid.UUID,
+    include_deleted: bool = Query(default=False),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    incident = get_incident(db, incident_id=incident_id, org_ids=list(context.org_ids))
+    if incident is None:
+        raise HTTPException(status_code=404, detail="Incident not found")
+    require_policy(can_view_incident(context, incident))
+
+    query = db.query(CaseNote).filter(CaseNote.incident_id == incident.incident_id)
+    if not include_deleted:
+        query = query.filter(or_(CaseNote.is_deleted.is_(False), CaseNote.is_deleted.is_(None)))
+    notes = query.order_by(CaseNote.created_at_utc.desc()).all()
+    return IncidentNotesResponse(items=[_to_note_item(note) for note in notes])
+
+
+@router.post("/incidents/{incident_id}/notes", response_model=IncidentNoteItem)
+def create_incident_note(
+    incident_id: uuid.UUID,
+    request: IncidentNoteCreateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    incident = get_incident(db, incident_id=incident_id, org_ids=list(context.org_ids))
+    if incident is None:
+        raise HTTPException(status_code=404, detail="Incident not found")
+    require_policy(can_modify_incident(context, incident))
+
+    note = CaseNote(
+        org_id=incident.org_id,
+        incident_id=incident.incident_id,
+        body=request.body,
+        note_type=request.note_type,
+        tags_json=list(request.tags or []),
+        created_by_user_id=current_user.id,
+    )
+    db.add(note)
+    db.commit()
+    db.refresh(note)
+    return _to_note_item(note)
+
+
+@router.patch("/incidents/{incident_id}/notes", response_model=IncidentNoteItem)
+def patch_incident_note(
+    incident_id: uuid.UUID,
+    request: IncidentNotePatchRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    incident = get_incident(db, incident_id=incident_id, org_ids=list(context.org_ids))
+    if incident is None:
+        raise HTTPException(status_code=404, detail="Incident not found")
+    require_policy(can_modify_incident(context, incident))
+
+    note = (
+        db.query(CaseNote)
+        .filter(CaseNote.incident_id == incident.incident_id, CaseNote.note_id == request.note_id)
+        .first()
+    )
+    if note is None:
+        raise HTTPException(status_code=404, detail="Note not found")
+    if bool(note.is_deleted):
+        raise HTTPException(status_code=409, detail="Cannot edit deleted note")
+    require_policy(_can_edit_note(current_user=current_user, note=note))
+
+    did_change = False
+    if request.body is not None:
+        note.body = request.body
+        did_change = True
+    if request.note_type is not None:
+        note.note_type = request.note_type
+        did_change = True
+    if request.tags is not None:
+        note.tags_json = list(request.tags)
+        did_change = True
+
+    if did_change:
+        note.edited_by_user_id = current_user.id
+        note.edited_at_utc = datetime.now(timezone.utc)
+
+    db.add(note)
+    db.commit()
+    db.refresh(note)
+    return _to_note_item(note)
+
+
+@router.delete("/incidents/{incident_id}/notes", response_model=IncidentNoteItem)
+def delete_incident_note(
+    incident_id: uuid.UUID,
+    request: IncidentNoteDeleteRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    incident = get_incident(db, incident_id=incident_id, org_ids=list(context.org_ids))
+    if incident is None:
+        raise HTTPException(status_code=404, detail="Incident not found")
+    require_policy(can_modify_incident(context, incident))
+
+    note = (
+        db.query(CaseNote)
+        .filter(CaseNote.incident_id == incident.incident_id, CaseNote.note_id == request.note_id)
+        .first()
+    )
+    if note is None:
+        raise HTTPException(status_code=404, detail="Note not found")
+    require_policy(_can_edit_note(current_user=current_user, note=note))
+
+    if not bool(note.is_deleted):
+        note.is_deleted = True
+        note.deleted_by_user_id = current_user.id
+        note.deleted_at_utc = datetime.now(timezone.utc)
+        db.add(note)
+        db.commit()
+        db.refresh(note)
+    return _to_note_item(note)
+
+
+def _can_edit_note(*, current_user: User, note: CaseNote) -> bool:
+    if current_user.role in {"org_admin", "system_admin"}:
+        return True
+    return note.created_by_user_id == current_user.id
+
+
+def _to_note_item(note: CaseNote) -> IncidentNoteItem:
+    return IncidentNoteItem(
+        note_id=note.note_id,
+        incident_id=note.incident_id,
+        body=note.body,
+        note_type=str(note.note_type or "standard"),
+        tags=list(note.tags_json or []),
+        created_by_user_id=note.created_by_user_id,
+        created_at_utc=note.created_at_utc,
+        edited=bool(note.edited_at_utc),
+        edited_by_user_id=note.edited_by_user_id,
+        edited_at_utc=note.edited_at_utc,
+        updated_at_utc=note.updated_at_utc,
+        is_deleted=bool(note.is_deleted),
+        deleted_by_user_id=note.deleted_by_user_id,
+        deleted_at_utc=note.deleted_at_utc,
+    )

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -487,6 +487,8 @@ class CaseOpsWorkspaceTaskItem(BaseModel):
 class CaseOpsWorkspaceNoteItem(BaseModel):
     note_id: uuid.UUID
     body: str
+    note_type: Literal["standard", "tagged", "decision"] = "standard"
+    tags: list[str] = Field(default_factory=list)
     created_by_user_id: Optional[uuid.UUID] = None
     created_at_utc: datetime
     edited_at_utc: Optional[datetime] = None
@@ -515,6 +517,44 @@ class CaseOpsWorkspaceResponse(BaseModel):
     open_tasks: list[CaseOpsWorkspaceTaskItem] = Field(default_factory=list)
     recent_notes: list[CaseOpsWorkspaceNoteItem] = Field(default_factory=list)
     activity: list[CaseOpsWorkspaceActivityItem] = Field(default_factory=list)
+
+
+class IncidentNoteCreateRequest(BaseModel):
+    body: LongText
+    note_type: Literal["standard", "tagged", "decision"] = "standard"
+    tags: list[ShortText] = Field(default_factory=list)
+
+
+class IncidentNotePatchRequest(BaseModel):
+    note_id: uuid.UUID
+    body: LongText | None = None
+    note_type: Literal["standard", "tagged", "decision"] | None = None
+    tags: list[ShortText] | None = None
+
+
+class IncidentNoteDeleteRequest(BaseModel):
+    note_id: uuid.UUID
+
+
+class IncidentNoteItem(BaseModel):
+    note_id: uuid.UUID
+    incident_id: uuid.UUID
+    body: str
+    note_type: Literal["standard", "tagged", "decision"] = "standard"
+    tags: list[str] = Field(default_factory=list)
+    created_by_user_id: Optional[uuid.UUID] = None
+    created_at_utc: datetime
+    edited: bool = False
+    edited_by_user_id: Optional[uuid.UUID] = None
+    edited_at_utc: Optional[datetime] = None
+    updated_at_utc: datetime
+    is_deleted: bool = False
+    deleted_by_user_id: Optional[uuid.UUID] = None
+    deleted_at_utc: Optional[datetime] = None
+
+
+class IncidentNotesResponse(BaseModel):
+    items: list[IncidentNoteItem] = Field(default_factory=list)
 
 
 class MessagingReliabilityResponse(BaseModel):

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -264,6 +264,13 @@ class CaseNote(Base):
         index=True,
     )
     body = Column(Text, nullable=False)
+    note_type = Column(
+        Enum("standard", "tagged", "decision", name="case_note_type"),
+        nullable=False,
+        default="standard",
+        server_default="standard",
+    )
+    tags_json = Column(JSONB, nullable=False, default=list, server_default=text("'[]'"))
     created_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
     edited_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
     edited_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from app.api.routes_driver import router as driver_router
 from app.api.routes_integrations import router as integrations_router
 from app.api.routes.routes_driver_artifacts import router as driver_artifacts_router
 from app.api.routes.routes_case_ops import router as case_ops_router
+from app.api.routes.routes_notes import router as notes_router
 from app.api.routes.routes_driver_report import router as driver_report_router
 from app.api.routes_admin import router as admin_router
 from app.api.routes_twilio import router as twilio_router
@@ -47,6 +48,7 @@ app.include_router(driver_router, prefix="/driver", tags=["driver"])
 app.include_router(driver_artifacts_router, prefix="/driver", tags=["driver-artifacts"])
 app.include_router(driver_report_router, prefix="/driver", tags=["driver-report"])
 app.include_router(case_ops_router, tags=["case-ops"])
+app.include_router(notes_router, tags=["notes"])
 app.include_router(admin_router, prefix="/admin", tags=["admin"])
 app.include_router(twilio_router, prefix="/twilio", tags=["twilio"])
 app.include_router(integrations_router, tags=["integrations"])

--- a/backend/tests/test_notes_routes.py
+++ b/backend/tests/test_notes_routes.py
@@ -1,0 +1,232 @@
+"""Tests for incident notes routes."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.security import create_access_token, hash_password
+from app.db.models import Base, CaseNote, Incident, Org, User, UserOrg
+from app.db.session import get_db
+from app.main import app
+
+
+@pytest.fixture()
+def db_session():
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine)
+    session = TestSession()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def org(db_session):
+    org = Org(name="Notes Org")
+    db_session.add(org)
+    db_session.commit()
+    db_session.refresh(org)
+    return org
+
+
+@pytest.fixture()
+def author_user(db_session, org):
+    user = User(
+        email="author@example.com",
+        password_hash=hash_password("testpass"),
+        role="safety_manager",
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    db_session.add(UserOrg(user_id=user.id, org_id=org.id))
+    db_session.commit()
+    return user
+
+
+@pytest.fixture()
+def editor_user(db_session, org):
+    user = User(
+        email="editor@example.com",
+        password_hash=hash_password("testpass"),
+        role="safety_manager",
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    db_session.add(UserOrg(user_id=user.id, org_id=org.id))
+    db_session.commit()
+    return user
+
+
+@pytest.fixture()
+def other_org_user(db_session):
+    other_org = Org(name="Other Org")
+    db_session.add(other_org)
+    db_session.commit()
+    db_session.refresh(other_org)
+
+    user = User(
+        email="other@example.com",
+        password_hash=hash_password("testpass"),
+        role="safety_manager",
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    db_session.add(UserOrg(user_id=user.id, org_id=other_org.id))
+    db_session.commit()
+    return user
+
+
+@pytest.fixture()
+def incident(db_session, org):
+    incident = Incident(
+        org_id=org.id,
+        status="open",
+        case_status="new",
+        severity="minor",
+        adc_vehicle_id="veh-notes",
+        adc_driver_id="drv-notes",
+    )
+    db_session.add(incident)
+    db_session.commit()
+    db_session.refresh(incident)
+    return incident
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token({"sub": str(user.id), "role": user.role})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_notes_crud_sets_edit_metadata_and_soft_delete_trail(
+    client: TestClient,
+    incident: Incident,
+    author_user: User,
+):
+    create_response = client.post(
+        f"/incidents/{incident.incident_id}/notes",
+        json={"body": "Initial note", "note_type": "tagged", "tags": ["urgent"]},
+        headers=_auth_headers(author_user),
+    )
+    assert create_response.status_code == 200
+    created = create_response.json()
+    assert created["note_type"] == "tagged"
+    assert created["tags"] == ["urgent"]
+    assert created["edited"] is False
+
+    patch_response = client.patch(
+        f"/incidents/{incident.incident_id}/notes",
+        json={"note_id": created["note_id"], "body": "Updated note", "note_type": "decision"},
+        headers=_auth_headers(author_user),
+    )
+    assert patch_response.status_code == 200
+    patched = patch_response.json()
+    assert patched["body"] == "Updated note"
+    assert patched["note_type"] == "decision"
+    assert patched["edited"] is True
+    assert patched["edited_at_utc"] is not None
+    assert patched["updated_at_utc"] is not None
+
+    delete_response = client.request(
+        method="DELETE",
+        url=f"/incidents/{incident.incident_id}/notes",
+        json={"note_id": created["note_id"]},
+        headers=_auth_headers(author_user),
+    )
+    assert delete_response.status_code == 200
+    deleted = delete_response.json()
+    assert deleted["is_deleted"] is True
+    assert deleted["deleted_at_utc"] is not None
+
+    list_default_response = client.get(
+        f"/incidents/{incident.incident_id}/notes", headers=_auth_headers(author_user)
+    )
+    assert list_default_response.status_code == 200
+    assert list_default_response.json()["items"] == []
+
+    list_with_deleted_response = client.get(
+        f"/incidents/{incident.incident_id}/notes?include_deleted=true",
+        headers=_auth_headers(author_user),
+    )
+    assert list_with_deleted_response.status_code == 200
+    items = list_with_deleted_response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["is_deleted"] is True
+
+
+def test_non_author_cannot_edit_or_delete_note(
+    client: TestClient,
+    db_session,
+    incident: Incident,
+    author_user: User,
+    editor_user: User,
+):
+    note = CaseNote(
+        org_id=incident.org_id,
+        incident_id=incident.incident_id,
+        body="Author note",
+        created_by_user_id=author_user.id,
+    )
+    db_session.add(note)
+    db_session.commit()
+    db_session.refresh(note)
+
+    patch_response = client.patch(
+        f"/incidents/{incident.incident_id}/notes",
+        json={"note_id": str(note.note_id), "body": "Trying to edit"},
+        headers=_auth_headers(editor_user),
+    )
+    assert patch_response.status_code == 403
+
+    delete_response = client.request(
+        method="DELETE",
+        url=f"/incidents/{incident.incident_id}/notes",
+        json={"note_id": str(note.note_id)},
+        headers=_auth_headers(editor_user),
+    )
+    assert delete_response.status_code == 403
+
+
+def test_notes_routes_enforce_org_isolation(
+    client: TestClient,
+    incident: Incident,
+    other_org_user: User,
+):
+    list_response = client.get(
+        f"/incidents/{incident.incident_id}/notes", headers=_auth_headers(other_org_user)
+    )
+    assert list_response.status_code == 404
+
+    create_response = client.post(
+        f"/incidents/{incident.incident_id}/notes",
+        json={"body": "No access"},
+        headers=_auth_headers(other_org_user),
+    )
+    assert create_response.status_code == 404


### PR DESCRIPTION
### Motivation
- Provide internal-only incident notes CRUD endpoints so case-ops can record and manage internal notes on incidents.
- Enforce org-scoped access and edit/delete authorization so only incident members and authorized roles can view or mutate notes.
- Capture edit metadata and a soft-delete trail so audit/context is preserved for note edits and deletions.

### Description
- Add a new router with `GET/POST/PATCH/DELETE /incidents/{incident_id}/notes` implementing list/create/patch/delete semantics, org-scoped incident lookup, optional `include_deleted` listing, author-or-admin edit/delete rules, edit metadata update, and soft-delete marking (`backend/app/api/routes/routes_notes.py`).
- Extend the `CaseNote` model with `note_type` and `tags_json` to support typed/tagged/decision notes (`backend/app/db/models.py`).
- Add Pydantic request/response schemas for creating, patching, deleting, and listing notes including `edited`, `updated_at_utc`, and soft-delete fields (`backend/app/api/schemas.py`).
- Wire the notes router into the FastAPI app and update the case-ops workspace serialization to include `note_type` and `tags` in recent notes (`backend/app/main.py`, `backend/app/api/routes/routes_case_ops.py`).
- Add tests covering author/edit permissions, org isolation, and deleted-note visibility/metadata (`backend/tests/test_notes_routes.py`).

### Testing
- Ran the backend linter via `ruff check app/ tests/` which completed successfully.
- Ran targeted pytest for notes and workspace behavior via `pytest -q tests/test_notes_routes.py tests/test_case_ops_workspace_route.py` and observed all tests passed (5 passed).
- No automated test failures were encountered in the targeted test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de54b9f6d88321b606e3f85ff1960f)