### PR TITLE
Add onboarding readiness domain models, API contracts, and persistence tables

### DIFF
--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -150,6 +150,21 @@ ArtifactUploadContentType = Literal[
     "image/png",
     "video/mp4",
 ]
+OnboardingReadinessStatus = Literal[
+    "not_started",
+    "in_progress",
+    "pilot_ready",
+    "launch_ready",
+    "blocked",
+]
+OnboardingReadinessStepStatus = Literal[
+    "not_started",
+    "in_progress",
+    "completed",
+    "blocked",
+]
+ImportJobStatus = Literal["pending", "running", "succeeded", "failed"]
+ValidationSeverity = Literal["info", "warning", "error"]
 
 
 ApiErrorCode = Literal[
@@ -519,8 +534,6 @@ class CaseOpsWorkspaceResponse(BaseModel):
     activity: list[CaseOpsWorkspaceActivityItem] = Field(default_factory=list)
 
 
-
-
 TaskStatus = Literal["open", "completed", "cancelled"]
 TaskType = Literal["review", "evidence", "follow_up", "export", "other"]
 TaskPriority = Literal["low", "medium", "high", "urgent"]
@@ -572,6 +585,7 @@ class IncidentTaskItem(BaseModel):
 class IncidentTaskListResponse(BaseModel):
     items: list[IncidentTaskItem] = Field(default_factory=list)
 
+
 class IncidentNoteCreateRequest(BaseModel):
     body: LongText
     note_type: Literal["standard", "tagged", "decision"] = "standard"
@@ -616,6 +630,82 @@ class MessagingReliabilityResponse(BaseModel):
     undelivered: int = Field(default=0, ge=0)
     failed: int = Field(default=0, ge=0)
     success_rate_pct: int = Field(default=0, ge=0, le=100)
+
+
+# ── Onboarding contracts ─────────────────────────────────────────────
+
+
+class ReadinessStepResponse(BaseModel):
+    key: ShortText
+    label: ShortText
+    status: OnboardingReadinessStepStatus = "not_started"
+    order: int = Field(default=0, ge=0)
+    completed_at_utc: Optional[datetime] = None
+    updated_at_utc: Optional[datetime] = None
+    metadata: dict[str, str] = Field(default_factory=dict)
+
+
+class ReadinessBlockerResponse(BaseModel):
+    code: ShortText
+    title: ShortText
+    detail: str
+    severity: ValidationSeverity = "warning"
+    blocking_step_key: Optional[ShortText] = None
+    created_at_utc: Optional[datetime] = None
+    resolved_at_utc: Optional[datetime] = None
+    is_resolved: bool = False
+
+
+class ImportJobResponse(BaseModel):
+    import_job_id: ShortText
+    provider: ShortText
+    status: ImportJobStatus
+    started_at_utc: Optional[datetime] = None
+    completed_at_utc: Optional[datetime] = None
+    records_total: int = Field(default=0, ge=0)
+    records_succeeded: int = Field(default=0, ge=0)
+    records_failed: int = Field(default=0, ge=0)
+    error_message: Optional[str] = None
+
+
+class IntegrationValidationResultResponse(BaseModel):
+    integration_key: ShortText
+    status: OnboardingReadinessStepStatus
+    checked_at_utc: datetime
+    detail: str
+    severity: ValidationSeverity = "info"
+    errors: list[str] = Field(default_factory=list)
+
+
+class VehicleQrDeploymentResponse(BaseModel):
+    status: OnboardingReadinessStepStatus = "not_started"
+    vehicles_total: int = Field(default=0, ge=0)
+    qr_codes_generated: int = Field(default=0, ge=0)
+    qr_codes_activated: int = Field(default=0, ge=0)
+    last_rotated_at_utc: Optional[datetime] = None
+
+
+class TestIncidentRunResponse(BaseModel):
+    status: OnboardingReadinessStepStatus = "not_started"
+    incident_id: Optional[uuid.UUID] = None
+    started_at_utc: Optional[datetime] = None
+    completed_at_utc: Optional[datetime] = None
+    findings: list[str] = Field(default_factory=list)
+
+
+class OrgLaunchReadinessResponse(BaseModel):
+    org_id: uuid.UUID
+    status: OnboardingReadinessStatus = "not_started"
+    percent_complete: int = Field(default=0, ge=0, le=100)
+    steps: list[ReadinessStepResponse] = Field(default_factory=list)
+    blockers: list[ReadinessBlockerResponse] = Field(default_factory=list)
+    import_jobs: list[ImportJobResponse] = Field(default_factory=list)
+    integration_validations: list[IntegrationValidationResultResponse] = Field(
+        default_factory=list
+    )
+    vehicle_qr_deployment: Optional[VehicleQrDeploymentResponse] = None
+    test_incident_run: Optional[TestIncidentRunResponse] = None
+    snapshot_created_at_utc: Optional[datetime] = None
 
 
 # ── Exports ─────────────────────────────────────────────────────────

--- a/backend/app/db/migrations/versions/0019_add_onboarding_readiness_snapshot_tables.py
+++ b/backend/app/db/migrations/versions/0019_add_onboarding_readiness_snapshot_tables.py
@@ -1,0 +1,246 @@
+"""add onboarding readiness snapshot tables
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-04-14
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0019"
+down_revision: Union[str, None] = "0018"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+org_launch_readiness_status = sa.Enum(
+    "not_started",
+    "in_progress",
+    "pilot_ready",
+    "launch_ready",
+    "blocked",
+    name="org_launch_readiness_status",
+)
+
+org_launch_readiness_step_status = sa.Enum(
+    "not_started",
+    "in_progress",
+    "completed",
+    "blocked",
+    name="org_launch_readiness_step_status",
+)
+
+org_launch_readiness_blocker_severity = sa.Enum(
+    "info",
+    "warning",
+    "error",
+    name="org_launch_readiness_blocker_severity",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    org_launch_readiness_status.create(bind, checkfirst=True)
+    org_launch_readiness_step_status.create(bind, checkfirst=True)
+    org_launch_readiness_blocker_severity.create(bind, checkfirst=True)
+
+    op.create_table(
+        "org_launch_readiness_snapshots",
+        sa.Column("snapshot_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "status",
+            org_launch_readiness_status,
+            nullable=False,
+            server_default="not_started",
+        ),
+        sa.Column("percent_complete", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "summary_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("created_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "created_at_utc",
+            postgresql.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("snapshot_id"),
+    )
+    op.create_index(
+        "ix_org_launch_readiness_snapshots_org_id",
+        "org_launch_readiness_snapshots",
+        ["org_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_org_launch_readiness_snapshots_org_created",
+        "org_launch_readiness_snapshots",
+        ["org_id", "created_at_utc"],
+        unique=False,
+    )
+
+    op.create_table(
+        "org_launch_readiness_step_progress",
+        sa.Column("step_progress_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("snapshot_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("step_key", sa.Text(), nullable=False),
+        sa.Column("step_label", sa.Text(), nullable=False),
+        sa.Column("step_order", sa.Integer(), nullable=False),
+        sa.Column(
+            "status",
+            org_launch_readiness_step_status,
+            nullable=False,
+            server_default="not_started",
+        ),
+        sa.Column(
+            "metadata_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "completed_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True
+        ),
+        sa.Column(
+            "updated_at_utc",
+            postgresql.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["snapshot_id"], ["org_launch_readiness_snapshots.snapshot_id"]
+        ),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("step_progress_id"),
+    )
+    op.create_index(
+        "ix_org_launch_readiness_step_progress_org_id",
+        "org_launch_readiness_step_progress",
+        ["org_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_org_launch_readiness_step_progress_snapshot_id",
+        "org_launch_readiness_step_progress",
+        ["snapshot_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_org_launch_readiness_steps_org_snapshot",
+        "org_launch_readiness_step_progress",
+        ["org_id", "snapshot_id", "step_order"],
+        unique=False,
+    )
+
+    op.create_table(
+        "org_launch_readiness_blockers",
+        sa.Column("blocker_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("snapshot_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("code", sa.Text(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("detail", sa.Text(), nullable=False),
+        sa.Column(
+            "severity",
+            org_launch_readiness_blocker_severity,
+            nullable=False,
+            server_default="warning",
+        ),
+        sa.Column("blocking_step_key", sa.Text(), nullable=True),
+        sa.Column(
+            "is_resolved",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "resolved_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True
+        ),
+        sa.Column(
+            "created_at_utc",
+            postgresql.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["snapshot_id"], ["org_launch_readiness_snapshots.snapshot_id"]
+        ),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("blocker_id"),
+    )
+    op.create_index(
+        "ix_org_launch_readiness_blockers_org_id",
+        "org_launch_readiness_blockers",
+        ["org_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_org_launch_readiness_blockers_snapshot_id",
+        "org_launch_readiness_blockers",
+        ["snapshot_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_org_launch_readiness_blockers_org_snapshot",
+        "org_launch_readiness_blockers",
+        ["org_id", "snapshot_id", "is_resolved"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_org_launch_readiness_blockers_org_snapshot",
+        table_name="org_launch_readiness_blockers",
+    )
+    op.drop_index(
+        "ix_org_launch_readiness_blockers_snapshot_id",
+        table_name="org_launch_readiness_blockers",
+    )
+    op.drop_index(
+        "ix_org_launch_readiness_blockers_org_id",
+        table_name="org_launch_readiness_blockers",
+    )
+    op.drop_table("org_launch_readiness_blockers")
+
+    op.drop_index(
+        "ix_org_launch_readiness_steps_org_snapshot",
+        table_name="org_launch_readiness_step_progress",
+    )
+    op.drop_index(
+        "ix_org_launch_readiness_step_progress_snapshot_id",
+        table_name="org_launch_readiness_step_progress",
+    )
+    op.drop_index(
+        "ix_org_launch_readiness_step_progress_org_id",
+        table_name="org_launch_readiness_step_progress",
+    )
+    op.drop_table("org_launch_readiness_step_progress")
+
+    op.drop_index(
+        "ix_org_launch_readiness_snapshots_org_created",
+        table_name="org_launch_readiness_snapshots",
+    )
+    op.drop_index(
+        "ix_org_launch_readiness_snapshots_org_id",
+        table_name="org_launch_readiness_snapshots",
+    )
+    op.drop_table("org_launch_readiness_snapshots")
+
+    bind = op.get_bind()
+    org_launch_readiness_blocker_severity.drop(bind, checkfirst=True)
+    org_launch_readiness_step_status.drop(bind, checkfirst=True)
+    org_launch_readiness_status.drop(bind, checkfirst=True)

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -241,10 +241,17 @@ class Incident(Base):
     )
 
     __table_args__ = (
-        Index("ix_incidents_org_case_status_owner", "org_id", "case_status", "owner_user_id"),
+        Index(
+            "ix_incidents_org_case_status_owner",
+            "org_id",
+            "case_status",
+            "owner_user_id",
+        ),
         Index("ix_incidents_org_readiness_state", "org_id", "readiness_state"),
         Index("ix_incidents_org_updated_at_utc", "org_id", "updated_at_utc"),
-        Index("ix_incidents_org_last_activity_at_utc", "org_id", "last_activity_at_utc"),
+        Index(
+            "ix_incidents_org_last_activity_at_utc", "org_id", "last_activity_at_utc"
+        ),
     )
 
 
@@ -271,12 +278,20 @@ class CaseNote(Base):
         server_default="standard",
     )
     tags_json = Column(JSONB, nullable=False, default=list, server_default=text("'[]'"))
-    created_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
-    edited_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    created_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
+    edited_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
     edited_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
-    deleted_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    deleted_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
     deleted_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
-    is_deleted = Column(Boolean, nullable=False, default=False, server_default=text("false"))
+    is_deleted = Column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
     created_at_utc = Column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
     )
@@ -288,7 +303,12 @@ class CaseNote(Base):
     )
 
     __table_args__ = (
-        Index("ix_case_notes_org_incident_created", "org_id", "incident_id", "created_at_utc"),
+        Index(
+            "ix_case_notes_org_incident_created",
+            "org_id",
+            "incident_id",
+            "created_at_utc",
+        ),
         Index(
             "ix_case_notes_org_incident_deleted_created",
             "org_id",
@@ -349,15 +369,25 @@ class CaseTask(Base):
         server_default="medium",
     )
     due_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
-    assigned_to_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    assigned_to_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
     assigned_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
-    assigned_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    assigned_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
     completed_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
-    completed_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    completed_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
     canceled_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
-    canceled_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    canceled_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
     canceled_reason = Column(Text, nullable=True)
-    created_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    created_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
     created_at_utc = Column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
     )
@@ -393,8 +423,12 @@ class CaseReadinessOverride(Base):
     completeness_percent = Column(Integer, nullable=True)
     completeness_status = Column(Text, nullable=True)
     reason = Column(Text, nullable=False)
-    created_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
-    cleared_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    created_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
+    cleared_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
     cleared_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
     created_at_utc = Column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
@@ -559,7 +593,9 @@ class IntegrationConnection(Base):
     )
     external_reference = Column(Text, nullable=True, index=True)
     credentials_ref = Column(Text, nullable=True)
-    config_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    config_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
     last_synced_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
     created_at_utc = Column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
@@ -598,7 +634,10 @@ class IntegrationOperation(Base):
         UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
     )
     incident_id = Column(
-        UUID(as_uuid=True), ForeignKey("incidents.incident_id"), nullable=True, index=True
+        UUID(as_uuid=True),
+        ForeignKey("incidents.incident_id"),
+        nullable=True,
+        index=True,
     )
     connection_id = Column(
         UUID(as_uuid=True),
@@ -632,8 +671,12 @@ class IntegrationOperation(Base):
     correlation_id = Column(Text, nullable=True, index=True)
     external_reference = Column(Text, nullable=True, index=True)
     external_reference_id = Column(Text, nullable=True, index=True)
-    payload_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
-    result_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    payload_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    result_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
     error_message = Column(Text, nullable=True)
     error_code = Column(Text, nullable=True, index=True)
     error_category = Column(Text, nullable=True, index=True)
@@ -690,7 +733,10 @@ class IntegrationOperationStatusHistory(Base):
         UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
     )
     incident_id = Column(
-        UUID(as_uuid=True), ForeignKey("incidents.incident_id"), nullable=True, index=True
+        UUID(as_uuid=True),
+        ForeignKey("incidents.incident_id"),
+        nullable=True,
+        index=True,
     )
     provider = Column(Text, nullable=False, index=True)
     domain = Column(Text, nullable=True, index=True)
@@ -727,12 +773,17 @@ class EvidenceRequest(Base):
 
     __tablename__ = "evidence_requests"
 
-    evidence_request_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    evidence_request_id = Column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
     org_id = Column(
         UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
     )
     incident_id = Column(
-        UUID(as_uuid=True), ForeignKey("incidents.incident_id"), nullable=True, index=True
+        UUID(as_uuid=True),
+        ForeignKey("incidents.incident_id"),
+        nullable=True,
+        index=True,
     )
     operation_id = Column(
         UUID(as_uuid=True),
@@ -794,7 +845,12 @@ class EvidenceRequest(Base):
             "status",
             "requested_at_utc",
         ),
-        Index("ix_evidence_requests_org_incident_status", "org_id", "incident_id", "status"),
+        Index(
+            "ix_evidence_requests_org_incident_status",
+            "org_id",
+            "incident_id",
+            "status",
+        ),
     )
 
 
@@ -808,7 +864,10 @@ class ExternalMapping(Base):
         UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
     )
     incident_id = Column(
-        UUID(as_uuid=True), ForeignKey("incidents.incident_id"), nullable=True, index=True
+        UUID(as_uuid=True),
+        ForeignKey("incidents.incident_id"),
+        nullable=True,
+        index=True,
     )
     provider = Column(Text, nullable=False, index=True)
     domain = Column(Text, nullable=True, index=True)
@@ -816,7 +875,9 @@ class ExternalMapping(Base):
     internal_entity_id = Column(Text, nullable=False, index=True)
     external_reference = Column(Text, nullable=False, index=True)
     status = Column(Text, nullable=False, default="active", server_default="active")
-    metadata_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    metadata_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
     created_at_utc = Column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
     )
@@ -856,7 +917,10 @@ class ProviderWebhookEvent(Base):
         UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
     )
     incident_id = Column(
-        UUID(as_uuid=True), ForeignKey("incidents.incident_id"), nullable=True, index=True
+        UUID(as_uuid=True),
+        ForeignKey("incidents.incident_id"),
+        nullable=True,
+        index=True,
     )
     provider = Column(Text, nullable=False, index=True)
     domain = Column(Text, nullable=True, index=True)
@@ -880,7 +944,9 @@ class ProviderWebhookEvent(Base):
     correlation_id = Column(Text, nullable=True, index=True)
     external_reference = Column(Text, nullable=True, index=True)
     raw_payload = Column(Text, nullable=False, default="", server_default="")
-    payload_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    payload_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
     error_details_json = Column(
         JSONB,
         nullable=False,
@@ -919,7 +985,9 @@ class MessageOperation(Base):
 
     __tablename__ = "message_operations"
 
-    message_operation_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    message_operation_id = Column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
     operation_id = Column(
         UUID(as_uuid=True),
         ForeignKey("integration_operations.operation_id"),
@@ -930,7 +998,10 @@ class MessageOperation(Base):
         UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=True, index=True
     )
     incident_id = Column(
-        UUID(as_uuid=True), ForeignKey("incidents.incident_id"), nullable=True, index=True
+        UUID(as_uuid=True),
+        ForeignKey("incidents.incident_id"),
+        nullable=True,
+        index=True,
     )
     provider = Column(Text, nullable=False, index=True)
     purpose = Column(Text, nullable=False, server_default="notification", index=True)
@@ -958,7 +1029,9 @@ class MessageOperation(Base):
     correlation_id = Column(Text, nullable=True, index=True)
     external_reference = Column(Text, nullable=True, index=True)
     template_name = Column(Text, nullable=True)
-    payload_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    payload_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
     sent_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
     delivered_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
     created_at_utc = Column(
@@ -980,7 +1053,12 @@ class MessageOperation(Base):
             "status",
             "created_at_utc",
         ),
-        Index("ix_message_operations_org_incident_created", "org_id", "incident_id", "created_at_utc"),
+        Index(
+            "ix_message_operations_org_incident_created",
+            "org_id",
+            "incident_id",
+            "created_at_utc",
+        ),
     )
 
 
@@ -1000,7 +1078,9 @@ class MessageOperationStatusHistory(Base):
     to_status = Column(Text, nullable=False, index=True)
     provider_message_id = Column(Text, nullable=True, index=True)
     normalized_error_code = Column(Text, nullable=True, index=True)
-    details_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    details_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
     created_at_utc = Column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now(), index=True
     )
@@ -1100,6 +1180,142 @@ class JobExecutionMeta(Base):
         nullable=False,
         server_default=func.now(),
         onupdate=func.now(),
+    )
+
+
+# ── Onboarding readiness models ──────────────────────────────────────
+
+
+class OrgLaunchReadinessSnapshot(Base):
+    """Point-in-time launch readiness snapshot for an organization."""
+
+    __tablename__ = "org_launch_readiness_snapshots"
+
+    snapshot_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    status = Column(
+        Enum(
+            "not_started",
+            "in_progress",
+            "pilot_ready",
+            "launch_ready",
+            "blocked",
+            name="org_launch_readiness_status",
+        ),
+        nullable=False,
+        default="not_started",
+        server_default="not_started",
+    )
+    percent_complete = Column(Integer, nullable=False, default=0, server_default="0")
+    summary_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    created_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_org_launch_readiness_snapshots_org_created",
+            "org_id",
+            "created_at_utc",
+        ),
+    )
+
+
+class OrgLaunchReadinessStepProgress(Base):
+    """Step-level progress for an onboarding readiness snapshot."""
+
+    __tablename__ = "org_launch_readiness_step_progress"
+
+    step_progress_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    snapshot_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("org_launch_readiness_snapshots.snapshot_id"),
+        nullable=False,
+        index=True,
+    )
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    step_key = Column(Text, nullable=False)
+    step_label = Column(Text, nullable=False)
+    step_order = Column(Integer, nullable=False)
+    status = Column(
+        Enum(
+            "not_started",
+            "in_progress",
+            "completed",
+            "blocked",
+            name="org_launch_readiness_step_status",
+        ),
+        nullable=False,
+        default="not_started",
+        server_default="not_started",
+    )
+    metadata_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    completed_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_org_launch_readiness_steps_org_snapshot",
+            "org_id",
+            "snapshot_id",
+            "step_order",
+        ),
+    )
+
+
+class OrgLaunchReadinessBlocker(Base):
+    """Blockers linked to a readiness snapshot and optionally a specific step."""
+
+    __tablename__ = "org_launch_readiness_blockers"
+
+    blocker_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    snapshot_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("org_launch_readiness_snapshots.snapshot_id"),
+        nullable=False,
+        index=True,
+    )
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    code = Column(Text, nullable=False)
+    title = Column(Text, nullable=False)
+    detail = Column(Text, nullable=False)
+    severity = Column(
+        Enum("info", "warning", "error", name="org_launch_readiness_blocker_severity"),
+        nullable=False,
+        default="warning",
+        server_default="warning",
+    )
+    blocking_step_key = Column(Text, nullable=True)
+    is_resolved = Column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+    resolved_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_org_launch_readiness_blockers_org_snapshot",
+            "org_id",
+            "snapshot_id",
+            "is_resolved",
+        ),
     )
 
 

--- a/backend/app/onboarding/__init__.py
+++ b/backend/app/onboarding/__init__.py
@@ -1,0 +1,1 @@
+"""Onboarding domain models and utilities."""

--- a/backend/app/onboarding/models.py
+++ b/backend/app/onboarding/models.py
@@ -1,0 +1,100 @@
+"""Typed onboarding models for launch readiness and setup workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal
+
+ReadinessStatus = Literal[
+    "not_started",
+    "in_progress",
+    "pilot_ready",
+    "launch_ready",
+    "blocked",
+]
+ReadinessStepStatus = Literal["not_started", "in_progress", "completed", "blocked"]
+ImportJobStatus = Literal["pending", "running", "succeeded", "failed"]
+ValidationSeverity = Literal["info", "warning", "error"]
+QrDeploymentStatus = Literal["not_started", "in_progress", "completed", "blocked"]
+IncidentRunStatus = Literal["not_started", "in_progress", "completed", "blocked"]
+
+
+@dataclass(slots=True)
+class ReadinessStep:
+    key: str
+    label: str
+    status: ReadinessStepStatus
+    order: int
+    completed_at_utc: datetime | None = None
+    updated_at_utc: datetime | None = None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ReadinessBlocker:
+    code: str
+    title: str
+    detail: str
+    severity: ValidationSeverity
+    blocking_step_key: str | None = None
+    created_at_utc: datetime | None = None
+    resolved_at_utc: datetime | None = None
+    is_resolved: bool = False
+
+
+@dataclass(slots=True)
+class ImportJob:
+    import_job_id: str
+    provider: str
+    status: ImportJobStatus
+    started_at_utc: datetime | None = None
+    completed_at_utc: datetime | None = None
+    records_total: int = 0
+    records_succeeded: int = 0
+    records_failed: int = 0
+    error_message: str | None = None
+
+
+@dataclass(slots=True)
+class IntegrationValidationResult:
+    integration_key: str
+    status: ReadinessStepStatus
+    checked_at_utc: datetime
+    detail: str
+    severity: ValidationSeverity = "info"
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class VehicleQrDeployment:
+    status: QrDeploymentStatus
+    vehicles_total: int
+    qr_codes_generated: int
+    qr_codes_activated: int
+    last_rotated_at_utc: datetime | None = None
+
+
+@dataclass(slots=True)
+class TestIncidentRun:
+    status: IncidentRunStatus
+    incident_id: str | None = None
+    started_at_utc: datetime | None = None
+    completed_at_utc: datetime | None = None
+    findings: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class OrgLaunchReadiness:
+    org_id: str
+    status: ReadinessStatus
+    percent_complete: int
+    steps: list[ReadinessStep] = field(default_factory=list)
+    blockers: list[ReadinessBlocker] = field(default_factory=list)
+    import_jobs: list[ImportJob] = field(default_factory=list)
+    integration_validations: list[IntegrationValidationResult] = field(
+        default_factory=list
+    )
+    vehicle_qr_deployment: VehicleQrDeployment | None = None
+    test_incident_run: TestIncidentRun | None = None
+    snapshot_created_at_utc: datetime | None = None


### PR DESCRIPTION
### Motivation

- Provide typed domain models for onboarding/launch readiness workflows and their status values to drive backend logic and frontend contracts.
- Persist point-in-time readiness snapshots, per-step progress, and blockers so readiness state can be audited and queried.
- Ensure frontend/backend compatibility by adding Pydantic response schemas matching the onboarding payloads expected by the UI.

### Description

- Add typed onboarding dataclasses in `backend/app/onboarding/models.py` for `OrgLaunchReadiness`, `ReadinessStep`, `ReadinessBlocker`, `ImportJob`, `IntegrationValidationResult`, `VehicleQrDeployment`, and `TestIncidentRun`, and declare literal status aliases including `not_started`, `in_progress`, `pilot_ready`, `launch_ready`, and `blocked`.
- Add onboarding Pydantic response/serializer contracts to `backend/app/api/schemas.py` (step/blocker/import/validation/QR/test-run and aggregate `OrgLaunchReadinessResponse`) so the API shape is explicit and stable for the frontend.
- Add SQLAlchemy persistence models to `backend/app/db/models.py` for `org_launch_readiness_snapshots`, `org_launch_readiness_step_progress`, and `org_launch_readiness_blockers` including enums, FKs, JSON summary fields, timestamps, and indexes.
- Add Alembic migration `backend/app/db/migrations/versions/0019_add_onboarding_readiness_snapshot_tables.py` to create/drop onboarding enums and the three tables with indexes and constraints.
- Run code formatting on changed files and apply minor whitespace/formatting adjustments to `db/models.py` for consistency.

### Testing

- Ran formatting with `ruff format` on changed files (completed successfully).
- Ran lint checks with `ruff check app tests` and the linter passed (`All checks passed!`).
- Ran targeted tests with `pytest tests/test_migration_integrity.py tests/test_frontend_contracts.py -q` and all tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7661b3608321a4f0848854512123)