### PR TITLE
Add case-ops workspace panels and controls to incident detail

### DIFF
--- a/frontend/app/incidents/[id]/IncidentDetailClient.tsx
+++ b/frontend/app/incidents/[id]/IncidentDetailClient.tsx
@@ -4,17 +4,36 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import {
+  completeTask,
+  createIncidentNote,
+  createIncidentTask,
   getIncident,
+  getIncidentWorkspace,
   getDriverProtocolSettings,
+  listIncidentNotes,
+  listIncidentTasks,
   type IncidentDetail,
+  type IncidentNoteItem,
+  type IncidentTaskItem,
+  type CaseWorkspaceResponse,
   type DriverProtocolSummary,
   type DriverResponseSummary,
+  patchIncidentOwner,
+  patchIncidentStatus,
   toUserErrorMessage,
 } from "@/lib/api";
 import { useAuth } from "@/lib/useAuth";
 import EvidenceTable, { EVIDENCE_TYPES } from "@/components/EvidenceTable";
 import Timeline from "@/components/Timeline";
 import IncidentDetailExportPanel from "@/components/IncidentDetailExportPanel";
+import CaseOwnerControl from "@/components/case-ops/CaseOwnerControl";
+import CaseStatusControl from "@/components/case-ops/CaseStatusControl";
+import CaseReadinessCard, { ExportReadinessBanner } from "@/components/case-ops/CaseReadinessCard";
+import EvidenceStatusPanel from "@/components/case-ops/EvidenceStatusPanel";
+import MissingItemsPanel from "@/components/case-ops/MissingItemsPanel";
+import CaseNotesPanel from "@/components/case-ops/CaseNotesPanel";
+import CaseTasksPanel from "@/components/case-ops/CaseTasksPanel";
+import TimelineFeed from "@/components/case-ops/TimelineFeed";
 
 function formatTime(iso?: string | null): string {
   if (!iso) return "—";
@@ -38,6 +57,9 @@ export default function IncidentDetailClient() {
   const [error, setError] = useState("");
   const [driverProtocolSettings, setDriverProtocolSettings] =
     useState<DriverProtocolSummary | null>(null);
+  const [workspace, setWorkspace] = useState<CaseWorkspaceResponse | null>(null);
+  const [notes, setNotes] = useState<IncidentNoteItem[]>([]);
+  const [tasks, setTasks] = useState<IncidentTaskItem[]>([]);
 
   const artifactStatuses = useMemo(() => {
     if (!incident) return [];
@@ -96,10 +118,30 @@ export default function IncidentDetailClient() {
         ? "Partial"
         : "Limited";
 
+  const refreshIncident = useCallback(() => {
+    return getIncident(id)
+      .then(setIncident)
+      .catch((err) => console.warn("Incident refresh failed", err));
+  }, [id]);
+
+  const refreshWorkspacePanels = useCallback(() => {
+    return Promise.all([
+      getIncidentWorkspace(id).then(setWorkspace),
+      listIncidentNotes(id).then((res) => setNotes(res.items)),
+      listIncidentTasks(id).then((res) => setTasks(res.items)),
+    ]).catch((err) => {
+      console.warn("Workspace refresh failed", err);
+    });
+  }, [id]);
+
   useEffect(() => {
     if (!user) return;
-    getIncident(id)
-      .then(setIncident)
+    Promise.all([
+      getIncident(id).then(setIncident),
+      getIncidentWorkspace(id).then(setWorkspace),
+      listIncidentNotes(id).then((res) => setNotes(res.items)),
+      listIncidentTasks(id).then((res) => setTasks(res.items)),
+    ])
       .catch((err) => setError(toUserErrorMessage(err, "Failed to load incident")))
       .finally(() => setLoading(false));
   }, [id, user]);
@@ -113,12 +155,6 @@ export default function IncidentDetailClient() {
       });
   }, [user]);
 
-  const refreshIncident = useCallback(() => {
-    return getIncident(id)
-      .then(setIncident)
-      .catch((err) => console.warn("Incident refresh failed", err));
-  }, [id]);
-
   useEffect(() => {
     if (!user || !isCapturing) return;
     const interval = window.setInterval(() => {
@@ -126,6 +162,131 @@ export default function IncidentDetailClient() {
     }, REFRESH_INTERVAL_MS);
     return () => window.clearInterval(interval);
   }, [isCapturing, refreshIncident, user]);
+
+  const captureSummary = isCapturing
+    ? `Capture in progress (auto-refreshing every ${refreshIntervalSeconds} seconds).`
+    : unavailable > 0
+      ? `Capture finished with ${unavailable} unavailable artifact${
+          unavailable === 1 ? "" : "s"
+        }.`
+      : "Capture complete.";
+
+  const driverResponse: DriverResponseSummary = incident?.driver_response ?? {};
+  const protocolSummary =
+    incident?.driver_protocol_summary ?? driverProtocolSettings;
+  const notificationSent = Boolean(driverResponse.notification_sent_at_utc);
+  const acknowledged = Boolean(driverResponse.acknowledged_at_utc);
+  const uploadsComplete = Boolean(driverResponse.uploads_complete);
+  const waitingOnDriver = Boolean(
+    driverResponse.awaiting_driver_action ??
+      (notificationSent && (!acknowledged || !uploadsComplete))
+  );
+  const workspaceCaseStatus = workspace?.case_status ?? incident?.status ?? "new";
+  const workspaceReadiness = workspace?.readiness_state ?? incident?.readiness_state ?? "not_ready";
+  const workspaceOwnerUserId = workspace?.owner?.user_id ?? null;
+  const workspaceMissingItems = workspace?.missing_items ?? incident?.completeness_missing_items ?? [];
+  const workspaceEvidence = workspace?.evidence_summary;
+  const workspaceActivity = workspace?.activity ?? [];
+
+  const onAssignMe = useCallback(async () => {
+    if (!user) return;
+    const previous = workspace;
+    setWorkspace((current) =>
+      current
+        ? { ...current, owner: { user_id: user.user_id, email: user.email } }
+        : current
+    );
+    try {
+      await patchIncidentOwner(id, {
+        operation: workspaceOwnerUserId ? "reassign" : "assign",
+        owner_user_id: user.user_id,
+      });
+      await Promise.all([refreshIncident(), refreshWorkspacePanels()]);
+    } catch (err) {
+      setWorkspace(previous);
+      setError(toUserErrorMessage(err, "Failed to assign owner"));
+    }
+  }, [id, refreshIncident, refreshWorkspacePanels, user, workspace, workspaceOwnerUserId]);
+
+  const onClearOwner = useCallback(async () => {
+    const previous = workspace;
+    setWorkspace((current) => (current ? { ...current, owner: null } : current));
+    try {
+      await patchIncidentOwner(id, { operation: "clear" });
+      await Promise.all([refreshIncident(), refreshWorkspacePanels()]);
+    } catch (err) {
+      setWorkspace(previous);
+      setError(toUserErrorMessage(err, "Failed to clear owner"));
+    }
+  }, [id, refreshIncident, refreshWorkspacePanels, workspace]);
+
+  const onCaseStatusChange = useCallback(async (nextStatus: string) => {
+    const previous = workspace;
+    setWorkspace((current) => (current ? { ...current, case_status: nextStatus } : current));
+    try {
+      await patchIncidentStatus(id, { case_status: nextStatus, reason: "workspace_update" });
+      await Promise.all([refreshIncident(), refreshWorkspacePanels()]);
+    } catch (err) {
+      setWorkspace(previous);
+      setError(toUserErrorMessage(err, "Failed to update status"));
+    }
+  }, [id, refreshIncident, refreshWorkspacePanels, workspace]);
+
+  const onAddNote = useCallback(async (body: string) => {
+    const tempNote: IncidentNoteItem = {
+      note_id: `temp-${Date.now()}`,
+      incident_id: id,
+      body,
+      note_type: "standard",
+      tags: [],
+      created_at_utc: new Date().toISOString(),
+      edited: false,
+      updated_at_utc: new Date().toISOString(),
+      is_deleted: false,
+    };
+    setNotes((current) => [tempNote, ...current]);
+    try {
+      await createIncidentNote(id, { body, note_type: "standard", tags: [] });
+      await refreshWorkspacePanels();
+    } catch (err) {
+      setNotes((current) => current.filter((note) => note.note_id !== tempNote.note_id));
+      setError(toUserErrorMessage(err, "Failed to add note"));
+    }
+  }, [id, refreshWorkspacePanels]);
+
+  const onAddTask = useCallback(async (title: string) => {
+    const tempTask: IncidentTaskItem = {
+      task_id: `temp-${Date.now()}`,
+      incident_id: id,
+      title,
+      task_type: "other",
+      status: "open",
+      priority: "medium",
+      overdue: false,
+    };
+    setTasks((current) => [tempTask, ...current]);
+    try {
+      await createIncidentTask(id, { title, task_type: "other", priority: "medium" });
+      await refreshWorkspacePanels();
+    } catch (err) {
+      setTasks((current) => current.filter((task) => task.task_id !== tempTask.task_id));
+      setError(toUserErrorMessage(err, "Failed to add task"));
+    }
+  }, [id, refreshWorkspacePanels]);
+
+  const onCompleteTask = useCallback(async (taskId: string) => {
+    const previous = tasks;
+    setTasks((current) =>
+      current.map((task) => (task.task_id === taskId ? { ...task, status: "completed" } : task))
+    );
+    try {
+      await completeTask(taskId);
+      await refreshWorkspacePanels();
+    } catch (err) {
+      setTasks(previous);
+      setError(toUserErrorMessage(err, "Failed to complete task"));
+    }
+  }, [refreshWorkspacePanels, tasks]);
 
   if (loading || authLoading) {
     return (
@@ -142,25 +303,6 @@ export default function IncidentDetailClient() {
       </div>
     );
   }
-
-  const captureSummary = isCapturing
-    ? `Capture in progress (auto-refreshing every ${refreshIntervalSeconds} seconds).`
-    : unavailable > 0
-      ? `Capture finished with ${unavailable} unavailable artifact${
-          unavailable === 1 ? "" : "s"
-        }.`
-      : "Capture complete.";
-
-  const driverResponse: DriverResponseSummary = incident.driver_response ?? {};
-  const protocolSummary =
-    incident.driver_protocol_summary ?? driverProtocolSettings;
-  const notificationSent = Boolean(driverResponse.notification_sent_at_utc);
-  const acknowledged = Boolean(driverResponse.acknowledged_at_utc);
-  const uploadsComplete = Boolean(driverResponse.uploads_complete);
-  const waitingOnDriver = Boolean(
-    driverResponse.awaiting_driver_action ??
-      (notificationSent && (!acknowledged || !uploadsComplete))
-  );
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
@@ -238,6 +380,34 @@ export default function IncidentDetailClient() {
             </div>
           </div>
         </div>
+
+        <div className="grid gap-4 lg:grid-cols-3">
+          <CaseOwnerControl
+            ownerUserId={workspaceOwnerUserId}
+            onAssignMe={onAssignMe}
+            onClearOwner={onClearOwner}
+          />
+          <CaseStatusControl caseStatus={workspaceCaseStatus} onChange={onCaseStatusChange} />
+          <CaseReadinessCard
+            readinessState={workspaceReadiness}
+            completenessPercent={workspace?.completeness.percent ?? completenessPercent}
+            blockersCount={(workspace?.blockers ?? []).length}
+          />
+        </div>
+
+        <ExportReadinessBanner blockersCount={(workspace?.blockers ?? []).length} />
+        <EvidenceStatusPanel
+          captured={workspaceEvidence?.captured ?? captured}
+          pending={workspaceEvidence?.pending ?? pending}
+          unavailable={workspaceEvidence?.unavailable ?? unavailable}
+          total={workspaceEvidence?.total ?? total}
+        />
+        <MissingItemsPanel items={workspaceMissingItems} />
+        <div className="grid gap-4 lg:grid-cols-2">
+          <CaseNotesPanel notes={notes} onAddNote={onAddNote} />
+          <CaseTasksPanel tasks={tasks} onAddTask={onAddTask} onCompleteTask={onCompleteTask} />
+        </div>
+        <TimelineFeed items={workspaceActivity} />
 
         {/* ── Panel A: Evidence Inventory ────────────────────────── */}
         <div className="rounded-lg border bg-white p-6 shadow dark:bg-gray-800">

--- a/frontend/components/case-ops/CaseNotesPanel.tsx
+++ b/frontend/components/case-ops/CaseNotesPanel.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import type { IncidentNoteItem } from "@/lib/api";
+
+interface CaseNotesPanelProps {
+  notes: IncidentNoteItem[];
+  onAddNote: (body: string) => Promise<void>;
+}
+
+export default function CaseNotesPanel({ notes, onAddNote }: CaseNotesPanelProps) {
+  const [body, setBody] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!body.trim()) return;
+    setBusy(true);
+    try {
+      await onAddNote(body.trim());
+      setBody("");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border bg-white p-4 shadow dark:bg-gray-800">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Case notes</h3>
+      <form onSubmit={submit} className="mt-3 flex gap-2">
+        <input
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="Add note"
+          className="flex-1 rounded border px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-900"
+        />
+        <button disabled={busy || !body.trim()} className="rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-60">
+          Add
+        </button>
+      </form>
+      <ul className="mt-3 space-y-2 text-sm">
+        {notes.map((note) => (
+          <li key={note.note_id} className="rounded border p-2 dark:border-gray-700">
+            <p className="text-gray-800 dark:text-gray-200">{note.body}</p>
+          </li>
+        ))}
+        {notes.length === 0 && <li className="text-gray-500">No notes yet.</li>}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/components/case-ops/CaseOwnerControl.tsx
+++ b/frontend/components/case-ops/CaseOwnerControl.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+
+interface CaseOwnerControlProps {
+  ownerUserId?: string | null;
+  onAssignMe: () => Promise<void>;
+  onClearOwner: () => Promise<void>;
+}
+
+export default function CaseOwnerControl({ ownerUserId, onAssignMe, onClearOwner }: CaseOwnerControlProps) {
+  const [busy, setBusy] = useState(false);
+
+  const run = async (action: () => Promise<void>) => {
+    setBusy(true);
+    try {
+      await action();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="rounded-md border bg-gray-50 p-3 dark:bg-gray-900/40">
+      <p className="text-xs text-gray-500">Case owner</p>
+      <p className="mt-1 font-mono text-xs text-gray-800 dark:text-gray-200">
+        {ownerUserId ? `${ownerUserId.slice(0, 8)}…` : "Unassigned"}
+      </p>
+      <div className="mt-2 flex gap-2">
+        <button
+          onClick={() => run(onAssignMe)}
+          disabled={busy}
+          className="rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+        >
+          Assign me
+        </button>
+        <button
+          onClick={() => run(onClearOwner)}
+          disabled={busy || !ownerUserId}
+          className="rounded border px-2 py-1 text-xs hover:bg-gray-100 disabled:opacity-60 dark:border-gray-600 dark:hover:bg-gray-700"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/case-ops/CaseReadinessCard.tsx
+++ b/frontend/components/case-ops/CaseReadinessCard.tsx
@@ -1,0 +1,26 @@
+interface CaseReadinessCardProps {
+  readinessState: string;
+  completenessPercent: number;
+  blockersCount: number;
+}
+
+export function ExportReadinessBanner({ blockersCount }: { blockersCount: number }) {
+  if (blockersCount === 0) {
+    return <div className="rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-800">Export readiness: no blockers detected.</div>;
+  }
+  return (
+    <div className="rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-sm text-yellow-800">
+      Export readiness: {blockersCount} blocker{blockersCount === 1 ? "" : "s"} still open.
+    </div>
+  );
+}
+
+export default function CaseReadinessCard({ readinessState, completenessPercent, blockersCount }: CaseReadinessCardProps) {
+  return (
+    <div className="rounded-md border bg-gray-50 p-3 dark:bg-gray-900/40">
+      <p className="text-xs text-gray-500">Readiness</p>
+      <p className="mt-1 text-sm font-semibold capitalize text-gray-900 dark:text-white">{readinessState.replaceAll("_", " ")}</p>
+      <p className="text-xs text-gray-600 dark:text-gray-300">Completeness {completenessPercent}% · {blockersCount} blocker{blockersCount === 1 ? "" : "s"}</p>
+    </div>
+  );
+}

--- a/frontend/components/case-ops/CaseStatusControl.tsx
+++ b/frontend/components/case-ops/CaseStatusControl.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+const CASE_STATUSES = [
+  "new",
+  "awaiting_evidence",
+  "in_review",
+  "ready_for_export",
+  "escalated",
+  "closed",
+] as const;
+
+interface CaseStatusControlProps {
+  caseStatus: string;
+  onChange: (nextStatus: string) => Promise<void>;
+}
+
+export default function CaseStatusControl({ caseStatus, onChange }: CaseStatusControlProps) {
+  return (
+    <label className="flex flex-col gap-1 rounded-md border bg-gray-50 p-3 text-xs dark:bg-gray-900/40">
+      <span className="text-gray-500">Case status</span>
+      <select
+        className="rounded border px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900"
+        value={caseStatus}
+        onChange={(e) => void onChange(e.target.value)}
+      >
+        {CASE_STATUSES.map((status) => (
+          <option key={status} value={status}>
+            {status}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/frontend/components/case-ops/CaseTasksPanel.tsx
+++ b/frontend/components/case-ops/CaseTasksPanel.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import type { IncidentTaskItem } from "@/lib/api";
+
+interface CaseTasksPanelProps {
+  tasks: IncidentTaskItem[];
+  onAddTask: (title: string) => Promise<void>;
+  onCompleteTask: (taskId: string) => Promise<void>;
+}
+
+export default function CaseTasksPanel({ tasks, onAddTask, onCompleteTask }: CaseTasksPanelProps) {
+  const [title, setTitle] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    setBusy(true);
+    try {
+      await onAddTask(title.trim());
+      setTitle("");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border bg-white p-4 shadow dark:bg-gray-800">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Case tasks</h3>
+      <form onSubmit={submit} className="mt-3 flex gap-2">
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Add task"
+          className="flex-1 rounded border px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-900"
+        />
+        <button disabled={busy || !title.trim()} className="rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-60">
+          Add
+        </button>
+      </form>
+
+      <ul className="mt-3 space-y-2 text-sm">
+        {tasks.map((task) => (
+          <li key={task.task_id} className="flex items-center justify-between rounded border p-2 dark:border-gray-700">
+            <div>
+              <p className="text-gray-800 dark:text-gray-200">{task.title}</p>
+              <p className="text-xs text-gray-500">{task.status} · {task.priority}</p>
+            </div>
+            <button
+              disabled={task.status === "completed"}
+              onClick={() => void onCompleteTask(task.task_id)}
+              className="rounded border px-2 py-1 text-xs hover:bg-gray-100 disabled:opacity-50 dark:border-gray-600 dark:hover:bg-gray-700"
+            >
+              Complete
+            </button>
+          </li>
+        ))}
+        {tasks.length === 0 && <li className="text-gray-500">No tasks yet.</li>}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/components/case-ops/EvidenceStatusPanel.tsx
+++ b/frontend/components/case-ops/EvidenceStatusPanel.tsx
@@ -1,0 +1,29 @@
+interface EvidenceStatusPanelProps {
+  captured: number;
+  pending: number;
+  unavailable: number;
+  total: number;
+}
+
+export default function EvidenceStatusPanel({ captured, pending, unavailable, total }: EvidenceStatusPanelProps) {
+  return (
+    <div className="rounded-lg border bg-white p-4 shadow dark:bg-gray-800">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Evidence status</h3>
+      <div className="mt-3 grid grid-cols-2 gap-2 text-sm sm:grid-cols-4">
+        <Metric label="Captured" value={`${captured}/${total}`} />
+        <Metric label="Pending" value={String(pending)} />
+        <Metric label="Unavailable" value={String(unavailable)} />
+        <Metric label="Coverage" value={`${Math.round((captured / Math.max(total, 1)) * 100)}%`} />
+      </div>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border bg-gray-50 p-2 dark:bg-gray-700">
+      <p className="text-xs text-gray-500">{label}</p>
+      <p className="font-semibold text-gray-900 dark:text-white">{value}</p>
+    </div>
+  );
+}

--- a/frontend/components/case-ops/MissingItemsPanel.tsx
+++ b/frontend/components/case-ops/MissingItemsPanel.tsx
@@ -1,0 +1,20 @@
+interface MissingItemsPanelProps {
+  items: string[];
+}
+
+export default function MissingItemsPanel({ items }: MissingItemsPanelProps) {
+  return (
+    <div className="rounded-lg border bg-white p-4 shadow dark:bg-gray-800">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Missing items</h3>
+      {items.length === 0 ? (
+        <p className="mt-2 text-sm text-green-700">No missing items.</p>
+      ) : (
+        <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-gray-700 dark:text-gray-200">
+          {items.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/case-ops/TimelineFeed.tsx
+++ b/frontend/components/case-ops/TimelineFeed.tsx
@@ -1,0 +1,29 @@
+import type { CaseWorkspaceActivityItem } from "@/lib/api";
+
+interface TimelineFeedProps {
+  items: CaseWorkspaceActivityItem[];
+}
+
+function formatTime(iso?: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString();
+}
+
+export default function TimelineFeed({ items }: TimelineFeedProps) {
+  return (
+    <div className="rounded-lg border bg-white p-4 shadow dark:bg-gray-800">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Timeline feed</h3>
+      <ul className="mt-3 space-y-2 text-sm">
+        {items.map((item, idx) => (
+          <li key={`${item.source}-${item.type}-${idx}`} className="rounded border p-2 dark:border-gray-700">
+            <p className="font-medium text-gray-800 dark:text-gray-200">
+              {item.source === "audit" ? "Ops" : "System"}: {item.type}
+            </p>
+            <p className="text-xs text-gray-500">{formatTime(item.occurred_at_utc)}</p>
+          </li>
+        ))}
+        {items.length === 0 && <li className="text-gray-500">No timeline activity.</li>}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -636,6 +636,207 @@ export function patchIncidentStatus(incidentId: string, data: {
   });
 }
 
+export interface CaseWorkspaceOwner {
+  user_id: string;
+  email?: string | null;
+}
+
+export interface CaseWorkspaceCompletenessSection {
+  name: string;
+  earned: number;
+  possible: number;
+  percent: number;
+  status: string;
+  missing_items: string[];
+}
+
+export interface CaseWorkspaceCompleteness {
+  percent: number;
+  status: string;
+  missing_items: string[];
+  sections: CaseWorkspaceCompletenessSection[];
+}
+
+export interface CaseWorkspaceEvidenceSummary {
+  total: number;
+  captured: number;
+  pending: number;
+  unavailable: number;
+}
+
+export interface CaseWorkspaceTaskItem {
+  task_id: string;
+  title: string;
+  status: string;
+  priority: string;
+  due_at_utc?: string | null;
+  assigned_to_user_id?: string | null;
+  created_at_utc?: string | null;
+}
+
+export interface CaseWorkspaceNoteItem {
+  note_id: string;
+  body: string;
+  note_type: "standard" | "tagged" | "decision";
+  tags: string[];
+  created_by_user_id?: string | null;
+  created_at_utc: string;
+  edited_at_utc?: string | null;
+}
+
+export interface CaseWorkspaceActivityItem {
+  source: "event" | "audit";
+  type: string;
+  occurred_at_utc: string;
+  actor_type: string;
+  actor_id: string;
+  detail: Record<string, unknown>;
+}
+
+export interface CaseWorkspaceResponse {
+  incident_id: string;
+  owner?: CaseWorkspaceOwner | null;
+  case_status: string;
+  readiness_state: string;
+  completeness: CaseWorkspaceCompleteness;
+  blockers: Array<Record<string, unknown>>;
+  evidence_summary: CaseWorkspaceEvidenceSummary;
+  missing_items: string[];
+  open_tasks: CaseWorkspaceTaskItem[];
+  recent_notes: CaseWorkspaceNoteItem[];
+  activity: CaseWorkspaceActivityItem[];
+}
+
+export interface IncidentTaskItem {
+  task_id: string;
+  incident_id: string;
+  title: string;
+  description?: string | null;
+  task_type: "review" | "evidence" | "follow_up" | "export" | "other";
+  status: "open" | "completed" | "cancelled";
+  priority: "low" | "medium" | "high" | "urgent";
+  due_at_utc?: string | null;
+  assigned_to_user_id?: string | null;
+  assigned_at_utc?: string | null;
+  assigned_by_user_id?: string | null;
+  created_by_user_id?: string | null;
+  created_at_utc?: string | null;
+  completed_at_utc?: string | null;
+  canceled_at_utc?: string | null;
+  canceled_reason?: string | null;
+  overdue: boolean;
+}
+
+export interface IncidentTaskListResponse {
+  items: IncidentTaskItem[];
+}
+
+export interface IncidentNoteItem {
+  note_id: string;
+  incident_id: string;
+  body: string;
+  note_type: "standard" | "tagged" | "decision";
+  tags: string[];
+  created_by_user_id?: string | null;
+  created_at_utc: string;
+  edited: boolean;
+  edited_by_user_id?: string | null;
+  edited_at_utc?: string | null;
+  updated_at_utc: string;
+  is_deleted: boolean;
+  deleted_by_user_id?: string | null;
+  deleted_at_utc?: string | null;
+}
+
+export interface IncidentNotesResponse {
+  items: IncidentNoteItem[];
+}
+
+export function getIncidentWorkspace(incidentId: string) {
+  return request<CaseWorkspaceResponse>(`/incidents/${incidentId}/workspace`);
+}
+
+export function listIncidentNotes(incidentId: string, params?: { includeDeleted?: boolean }) {
+  const suffix = params?.includeDeleted ? "?include_deleted=true" : "";
+  return request<IncidentNotesResponse>(`/incidents/${incidentId}/notes${suffix}`);
+}
+
+export function createIncidentNote(incidentId: string, data: {
+  body: string;
+  note_type?: "standard" | "tagged" | "decision";
+  tags?: string[];
+}) {
+  return request<IncidentNoteItem>(`/incidents/${incidentId}/notes`, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export function patchIncidentNote(incidentId: string, data: {
+  note_id: string;
+  body?: string;
+  note_type?: "standard" | "tagged" | "decision";
+  tags?: string[];
+}) {
+  return request<IncidentNoteItem>(`/incidents/${incidentId}/notes`, {
+    method: "PATCH",
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteIncidentNote(incidentId: string, data: { note_id: string }) {
+  return request<IncidentNoteItem>(`/incidents/${incidentId}/notes`, {
+    method: "DELETE",
+    body: JSON.stringify(data),
+  });
+}
+
+export function listIncidentTasks(incidentId: string) {
+  return request<IncidentTaskListResponse>(`/incidents/${incidentId}/tasks`);
+}
+
+export function createIncidentTask(incidentId: string, data: {
+  title: string;
+  description?: string;
+  task_type?: "review" | "evidence" | "follow_up" | "export" | "other";
+  priority?: "low" | "medium" | "high" | "urgent";
+  due_at_utc?: string;
+  assigned_to_user_id?: string;
+}) {
+  return request<IncidentTaskItem>(`/incidents/${incidentId}/tasks`, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export function patchTask(taskId: string, data: {
+  title?: string;
+  description?: string;
+  task_type?: "review" | "evidence" | "follow_up" | "export" | "other";
+  priority?: "low" | "medium" | "high" | "urgent";
+  due_at_utc?: string;
+  assigned_to_user_id?: string;
+  status?: "open" | "completed" | "cancelled";
+}) {
+  return request<IncidentTaskItem>(`/tasks/${taskId}`, {
+    method: "PATCH",
+    body: JSON.stringify(data),
+  });
+}
+
+export function completeTask(taskId: string) {
+  return request<IncidentTaskItem>(`/tasks/${taskId}/complete`, {
+    method: "POST",
+  });
+}
+
+export function cancelTask(taskId: string, data?: { reason?: string }) {
+  return request<IncidentTaskItem>(`/tasks/${taskId}/cancel`, {
+    method: "POST",
+    body: JSON.stringify(data ?? {}),
+  });
+}
+
 export interface OpsIncidentItem {
   incident_id: string;
   status: string;


### PR DESCRIPTION
### Motivation

- Surface the case-ops workspace alongside incident details so operators can view workspace readiness, missing items, notes, tasks, owner, and status without leaving the incident page.
- Provide lightweight, actionable UI controls for assigning/clearing owners and changing case status and enable optimistic updates that keep the UI responsive.
- Merge system events and ops (audit) activity into a single timeline feed for easier operational review.

### Description

- Expanded `IncidentDetailClient` to load the case workspace, recent notes, and tasks in parallel with the incident and added a reusable `refreshWorkspacePanels` callback used after actions to refresh key panels.
- Added new case-ops UI components: `CaseOwnerControl`, `CaseStatusControl`, `CaseReadinessCard` (+ `ExportReadinessBanner`), `EvidenceStatusPanel`, `MissingItemsPanel`, `CaseNotesPanel`, `CaseTasksPanel`, and `TimelineFeed`, and integrated them into the incident detail layout.
- Implemented optimistic action handlers that call the case-ops APIs (`/incidents/{id}/owner`, `/incidents/{id}/status`, `/incidents/{id}/notes`, `/incidents/{id}/tasks`, `/tasks/{id}/complete`) via new client helpers and then refresh the incident and workspace panels on success; rollback and surface an error message on failure.
- Extended the frontend API client (`frontend/lib/api.ts`) with typed workspace/notes/tasks contracts and helper functions: `getIncidentWorkspace`, `listIncidentNotes`, `createIncidentNote`, `patchIncidentNote`, `deleteIncidentNote`, `listIncidentTasks`, `createIncidentTask`, `patchTask`, `completeTask`, and `cancelTask`.

### Testing

- Ran `cd frontend && npm run lint`, which completed successfully after edits to satisfy hooks and typing rules.
- Ran `cd frontend && npm run typecheck`, which passed with no TypeScript errors.
- Ran `cd frontend && npm test`, and the frontend test harness completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de65a252fc83219c8281e78b06b169)