### PR TITLE
Add incident task APIs with status workflow, enums, overdue detection, and audit events

### DIFF
--- a/backend/app/api/routes/routes_tasks.py
+++ b/backend/app/api/routes/routes_tasks.py
@@ -1,0 +1,350 @@
+"""Incident task CRUD and workflow routes."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.api.schemas import (
+    IncidentTaskCancelRequest,
+    IncidentTaskCreateRequest,
+    IncidentTaskItem,
+    IncidentTaskListResponse,
+    IncidentTaskPatchRequest,
+)
+from app.audit.emitter import emit_audit_event
+from app.core.deps import get_current_user
+from app.db.models import CaseTask, Incident, User
+from app.db.repo.incidents import get_incident
+from app.db.session import get_db
+from app.security.authn import build_user_auth_context
+from app.security.authz import can_modify_incident, can_view_incident, require_policy
+
+router = APIRouter()
+
+
+@router.get("/incidents/{incident_id}/tasks", response_model=IncidentTaskListResponse)
+def list_incident_tasks(
+    incident_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    incident, _ = _require_incident_access(
+        db=db,
+        current_user=current_user,
+        incident_id=incident_id,
+        write_access=False,
+    )
+    now_utc = datetime.now(timezone.utc)
+    tasks = (
+        db.query(CaseTask)
+        .filter(CaseTask.incident_id == incident.incident_id)
+        .order_by(CaseTask.due_at_utc.asc().nullslast(), CaseTask.created_at_utc.desc())
+        .all()
+    )
+    return IncidentTaskListResponse(items=[_to_task_item(task, now_utc=now_utc) for task in tasks])
+
+
+@router.post("/incidents/{incident_id}/tasks", response_model=IncidentTaskItem)
+def create_incident_task(
+    incident_id: uuid.UUID,
+    request: IncidentTaskCreateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    incident, _ = _require_incident_access(
+        db=db,
+        current_user=current_user,
+        incident_id=incident_id,
+        write_access=True,
+    )
+
+    now_utc = datetime.now(timezone.utc)
+    task = CaseTask(
+        org_id=incident.org_id,
+        incident_id=incident.incident_id,
+        title=request.title,
+        description=request.description,
+        task_type=request.task_type,
+        priority=request.priority,
+        due_at_utc=request.due_at_utc,
+        assigned_to_user_id=request.assigned_to_user_id,
+        created_by_user_id=current_user.id,
+    )
+    if request.assigned_to_user_id is not None:
+        task.assigned_at_utc = now_utc
+        task.assigned_by_user_id = current_user.id
+
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+
+    emit_audit_event(
+        db,
+        org_id=incident.org_id,
+        actor_type="user",
+        actor_id=str(current_user.id),
+        action="task.create",
+        event_type="incident_task_created",
+        outcome="success",
+        incident_id=incident.incident_id,
+        metadata={"task_id": str(task.task_id), "task_type": task.task_type, "priority": task.priority},
+    )
+
+    return _to_task_item(task, now_utc=now_utc)
+
+
+@router.patch("/tasks/{task_id}", response_model=IncidentTaskItem)
+def patch_task(
+    task_id: uuid.UUID,
+    request: IncidentTaskPatchRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    task, incident = _require_task_write_access(db=db, current_user=current_user, task_id=task_id)
+    now_utc = datetime.now(timezone.utc)
+
+    previous_assignee = task.assigned_to_user_id
+    previous_status = _api_status(task.status)
+
+    if request.title is not None:
+        task.title = request.title
+    if request.description is not None:
+        task.description = request.description
+    if request.priority is not None:
+        task.priority = request.priority
+    if request.task_type is not None:
+        task.task_type = request.task_type
+    if request.due_at_utc is not None:
+        task.due_at_utc = request.due_at_utc
+
+    if request.assigned_to_user_id is not None and request.assigned_to_user_id != task.assigned_to_user_id:
+        task.assigned_to_user_id = request.assigned_to_user_id
+        task.assigned_at_utc = now_utc
+        task.assigned_by_user_id = current_user.id
+
+    if request.status is not None:
+        _validate_transition(current_status=_api_status(task.status), next_status=request.status)
+        _apply_status(task=task, next_status=request.status, actor_user_id=current_user.id, now_utc=now_utc)
+
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+
+    if previous_assignee != task.assigned_to_user_id:
+        emit_audit_event(
+            db,
+            org_id=incident.org_id,
+            actor_type="user",
+            actor_id=str(current_user.id),
+            action="task.reassign",
+            event_type="incident_task_reassigned",
+            outcome="success",
+            incident_id=incident.incident_id,
+            metadata={
+                "task_id": str(task.task_id),
+                "previous_assignee": str(previous_assignee) if previous_assignee else None,
+                "new_assignee": str(task.assigned_to_user_id) if task.assigned_to_user_id else None,
+            },
+        )
+
+    if previous_status != _api_status(task.status):
+        emit_audit_event(
+            db,
+            org_id=incident.org_id,
+            actor_type="user",
+            actor_id=str(current_user.id),
+            action="task.status.patch",
+            event_type="incident_task_status_updated",
+            outcome="success",
+            incident_id=incident.incident_id,
+            metadata={"task_id": str(task.task_id), "from": previous_status, "to": _api_status(task.status)},
+        )
+
+    return _to_task_item(task, now_utc=now_utc)
+
+
+@router.post("/tasks/{task_id}/complete", response_model=IncidentTaskItem)
+def complete_task(
+    task_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    task, incident = _require_task_write_access(db=db, current_user=current_user, task_id=task_id)
+    now_utc = datetime.now(timezone.utc)
+    _validate_transition(current_status=_api_status(task.status), next_status="completed")
+    _apply_status(task=task, next_status="completed", actor_user_id=current_user.id, now_utc=now_utc)
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+
+    emit_audit_event(
+        db,
+        org_id=incident.org_id,
+        actor_type="user",
+        actor_id=str(current_user.id),
+        action="task.complete",
+        event_type="incident_task_completed",
+        outcome="success",
+        incident_id=incident.incident_id,
+        metadata={"task_id": str(task.task_id)},
+    )
+
+    return _to_task_item(task, now_utc=now_utc)
+
+
+@router.post("/tasks/{task_id}/cancel", response_model=IncidentTaskItem)
+def cancel_task(
+    task_id: uuid.UUID,
+    request: IncidentTaskCancelRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    task, incident = _require_task_write_access(db=db, current_user=current_user, task_id=task_id)
+    now_utc = datetime.now(timezone.utc)
+    _validate_transition(current_status=_api_status(task.status), next_status="cancelled")
+    _apply_status(
+        task=task,
+        next_status="cancelled",
+        actor_user_id=current_user.id,
+        now_utc=now_utc,
+        cancel_reason=request.reason,
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+
+    emit_audit_event(
+        db,
+        org_id=incident.org_id,
+        actor_type="user",
+        actor_id=str(current_user.id),
+        action="task.cancel",
+        event_type="incident_task_cancelled",
+        outcome="success",
+        incident_id=incident.incident_id,
+        metadata={"task_id": str(task.task_id), "reason": request.reason},
+    )
+
+    return _to_task_item(task, now_utc=now_utc)
+
+
+def _require_incident_access(
+    *,
+    db: Session,
+    current_user: User,
+    incident_id: uuid.UUID,
+    write_access: bool,
+) -> tuple[Incident, object]:
+    context = build_user_auth_context(db, current_user)
+    incident = get_incident(db, incident_id=incident_id, org_ids=list(context.org_ids))
+    if incident is None:
+        raise HTTPException(status_code=404, detail="Incident not found")
+    if write_access:
+        require_policy(can_modify_incident(context, incident))
+    else:
+        require_policy(can_view_incident(context, incident))
+    return incident, context
+
+
+def _require_task_write_access(*, db: Session, current_user: User, task_id: uuid.UUID) -> tuple[CaseTask, Incident]:
+    task = db.query(CaseTask).filter(CaseTask.task_id == task_id).first()
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    incident, _ = _require_incident_access(
+        db=db,
+        current_user=current_user,
+        incident_id=task.incident_id,
+        write_access=True,
+    )
+    return task, incident
+
+
+def _validate_transition(*, current_status: str, next_status: str) -> None:
+    if current_status == next_status:
+        return
+    allowed_transitions = {
+        "open": {"completed", "cancelled"},
+        "completed": set(),
+        "cancelled": set(),
+    }
+    if next_status not in allowed_transitions.get(current_status, set()):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Invalid task status transition from {current_status} to {next_status}",
+        )
+
+
+def _apply_status(
+    *,
+    task: CaseTask,
+    next_status: str,
+    actor_user_id: uuid.UUID,
+    now_utc: datetime,
+    cancel_reason: str | None = None,
+) -> None:
+    if next_status == "open":
+        task.status = "open"
+        task.completed_at_utc = None
+        task.completed_by_user_id = None
+        task.canceled_at_utc = None
+        task.canceled_by_user_id = None
+        task.canceled_reason = None
+        return
+
+    if next_status == "completed":
+        task.status = "completed"
+        task.completed_at_utc = now_utc
+        task.completed_by_user_id = actor_user_id
+        task.canceled_at_utc = None
+        task.canceled_by_user_id = None
+        task.canceled_reason = None
+        return
+
+    task.status = "canceled"
+    task.canceled_at_utc = now_utc
+    task.canceled_by_user_id = actor_user_id
+    task.canceled_reason = cancel_reason
+    task.completed_at_utc = None
+    task.completed_by_user_id = None
+
+
+def _api_status(status: str | None) -> str:
+    if status == "canceled":
+        return "cancelled"
+    return str(status or "open")
+
+
+def _to_task_item(task: CaseTask, *, now_utc: datetime) -> IncidentTaskItem:
+    due_at_utc = _as_utc(task.due_at_utc)
+    return IncidentTaskItem(
+        task_id=task.task_id,
+        incident_id=task.incident_id,
+        title=task.title,
+        description=task.description,
+        task_type=str(task.task_type),
+        status=_api_status(task.status),
+        priority=str(task.priority),
+        due_at_utc=due_at_utc,
+        assigned_to_user_id=task.assigned_to_user_id,
+        assigned_at_utc=task.assigned_at_utc,
+        assigned_by_user_id=task.assigned_by_user_id,
+        created_by_user_id=task.created_by_user_id,
+        created_at_utc=task.created_at_utc,
+        completed_at_utc=task.completed_at_utc,
+        canceled_at_utc=task.canceled_at_utc,
+        canceled_reason=task.canceled_reason,
+        overdue=bool(due_at_utc and due_at_utc < now_utc and _api_status(task.status) == "open"),
+    )
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -519,6 +519,59 @@ class CaseOpsWorkspaceResponse(BaseModel):
     activity: list[CaseOpsWorkspaceActivityItem] = Field(default_factory=list)
 
 
+
+
+TaskStatus = Literal["open", "completed", "cancelled"]
+TaskType = Literal["review", "evidence", "follow_up", "export", "other"]
+TaskPriority = Literal["low", "medium", "high", "urgent"]
+
+
+class IncidentTaskCreateRequest(BaseModel):
+    title: ShortText
+    description: Optional[LongText] = None
+    task_type: TaskType = "other"
+    priority: TaskPriority = "medium"
+    due_at_utc: Optional[datetime] = None
+    assigned_to_user_id: Optional[uuid.UUID] = None
+
+
+class IncidentTaskPatchRequest(BaseModel):
+    title: Optional[ShortText] = None
+    description: Optional[LongText] = None
+    task_type: Optional[TaskType] = None
+    priority: Optional[TaskPriority] = None
+    due_at_utc: Optional[datetime] = None
+    assigned_to_user_id: Optional[uuid.UUID] = None
+    status: Optional[TaskStatus] = None
+
+
+class IncidentTaskCancelRequest(BaseModel):
+    reason: Optional[ShortText] = None
+
+
+class IncidentTaskItem(BaseModel):
+    task_id: uuid.UUID
+    incident_id: uuid.UUID
+    title: str
+    description: Optional[str] = None
+    task_type: TaskType
+    status: TaskStatus
+    priority: TaskPriority
+    due_at_utc: Optional[datetime] = None
+    assigned_to_user_id: Optional[uuid.UUID] = None
+    assigned_at_utc: Optional[datetime] = None
+    assigned_by_user_id: Optional[uuid.UUID] = None
+    created_by_user_id: Optional[uuid.UUID] = None
+    created_at_utc: Optional[datetime] = None
+    completed_at_utc: Optional[datetime] = None
+    canceled_at_utc: Optional[datetime] = None
+    canceled_reason: Optional[str] = None
+    overdue: bool = False
+
+
+class IncidentTaskListResponse(BaseModel):
+    items: list[IncidentTaskItem] = Field(default_factory=list)
+
 class IncidentNoteCreateRequest(BaseModel):
     body: LongText
     note_type: Literal["standard", "tagged", "decision"] = "standard"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.api.routes.routes_driver_artifacts import router as driver_artifacts_ro
 from app.api.routes.routes_case_ops import router as case_ops_router
 from app.api.routes.routes_notes import router as notes_router
 from app.api.routes.routes_driver_report import router as driver_report_router
+from app.api.routes.routes_tasks import router as tasks_router
 from app.api.routes_admin import router as admin_router
 from app.api.routes_twilio import router as twilio_router
 from app.health.routes import router as health_router
@@ -49,6 +50,7 @@ app.include_router(driver_artifacts_router, prefix="/driver", tags=["driver-arti
 app.include_router(driver_report_router, prefix="/driver", tags=["driver-report"])
 app.include_router(case_ops_router, tags=["case-ops"])
 app.include_router(notes_router, tags=["notes"])
+app.include_router(tasks_router, tags=["tasks"])
 app.include_router(admin_router, prefix="/admin", tags=["admin"])
 app.include_router(twilio_router, prefix="/twilio", tags=["twilio"])
 app.include_router(integrations_router, tags=["integrations"])

--- a/backend/tests/test_tasks_routes.py
+++ b/backend/tests/test_tasks_routes.py
@@ -1,0 +1,223 @@
+"""Tests for incident task management routes."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.security import create_access_token, hash_password
+from app.db.models import AuditEvent, Base, CaseTask, Incident, Org, User, UserOrg
+from app.db.session import get_db
+from app.main import app
+
+
+@pytest.fixture()
+def db_session():
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    test_session = sessionmaker(bind=engine)
+    session = test_session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def org(db_session):
+    org = Org(name="Tasks Org")
+    db_session.add(org)
+    db_session.commit()
+    db_session.refresh(org)
+    return org
+
+
+@pytest.fixture()
+def user(db_session, org):
+    user = User(
+        email="tasks@example.com",
+        password_hash=hash_password("testpass"),
+        role="safety_manager",
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    db_session.add(UserOrg(user_id=user.id, org_id=org.id))
+    db_session.commit()
+    return user
+
+
+@pytest.fixture()
+def assignee(db_session, org):
+    user = User(
+        email="assignee@example.com",
+        password_hash=hash_password("testpass"),
+        role="safety_manager",
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    db_session.add(UserOrg(user_id=user.id, org_id=org.id))
+    db_session.commit()
+    return user
+
+
+@pytest.fixture()
+def incident(db_session, org):
+    incident = Incident(
+        org_id=org.id,
+        status="open",
+        case_status="new",
+        severity="minor",
+        adc_vehicle_id="veh-task",
+        adc_driver_id="drv-task",
+    )
+    db_session.add(incident)
+    db_session.commit()
+    db_session.refresh(incident)
+    return incident
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token({"sub": str(user.id), "role": user.role})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_task_routes_create_list_patch_complete_cancel_with_audit(
+    client: TestClient,
+    db_session,
+    incident: Incident,
+    user: User,
+    assignee: User,
+):
+    due_at = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    create_response = client.post(
+        f"/incidents/{incident.incident_id}/tasks",
+        json={
+            "title": "Collect witness statement",
+            "description": "Reach out before EOD",
+            "task_type": "follow_up",
+            "priority": "high",
+            "due_at_utc": due_at,
+        },
+        headers=_auth_headers(user),
+    )
+    assert create_response.status_code == 200
+    created = create_response.json()
+    assert created["status"] == "open"
+    assert created["task_type"] == "follow_up"
+    assert created["overdue"] is True
+
+    list_response = client.get(
+        f"/incidents/{incident.incident_id}/tasks",
+        headers=_auth_headers(user),
+    )
+    assert list_response.status_code == 200
+    assert len(list_response.json()["items"]) == 1
+
+    patch_response = client.patch(
+        f"/tasks/{created['task_id']}",
+        json={"assigned_to_user_id": str(assignee.id), "priority": "urgent"},
+        headers=_auth_headers(user),
+    )
+    assert patch_response.status_code == 200
+    patched = patch_response.json()
+    assert patched["assigned_to_user_id"] == str(assignee.id)
+    assert patched["assigned_at_utc"] is not None
+    assert patched["priority"] == "urgent"
+
+    complete_response = client.post(
+        f"/tasks/{created['task_id']}/complete",
+        headers=_auth_headers(user),
+    )
+    assert complete_response.status_code == 200
+    completed = complete_response.json()
+    assert completed["status"] == "completed"
+    assert completed["completed_at_utc"] is not None
+    assert completed["overdue"] is False
+
+    invalid_transition = client.post(
+        f"/tasks/{created['task_id']}/cancel",
+        json={"reason": "No longer needed"},
+        headers=_auth_headers(user),
+    )
+    assert invalid_transition.status_code == 409
+
+    second_task = CaseTask(
+        org_id=incident.org_id,
+        incident_id=incident.incident_id,
+        title="Second",
+        status="open",
+        priority="medium",
+    )
+    db_session.add(second_task)
+    db_session.commit()
+    db_session.refresh(second_task)
+
+    cancel_response = client.post(
+        f"/tasks/{second_task.task_id}/cancel",
+        json={"reason": "Duplicate"},
+        headers=_auth_headers(user),
+    )
+    assert cancel_response.status_code == 200
+    cancelled = cancel_response.json()
+    assert cancelled["status"] == "cancelled"
+    assert cancelled["canceled_reason"] == "Duplicate"
+
+    events = db_session.query(AuditEvent).filter(AuditEvent.incident_id == incident.incident_id).all()
+    event_types = {event.event_type for event in events}
+    assert {
+        "incident_task_created",
+        "incident_task_reassigned",
+        "incident_task_completed",
+        "incident_task_cancelled",
+    }.issubset(event_types)
+
+
+def test_task_patch_rejects_invalid_status_transition(
+    client: TestClient,
+    db_session,
+    incident: Incident,
+    user: User,
+):
+    task = CaseTask(
+        org_id=incident.org_id,
+        incident_id=incident.incident_id,
+        title="Immutable done task",
+        status="completed",
+        priority="low",
+    )
+    db_session.add(task)
+    db_session.commit()
+    db_session.refresh(task)
+
+    response = client.patch(
+        f"/tasks/{task.task_id}",
+        json={"status": "open"},
+        headers=_auth_headers(user),
+    )
+    assert response.status_code == 409


### PR DESCRIPTION
### Motivation
- Provide CRUD and workflow endpoints for case tasks tied to incidents so case-ops can create, reassign, complete, and cancel tasks. 
- Enforce explicit status transitions and capture priority/task-type metadata for consistent client/server behavior. 
- Surface overdue status and persist audit trail entries for task lifecycle changes to support observability and accountability.

### Description
- Added new router `backend/app/api/routes/routes_tasks.py` implementing `GET/POST /incidents/{incident_id}/tasks`, `PATCH /tasks/{task_id}`, `POST /tasks/{task_id}/complete`, and `POST /tasks/{task_id}/cancel` with status transition validation and reassignment handling. 
- Added API schemas and enums for `TaskStatus`, `TaskType`, and `TaskPriority` and request/response models in `backend/app/api/schemas.py`. 
- Implemented overdue detection (`dueAtUtc < now && status == open`) with timezone-safe handling and API⇄DB status mapping (`cancelled` API ↔ `canceled` DB) in route helpers. 
- Emit audit events for create/reassign/status/complete/cancel actions via `app.audit.emitter.emit_audit_event`, and registered the tasks router in `backend/app/main.py`.

### Testing
- Ran linting via `make lint` which passed. 
- Executed unit/integration tests with `pytest tests/test_tasks_routes.py tests/test_notes_routes.py tests/test_case_ops_workspace_route.py -q` and all tests passed (`7 passed`). 
- Added `backend/tests/test_tasks_routes.py` covering create/list/patch/complete/cancel flows, overdue detection, invalid transition rejection, reassignment metadata, and audit persistence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de57e5466883218ddb23ad4c39a5f6)