### PR TITLE
Enforce readiness-aware export requests, persist readiness snapshot, and sync case status on export completion

### DIFF
--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -606,6 +606,50 @@ def request_export_endpoint(
                         progress_stage=row.progress_stage,
                     )
 
+    artifacts = get_artifacts_by_incident(db, incident_id)
+    events = get_events_by_incident(db, incident_id)
+    prior_exports = get_exports_by_incident(db, incident_id)
+    snapshot = build_case_snapshot(
+        incident=incident,
+        artifacts=artifacts,
+        events=events,
+        exports=prior_exports,
+    )
+    readiness_reasons = [
+        {
+            "code": blocker.code,
+            "message": blocker.message,
+            "severity": blocker.severity,
+            "blocks_readiness": blocker.blocks_readiness,
+        }
+        for blocker in snapshot.blockers.items
+    ]
+    readiness_snapshot = {
+        "state": snapshot.readiness.state,
+        "completeness_percent": snapshot.completeness.percent,
+        "completeness_status": snapshot.completeness.status,
+        "blocking_codes": snapshot.readiness.blocking_codes,
+        "reasons": readiness_reasons,
+        "captured_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    if snapshot.readiness.state == "not_ready":
+        increment(MetricNames.EXPORT_REQUEST_FAILURES)
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": "Case is not ready for export.",
+                "readiness_state": snapshot.readiness.state,
+                "reasons": readiness_reasons,
+            },
+        )
+    readiness_warning = None
+    if snapshot.readiness.state == "conditionally_ready":
+        readiness_warning = {
+            "code": "conditional_export_readiness",
+            "message": "Case is conditionally ready for export. Exporting may omit or flag unresolved evidence.",
+            "blocking_codes": snapshot.readiness.blocking_codes,
+        }
+
     export = create_export(
         db,
         incident_id=incident_id,
@@ -614,6 +658,10 @@ def request_export_endpoint(
         export_type="court_defense",
         profile_id=get_default_packet_profile("court_defense").profile_id,
         requested_by_user_id=current_user.id,
+        options_json={
+            "readiness_snapshot": readiness_snapshot,
+            "readiness_warning": readiness_warning,
+        },
         progress_stage="request_accepted",
     )
 
@@ -628,6 +676,8 @@ def request_export_endpoint(
             "incident_id": str(incident_id),
             "export_type": "court_defense",
             "status": "requested",
+            "readiness_snapshot": readiness_snapshot,
+            "readiness_warning": readiness_warning,
             "actor": {"type": "user", "id": str(current_user.id)},
         },
     )

--- a/backend/app/tasks/export_tasks.py
+++ b/backend/app/tasks/export_tasks.py
@@ -8,6 +8,7 @@ import re
 import uuid as _uuid
 import zipfile
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 from app.core.metrics import increment
@@ -364,6 +365,37 @@ def _upload_and_finalize(ctx: ExportRuntimeContext):
     )
 
 
+def _sync_incident_case_status_after_export(ctx: ExportRuntimeContext):
+    from app.db.repo.events import create_event
+
+    incident_row = ctx.incident_row
+    if incident_row is None:
+        return
+    if str(incident_row.case_status) != "ready_for_export":
+        return
+
+    incident_row.case_status = "exported"
+    incident_row.readiness_state = "exported"
+    db_now = datetime.now(timezone.utc)
+    incident_row.last_activity_at_utc = db_now
+    ctx.db.flush()
+    create_event(
+        ctx.db,
+        incident_id=ctx.incident_uuid,
+        event_type=ctx.system_event_type.INCIDENT_STATUS_CHANGED,
+        actor_type="system",
+        actor_id="celery",
+        payload={
+            "from_case_status": "ready_for_export",
+            "to_case_status": "exported",
+            "transition_reason": "export_completed",
+            "transitioned_at_utc": db_now.isoformat(),
+            "export_id": ctx.export_id,
+            "actor": {"type": "system", "id": "celery"},
+        },
+    )
+
+
 @celery_app.task(
     bind=True,
     acks_late=True,
@@ -576,6 +608,7 @@ def build_export(
             package_sha256=build_result.package_sha256,
             byte_size=build_result.byte_size,
         )
+        _sync_incident_case_status_after_export(ctx)
         _emit_stage(ctx, "after", "uploading_export")
         _emit(
             ctx.db,

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -3,6 +3,7 @@
 import uuid
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch, MagicMock
+from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
@@ -258,6 +259,101 @@ class TestGetIncident:
         for event in data["timeline"]:
             assert "occurred_at_utc" in event
             assert "actor_type" in event
+
+
+class TestIncidentExportReadiness:
+    @patch("app.api.routes_incidents.build_export.delay")
+    @patch("app.api.routes_incidents.build_case_snapshot")
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
+    def test_incident_export_blocks_not_ready(
+        self,
+        mock_begin_capture,
+        mock_snapshot,
+        mock_delay,
+        client,
+        auth_headers,
+    ):
+        create_resp = client.post(
+            "/incidents/",
+            json={
+                "severity": "serious",
+                "adc_vehicle_id": "veh-123",
+                "samsara_vehicle_id": "sm-veh-987",
+                "adc_driver_id": "drv-555",
+            },
+            headers=auth_headers,
+        )
+        incident_id = create_resp.json()["incident_id"]
+        mock_snapshot.return_value = SimpleNamespace(
+            readiness=SimpleNamespace(state="not_ready", blocking_codes=["evidence_capture_incomplete"]),
+            completeness=SimpleNamespace(percent=45, status="incomplete"),
+            blockers=SimpleNamespace(
+                items=[
+                    SimpleNamespace(
+                        code="evidence_capture_incomplete",
+                        message="Evidence capture incomplete.",
+                        severity="critical",
+                        blocks_readiness=True,
+                    )
+                ]
+            ),
+        )
+
+        resp = client.post(f"/incidents/{incident_id}/exports", headers=auth_headers)
+        assert resp.status_code == 409
+        payload = resp.json()["detail"]
+        assert payload["readiness_state"] == "not_ready"
+        assert payload["reasons"][0]["code"] == "evidence_capture_incomplete"
+        mock_delay.assert_not_called()
+
+    @patch("app.api.routes_incidents.build_export.delay")
+    @patch("app.api.routes_incidents.build_case_snapshot")
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
+    def test_incident_export_allows_conditionally_ready_and_persists_snapshot(
+        self,
+        mock_begin_capture,
+        mock_snapshot,
+        mock_delay,
+        client,
+        db_session,
+        auth_headers,
+    ):
+        create_resp = client.post(
+            "/incidents/",
+            json={
+                "severity": "serious",
+                "adc_vehicle_id": "veh-123",
+                "samsara_vehicle_id": "sm-veh-987",
+                "adc_driver_id": "drv-555",
+            },
+            headers=auth_headers,
+        )
+        incident_id = create_resp.json()["incident_id"]
+        mock_snapshot.return_value = SimpleNamespace(
+            readiness=SimpleNamespace(state="conditionally_ready", blocking_codes=["driver_statement_missing"]),
+            completeness=SimpleNamespace(percent=88, status="mostly_complete"),
+            blockers=SimpleNamespace(
+                items=[
+                    SimpleNamespace(
+                        code="driver_statement_missing",
+                        message="Driver statement still pending.",
+                        severity="important",
+                        blocks_readiness=False,
+                    )
+                ]
+            ),
+        )
+        mock_delay.return_value = MagicMock(id="task-123")
+
+        resp = client.post(f"/incidents/{incident_id}/exports", headers=auth_headers)
+        assert resp.status_code == 201
+
+        export = db_session.query(Export).one()
+        readiness_snapshot = export.options_json.get("readiness_snapshot")
+        readiness_warning = export.options_json.get("readiness_warning")
+        assert readiness_snapshot["state"] == "conditionally_ready"
+        assert readiness_snapshot["blocking_codes"] == ["driver_statement_missing"]
+        assert readiness_warning["code"] == "conditional_export_readiness"
 
 
 class TestIntegrationDiagnosticsRoutes:

--- a/backend/tests/test_export_case_status_sync.py
+++ b/backend/tests/test_export_case_status_sync.py
@@ -1,0 +1,75 @@
+import uuid
+from datetime import datetime
+from types import SimpleNamespace
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db.models import Base, Event, Incident, Org
+from app.tasks.export_tasks import ExportRuntimeContext, _sync_incident_case_status_after_export
+
+
+def test_sync_incident_case_status_after_export_moves_ready_for_export_to_exported():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+
+    org = Org(name="Test Org")
+    session.add(org)
+    session.commit()
+    session.refresh(org)
+
+    incident = Incident(
+        org_id=org.id,
+        case_status="ready_for_export",
+        readiness_state="ready_for_export",
+    )
+    session.add(incident)
+    session.commit()
+    session.refresh(incident)
+
+    ctx = ExportRuntimeContext(
+        db=session,
+        incident_uuid=incident.incident_id,
+        export_uuid=uuid.uuid4(),
+        incident_id=str(incident.incident_id),
+        export_id=str(uuid.uuid4()),
+        workflow_key="workflow",
+        org_id=str(org.id),
+        settings=SimpleNamespace(S3_BUCKET="bucket"),
+        system_event_type=SimpleNamespace(INCIDENT_STATUS_CHANGED="incident_status_changed"),
+        s3_key_builder=None,
+        s3=None,
+        export_row=SimpleNamespace(export_type="court_defense", options_json={}),
+        incident_row=incident,
+        warnings=[],
+        missing_items=[],
+        artifacts=[],
+        events=[],
+        exportable_artifacts=[],
+        inventory_csv_bytes=b"",
+        coc_csv_bytes=b"",
+        appendix_csv_bytes=b"",
+        readme_content="",
+        zip_bytes=b"",
+        zip_key=None,
+    )
+
+    _sync_incident_case_status_after_export(ctx)
+    session.commit()
+    session.refresh(incident)
+
+    assert incident.case_status == "exported"
+    assert incident.readiness_state == "exported"
+    assert isinstance(incident.last_activity_at_utc, datetime)
+    assert incident.last_activity_at_utc is not None
+
+    status_event = session.query(Event).filter(Event.incident_id == incident.incident_id).one()
+    assert status_event.event_type == "incident_status_changed"
+    assert status_event.payload["from_case_status"] == "ready_for_export"
+    assert status_event.payload["to_case_status"] == "exported"

--- a/frontend/app/incidents/[id]/IncidentDetailClient.tsx
+++ b/frontend/app/incidents/[id]/IncidentDetailClient.tsx
@@ -395,7 +395,11 @@ export default function IncidentDetailClient() {
           />
         </div>
 
-        <ExportReadinessBanner blockersCount={(workspace?.blockers ?? []).length} />
+        <ExportReadinessBanner
+          blockersCount={(workspace?.blockers ?? []).length}
+          readinessState={workspaceReadiness}
+          blockers={(workspace?.blockers ?? []) as Array<{ code?: string; message?: string; blocks_readiness?: boolean }>}
+        />
         <EvidenceStatusPanel
           captured={workspaceEvidence?.captured ?? captured}
           pending={workspaceEvidence?.pending ?? pending}

--- a/frontend/components/IncidentDetailExportPanel.tsx
+++ b/frontend/components/IncidentDetailExportPanel.tsx
@@ -87,6 +87,15 @@ export default function IncidentDetailExportPanel({
       }, 0),
     [recentExports]
   );
+  const latestReadinessSnapshot = latestExport?.options_json?.readiness_snapshot as
+    | {
+        state?: string;
+        reasons?: Array<{ message?: string; code?: string }>;
+      }
+    | undefined;
+  const latestReadinessWarning = latestExport?.options_json?.readiness_warning as
+    | { message?: string }
+    | undefined;
 
   const integrationStatusItems = useMemo<EvidenceStatusItem[]>(() => {
     const source = latestExport?.options_json?.evidence_statuses;
@@ -242,6 +251,22 @@ export default function IncidentDetailExportPanel({
           New export
         </button>
       </div>
+
+      {latestReadinessSnapshot && (
+        <div className="rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+          <p className="font-medium">
+            Readiness at request time: {(latestReadinessSnapshot.state ?? "unknown").replaceAll("_", " ")}
+          </p>
+          {latestReadinessWarning?.message && <p className="text-xs">{latestReadinessWarning.message}</p>}
+          {Array.isArray(latestReadinessSnapshot.reasons) && latestReadinessSnapshot.reasons.length > 0 && (
+            <ul className="mt-1 list-disc pl-5 text-xs">
+              {latestReadinessSnapshot.reasons.slice(0, 3).map((reason, index) => (
+                <li key={`${reason.code ?? "reason"}-${index}`}>{reason.message ?? reason.code ?? "Readiness reason unavailable"}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
 
       {isProcessing && (
         <div className="rounded border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900">

--- a/frontend/components/case-ops/CaseReadinessCard.tsx
+++ b/frontend/components/case-ops/CaseReadinessCard.tsx
@@ -4,13 +4,55 @@ interface CaseReadinessCardProps {
   blockersCount: number;
 }
 
-export function ExportReadinessBanner({ blockersCount }: { blockersCount: number }) {
-  if (blockersCount === 0) {
+interface ReadinessBlocker {
+  code?: string;
+  message?: string;
+  blocks_readiness?: boolean;
+}
+
+export function ExportReadinessBanner({
+  blockersCount,
+  readinessState,
+  blockers = [],
+}: {
+  blockersCount: number;
+  readinessState: string;
+  blockers?: ReadinessBlocker[];
+}) {
+  const topReasons = blockers
+    .filter((blocker) => blocker.blocks_readiness !== false)
+    .slice(0, 2)
+    .map((blocker) => blocker.message || blocker.code || "Unspecified readiness blocker");
+
+  if (readinessState === "ready_for_export" || readinessState === "exported" || blockersCount === 0) {
     return <div className="rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-800">Export readiness: no blockers detected.</div>;
   }
+
+  if (readinessState === "conditionally_ready") {
+    return (
+      <div className="rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-sm text-yellow-800">
+        <p>Export readiness: conditionally ready. {blockersCount} blocker{blockersCount === 1 ? "" : "s"} may affect packet completeness.</p>
+        {topReasons.length > 0 && (
+          <ul className="mt-1 list-disc pl-5 text-xs">
+            {topReasons.map((reason) => (
+              <li key={reason}>{reason}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  }
+
   return (
-    <div className="rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-sm text-yellow-800">
-      Export readiness: {blockersCount} blocker{blockersCount === 1 ? "" : "s"} still open.
+    <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">
+      <p>Export readiness: blocked. Resolve readiness blockers before requesting export.</p>
+      {topReasons.length > 0 && (
+        <ul className="mt-1 list-disc pl-5 text-xs">
+          {topReasons.map((reason) => (
+            <li key={reason}>{reason}</li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Prevent exporting cases that are explicitly `not_ready` while allowing `conditionally_ready` requests with a visible warning, and capture the state that was used to make the request so operators can understand exported packet completeness.
- Ensure case status moves from `ready_for_export` to `exported` when an export completes so the case lifecycle stays consistent.
- Surface request-time readiness reasoning in the frontend export panel/banner so users see why an export was allowed, blocked, or conditionally allowed.

### Description
- Updated the incident export route (`POST /incidents/{incident_id}/exports`) to build a case-ops snapshot using `build_case_snapshot`, block requests when `snapshot.readiness.state == "not_ready"` with a `409` containing readiness reasons, allow `conditionally_ready` while creating a `readiness_warning`, and persist a `readiness_snapshot` and optional `readiness_warning` in the new export's `options_json` and the `EXPORT_REQUESTED` event payload. (backend/app/api/routes_incidents.py)
- Added a worker-side sync function `_sync_incident_case_status_after_export` and invoked it after the export upload finalization so an incident in `case_status == "ready_for_export"` is transitioned to `exported`, its `readiness_state` is updated, `last_activity_at_utc` is set, and an `incident_status_changed` system event is emitted. (backend/app/tasks/export_tasks.py)
- Enhanced frontend readiness UI: expanded `ExportReadinessBanner` to show blocked/conditional states and top readiness reasons, passed `readinessState` and blocker details into the banner on the incident detail page, and added a small card in the export panel to display the latest request-time `readiness_snapshot` and `readiness_warning` from `export.options_json`. (frontend/components/case-ops/CaseReadinessCard.tsx, frontend/app/incidents/[id]/IncidentDetailClient.tsx, frontend/components/IncidentDetailExportPanel.tsx)
- Added tests covering readiness-gated export behavior and persistence of the readiness snapshot and warning, plus a test for export completion case-status sync; introduced `backend/tests/test_export_case_status_sync.py` and extended `backend/tests/test_api_endpoints.py` with readiness cases. (backend/tests/...)

### Testing
- Ran `ruff` checks against modified Python files with `ruff check` and the backend linter reported all checks passed. 
- Executed the new/related backend tests with `pytest -q backend/tests/test_api_endpoints.py::TestIncidentExportReadiness backend/tests/test_export_case_status_sync.py` and they passed (`3 passed`).
- Ran frontend static checks and tests with `npm run lint`, `npm run typecheck`, and `npm run test` in the `frontend` package and all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7180edd483218e49bf6e2cf3fb9c)