### PR TITLE
Implement onboarding readiness aggregation service and threshold logic

### DIFF
--- a/backend/app/onboarding/blockers.py
+++ b/backend/app/onboarding/blockers.py
@@ -1,0 +1,159 @@
+"""Blocker classification for onboarding readiness."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Literal
+
+from app.onboarding.models import ReadinessBlocker
+from app.onboarding.progress import OnboardingSignals
+
+BlockerSeverity = Literal["critical", "important"]
+
+
+@dataclass(slots=True)
+class ClassifiedBlocker:
+    code: str
+    title: str
+    detail: str
+    severity: BlockerSeverity
+    blocking_step_key: str
+
+    def to_model(self) -> ReadinessBlocker:
+        return ReadinessBlocker(
+            code=self.code,
+            title=self.title,
+            detail=self.detail,
+            severity="error" if self.severity == "critical" else "warning",
+            blocking_step_key=self.blocking_step_key,
+            created_at_utc=datetime.now(timezone.utc),
+            is_resolved=False,
+        )
+
+
+def classify_blockers(*, signals: OnboardingSignals) -> list[ClassifiedBlocker]:
+    """Classify onboarding blockers into critical/important severity buckets."""
+    blockers: list[ClassifiedBlocker] = []
+
+    if not signals.org_settings_configured:
+        blockers.append(
+            ClassifiedBlocker(
+                code="org_settings_incomplete",
+                title="Organization settings incomplete",
+                detail="Configure communication and safety contact settings before rollout.",
+                severity="critical",
+                blocking_step_key="org_settings",
+            )
+        )
+
+    if signals.org_admin_count == 0:
+        blockers.append(
+            ClassifiedBlocker(
+                code="org_admin_missing",
+                title="Organization admin missing",
+                detail="At least one org_admin account is required to administer launch settings.",
+                severity="critical",
+                blocking_step_key="users_roles",
+            )
+        )
+
+    if signals.successful_import_count == 0:
+        blockers.append(
+            ClassifiedBlocker(
+                code="imports_missing",
+                title="No successful import",
+                detail="Run and complete at least one source data import.",
+                severity="critical",
+                blocking_step_key="imports",
+            )
+        )
+    elif signals.failed_import_count > 0:
+        blockers.append(
+            ClassifiedBlocker(
+                code="imports_with_failures",
+                title="Import failures detected",
+                detail="One or more import jobs failed and must be remediated.",
+                severity="important",
+                blocking_step_key="imports",
+            )
+        )
+
+    if signals.mapping_count == 0:
+        blockers.append(
+            ClassifiedBlocker(
+                code="mappings_missing",
+                title="Mappings incomplete",
+                detail="External mappings are required for synced entities.",
+                severity="important",
+                blocking_step_key="mappings",
+            )
+        )
+
+    if signals.active_integration_count == 0:
+        blockers.append(
+            ClassifiedBlocker(
+                code="integrations_inactive",
+                title="No active integrations",
+                detail="Activate at least one integration connection.",
+                severity="critical",
+                blocking_step_key="integrations",
+            )
+        )
+
+    if (
+        signals.vehicles_total > 0
+        and signals.qr_codes_activated < signals.vehicles_total
+    ):
+        blockers.append(
+            ClassifiedBlocker(
+                code="vehicle_qr_incomplete",
+                title="Vehicle QR rollout incomplete",
+                detail="Generate and activate QR tokens for all active vehicles.",
+                severity="important",
+                blocking_step_key="vehicle_qr",
+            )
+        )
+
+    if not signals.protocol_configured:
+        blockers.append(
+            ClassifiedBlocker(
+                code="driver_protocol_missing",
+                title="Driver protocol not configured",
+                detail="Enable driver acknowledgement workflow and publish instruction steps.",
+                severity="critical",
+                blocking_step_key="driver_protocol",
+            )
+        )
+
+    if not signals.test_run_passed:
+        blockers.append(
+            ClassifiedBlocker(
+                code="test_run_missing",
+                title="Test run not completed",
+                detail="Complete a successful test incident run before go-live.",
+                severity="critical",
+                blocking_step_key="test_run",
+            )
+        )
+
+    if not signals.export_validation_passed:
+        blockers.append(
+            ClassifiedBlocker(
+                code="export_validation_failed",
+                title="Export validation failed",
+                detail="Export pipeline must produce a ready package without failures.",
+                severity="critical",
+                blocking_step_key="export_validation",
+            )
+        )
+
+    return blockers
+
+
+def blocked_step_keys(blockers: list[ClassifiedBlocker]) -> set[str]:
+    return {
+        blocker.blocking_step_key
+        for blocker in blockers
+        if blocker.severity == "critical"
+    }

--- a/backend/app/onboarding/progress.py
+++ b/backend/app/onboarding/progress.py
@@ -1,0 +1,119 @@
+"""Onboarding progress primitives and step derivation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from app.onboarding.models import ReadinessStep, ReadinessStepStatus
+
+
+@dataclass(slots=True)
+class OnboardingSignals:
+    """Normalized onboarding signals used by readiness orchestration."""
+
+    org_settings_configured: bool = False
+    org_admin_count: int = 0
+    active_user_count: int = 0
+    successful_import_count: int = 0
+    failed_import_count: int = 0
+    mapping_count: int = 0
+    active_integration_count: int = 0
+    total_integration_count: int = 0
+    vehicles_total: int = 0
+    qr_codes_generated: int = 0
+    qr_codes_activated: int = 0
+    last_qr_rotation_at_utc: datetime | None = None
+    protocol_configured: bool = False
+    test_run_passed: bool = False
+    export_validation_passed: bool = False
+    has_started_activity: bool = False
+
+
+@dataclass(slots=True)
+class StepDefinition:
+    key: str
+    label: str
+    order: int
+
+
+STEP_DEFINITIONS: tuple[StepDefinition, ...] = (
+    StepDefinition("org_settings", "Organization settings", 10),
+    StepDefinition("users_roles", "Users and roles", 20),
+    StepDefinition("imports", "Data imports", 30),
+    StepDefinition("mappings", "External mappings", 40),
+    StepDefinition("integrations", "Integrations", 50),
+    StepDefinition("vehicle_qr", "Vehicle QR deployment", 60),
+    StepDefinition("driver_protocol", "Driver protocol", 70),
+    StepDefinition("test_run", "Test incident run", 80),
+    StepDefinition("export_validation", "Export validation", 90),
+)
+
+
+def derive_step_statuses(
+    *, signals: OnboardingSignals, blocked_step_keys: set[str]
+) -> list[ReadinessStep]:
+    """Derive step-level readiness status from normalized onboarding signals."""
+    statuses: dict[str, ReadinessStepStatus] = {
+        "org_settings": "completed"
+        if signals.org_settings_configured
+        else "not_started",
+        "users_roles": "completed"
+        if signals.org_admin_count > 0 and signals.active_user_count > 0
+        else "in_progress"
+        if signals.active_user_count > 0
+        else "not_started",
+        "imports": "completed"
+        if signals.successful_import_count > 0 and signals.failed_import_count == 0
+        else "in_progress"
+        if signals.successful_import_count > 0 or signals.failed_import_count > 0
+        else "not_started",
+        "mappings": "completed" if signals.mapping_count > 0 else "not_started",
+        "integrations": "completed"
+        if signals.active_integration_count > 0
+        else "in_progress"
+        if signals.total_integration_count > 0
+        else "not_started",
+        "vehicle_qr": "completed"
+        if signals.vehicles_total > 0
+        and signals.qr_codes_activated >= signals.vehicles_total
+        else "in_progress"
+        if signals.qr_codes_generated > 0
+        else "not_started",
+        "driver_protocol": "completed"
+        if signals.protocol_configured
+        else "not_started",
+        "test_run": "completed" if signals.test_run_passed else "not_started",
+        "export_validation": "completed"
+        if signals.export_validation_passed
+        else "not_started",
+    }
+
+    steps: list[ReadinessStep] = []
+    for definition in STEP_DEFINITIONS:
+        status = (
+            "blocked"
+            if definition.key in blocked_step_keys
+            else statuses[definition.key]
+        )
+        steps.append(
+            ReadinessStep(
+                key=definition.key,
+                label=definition.label,
+                status=status,
+                order=definition.order,
+                metadata={},
+            )
+        )
+    return steps
+
+
+def completion_percent(steps: list[ReadinessStep]) -> int:
+    if not steps:
+        return 0
+    completed = sum(1 for step in steps if step.status == "completed")
+    return int((completed / len(steps)) * 100)
+
+
+def completed_step_keys(steps: list[ReadinessStep]) -> set[str]:
+    return {step.key for step in steps if step.status == "completed"}

--- a/backend/app/onboarding/readiness.py
+++ b/backend/app/onboarding/readiness.py
@@ -1,0 +1,51 @@
+"""Readiness status derivation for pilot and launch milestones."""
+
+from __future__ import annotations
+
+from app.onboarding.models import ReadinessStatus, ReadinessStep
+
+PILOT_THRESHOLD_PERCENT = 60
+LAUNCH_THRESHOLD_PERCENT = 90
+
+PILOT_REQUIRED_STEPS = {
+    "org_settings",
+    "users_roles",
+    "integrations",
+    "driver_protocol",
+    "test_run",
+}
+
+LAUNCH_REQUIRED_STEPS = {
+    "org_settings",
+    "users_roles",
+    "imports",
+    "mappings",
+    "integrations",
+    "vehicle_qr",
+    "driver_protocol",
+    "test_run",
+    "export_validation",
+}
+
+
+def derive_readiness_status(
+    *, steps: list[ReadinessStep], percent_complete: int
+) -> ReadinessStatus:
+    """Determine readiness status from step progress and pilot/launch thresholds."""
+    if any(step.status == "blocked" for step in steps):
+        return "blocked"
+
+    completed = {step.key for step in steps if step.status == "completed"}
+
+    launch_requirements_met = LAUNCH_REQUIRED_STEPS.issubset(completed)
+    if launch_requirements_met and percent_complete >= LAUNCH_THRESHOLD_PERCENT:
+        return "launch_ready"
+
+    pilot_requirements_met = PILOT_REQUIRED_STEPS.issubset(completed)
+    if pilot_requirements_met and percent_complete >= PILOT_THRESHOLD_PERCENT:
+        return "pilot_ready"
+
+    if any(step.status in {"in_progress", "completed"} for step in steps):
+        return "in_progress"
+
+    return "not_started"

--- a/backend/app/onboarding/service.py
+++ b/backend/app/onboarding/service.py
@@ -1,0 +1,248 @@
+"""Onboarding readiness service for API routes and background jobs."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import distinct, func
+from sqlalchemy.orm import Session
+
+from app.db.models import (
+    DriverInstructionSet,
+    DriverInstructionStep,
+    DriverVehicleAssignment,
+    Event,
+    Export,
+    ExternalMapping,
+    IntegrationConnection,
+    IntegrationOperation,
+    Org,
+    User,
+    UserOrg,
+    VehicleQrToken,
+)
+from app.onboarding.blockers import blocked_step_keys, classify_blockers
+from app.onboarding.models import (
+    ImportJob,
+    IntegrationValidationResult,
+    OrgLaunchReadiness,
+    TestIncidentRun,
+    VehicleQrDeployment,
+)
+from app.onboarding.progress import (
+    OnboardingSignals,
+    completion_percent,
+    derive_step_statuses,
+)
+from app.onboarding.readiness import derive_readiness_status
+
+
+def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingSignals:
+    """Collect normalized onboarding signals from persisted org state."""
+    org = db.query(Org).filter(Org.id == org_id).first()
+    if org is None:
+        return OnboardingSignals()
+
+    org_settings_configured = bool(org.safety_manager_phone) and bool(
+        org.sms_enabled or org.voice_enabled
+    )
+
+    user_rows = (
+        db.query(User)
+        .join(UserOrg, UserOrg.user_id == User.id)
+        .filter(UserOrg.org_id == org_id)
+        .all()
+    )
+    active_users = [
+        user for user in user_rows if bool(getattr(user, "is_active", True))
+    ]
+    org_admin_count = sum(1 for user in active_users if str(user.role) == "org_admin")
+
+    import_operations = (
+        db.query(IntegrationOperation)
+        .filter(
+            IntegrationOperation.org_id == org_id,
+            func.lower(IntegrationOperation.operation_type).like("%import%"),
+        )
+        .all()
+    )
+    successful_import_count = sum(
+        1 for op in import_operations if op.status == "succeeded"
+    )
+    failed_import_count = sum(1 for op in import_operations if op.status == "failed")
+
+    mapping_count = (
+        db.query(ExternalMapping.mapping_id)
+        .filter(ExternalMapping.org_id == org_id)
+        .count()
+    )
+
+    integration_rows = (
+        db.query(IntegrationConnection)
+        .filter(IntegrationConnection.org_id == org_id)
+        .all()
+    )
+    active_integration_count = sum(
+        1 for row in integration_rows if row.status == "active"
+    )
+
+    vehicles_total = (
+        db.query(func.count(distinct(DriverVehicleAssignment.adc_vehicle_id)))
+        .filter(DriverVehicleAssignment.org_id == org_id)
+        .scalar()
+        or 0
+    )
+    qr_rows = db.query(VehicleQrToken).filter(VehicleQrToken.org_id == org_id).all()
+    qr_codes_generated = len(qr_rows)
+    qr_codes_activated = sum(1 for row in qr_rows if row.status == "active")
+    qr_rotation_times = [
+        row.created_at_utc for row in qr_rows if row.created_at_utc is not None
+    ]
+
+    instruction_set = (
+        db.query(DriverInstructionSet)
+        .filter(DriverInstructionSet.org_id == org_id)
+        .order_by(DriverInstructionSet.created_at_utc.desc())
+        .first()
+    )
+    enabled_step_count = 0
+    if instruction_set is not None:
+        enabled_step_count = (
+            db.query(DriverInstructionStep.step_id)
+            .filter(
+                DriverInstructionStep.instruction_set_id
+                == instruction_set.instruction_set_id,
+                DriverInstructionStep.enabled.is_(True),
+            )
+            .count()
+        )
+    protocol_configured = bool(org.require_driver_ack and enabled_step_count > 0)
+
+    test_run_event = (
+        db.query(Event)
+        .filter(
+            Event.org_id == org_id,
+            Event.event_type == "incident_protocol_initiated",
+        )
+        .order_by(Event.occurred_at_utc.desc())
+        .first()
+    )
+    test_run_passed = test_run_event is not None
+
+    latest_export = (
+        db.query(Export)
+        .filter(Export.org_id == org_id)
+        .order_by(Export.updated_at_utc.desc(), Export.created_at_utc.desc())
+        .first()
+    )
+    export_validation_passed = (
+        latest_export is not None and latest_export.status == "ready"
+    )
+
+    has_started_activity = any(
+        [
+            len(active_users) > 0,
+            len(import_operations) > 0,
+            mapping_count > 0,
+            len(integration_rows) > 0,
+            qr_codes_generated > 0,
+            test_run_event is not None,
+            latest_export is not None,
+        ]
+    )
+
+    return OnboardingSignals(
+        org_settings_configured=org_settings_configured,
+        org_admin_count=org_admin_count,
+        active_user_count=len(active_users),
+        successful_import_count=successful_import_count,
+        failed_import_count=failed_import_count,
+        mapping_count=mapping_count,
+        active_integration_count=active_integration_count,
+        total_integration_count=len(integration_rows),
+        vehicles_total=vehicles_total,
+        qr_codes_generated=qr_codes_generated,
+        qr_codes_activated=qr_codes_activated,
+        last_qr_rotation_at_utc=max(qr_rotation_times) if qr_rotation_times else None,
+        protocol_configured=protocol_configured,
+        test_run_passed=test_run_passed,
+        export_validation_passed=export_validation_passed,
+        has_started_activity=has_started_activity,
+    )
+
+
+def build_onboarding_readiness(
+    *, org_id: uuid.UUID, signals: OnboardingSignals
+) -> OrgLaunchReadiness:
+    """Build a typed readiness snapshot from normalized onboarding signals."""
+    classified = classify_blockers(signals=signals)
+    steps = derive_step_statuses(
+        signals=signals, blocked_step_keys=blocked_step_keys(classified)
+    )
+    percent_complete = completion_percent(steps)
+    status = derive_readiness_status(steps=steps, percent_complete=percent_complete)
+
+    import_jobs = [
+        ImportJob(
+            import_job_id="imports_success",
+            provider="aggregated",
+            status="succeeded" if signals.successful_import_count > 0 else "pending",
+            records_total=signals.successful_import_count + signals.failed_import_count,
+            records_succeeded=signals.successful_import_count,
+            records_failed=signals.failed_import_count,
+        )
+    ]
+
+    integration_validations = [
+        IntegrationValidationResult(
+            integration_key="active_integrations",
+            status="completed"
+            if signals.active_integration_count > 0
+            else "not_started",
+            checked_at_utc=datetime.now(timezone.utc),
+            detail=f"{signals.active_integration_count} active of {signals.total_integration_count} configured",
+            severity="info" if signals.active_integration_count > 0 else "warning",
+        )
+    ]
+
+    test_incident_run = TestIncidentRun(
+        status="completed" if signals.test_run_passed else "not_started",
+        findings=[]
+        if signals.test_run_passed
+        else ["No completed test incident protocol run detected."],
+    )
+
+    qr_deployment = VehicleQrDeployment(
+        status="completed"
+        if signals.vehicles_total > 0
+        and signals.qr_codes_activated >= signals.vehicles_total
+        else "in_progress"
+        if signals.qr_codes_generated > 0
+        else "not_started",
+        vehicles_total=signals.vehicles_total,
+        qr_codes_generated=signals.qr_codes_generated,
+        qr_codes_activated=signals.qr_codes_activated,
+        last_rotated_at_utc=signals.last_qr_rotation_at_utc,
+    )
+
+    return OrgLaunchReadiness(
+        org_id=str(org_id),
+        status=status,
+        percent_complete=percent_complete,
+        steps=steps,
+        blockers=[item.to_model() for item in classified],
+        import_jobs=import_jobs,
+        integration_validations=integration_validations,
+        vehicle_qr_deployment=qr_deployment,
+        test_incident_run=test_incident_run,
+        snapshot_created_at_utc=datetime.now(timezone.utc),
+    )
+
+
+def get_org_onboarding_readiness(
+    db: Session, *, org_id: uuid.UUID
+) -> OrgLaunchReadiness:
+    """Reusable facade for API routes and background jobs."""
+    signals = collect_onboarding_signals(db, org_id=org_id)
+    return build_onboarding_readiness(org_id=org_id, signals=signals)

--- a/backend/tests/test_onboarding_service.py
+++ b/backend/tests/test_onboarding_service.py
@@ -1,0 +1,101 @@
+import uuid
+
+from app.onboarding.blockers import classify_blockers
+from app.onboarding.progress import (
+    OnboardingSignals,
+    completion_percent,
+    derive_step_statuses,
+)
+from app.onboarding.readiness import derive_readiness_status
+from app.onboarding.service import build_onboarding_readiness
+
+
+def test_classify_blockers_severity_buckets():
+    blockers = classify_blockers(
+        signals=OnboardingSignals(
+            org_settings_configured=False,
+            org_admin_count=0,
+            successful_import_count=0,
+            mapping_count=0,
+            active_integration_count=0,
+            protocol_configured=False,
+            test_run_passed=False,
+            export_validation_passed=False,
+        )
+    )
+
+    by_code = {blocker.code: blocker for blocker in blockers}
+    assert by_code["org_settings_incomplete"].severity == "critical"
+    assert by_code["mappings_missing"].severity == "important"
+    assert by_code["export_validation_failed"].severity == "critical"
+
+
+def test_readiness_status_transitions_pilot_and_launch():
+    pilot_steps = derive_step_statuses(
+        signals=OnboardingSignals(
+            org_settings_configured=True,
+            org_admin_count=1,
+            active_user_count=2,
+            successful_import_count=1,
+            mapping_count=0,
+            active_integration_count=1,
+            total_integration_count=1,
+            protocol_configured=True,
+            test_run_passed=True,
+            export_validation_passed=False,
+        ),
+        blocked_step_keys=set(),
+    )
+    pilot_percent = completion_percent(pilot_steps)
+    assert (
+        derive_readiness_status(steps=pilot_steps, percent_complete=pilot_percent)
+        == "pilot_ready"
+    )
+
+    launch_steps = derive_step_statuses(
+        signals=OnboardingSignals(
+            org_settings_configured=True,
+            org_admin_count=1,
+            active_user_count=2,
+            successful_import_count=1,
+            mapping_count=3,
+            active_integration_count=1,
+            total_integration_count=1,
+            vehicles_total=2,
+            qr_codes_generated=2,
+            qr_codes_activated=2,
+            protocol_configured=True,
+            test_run_passed=True,
+            export_validation_passed=True,
+        ),
+        blocked_step_keys=set(),
+    )
+    launch_percent = completion_percent(launch_steps)
+    assert (
+        derive_readiness_status(steps=launch_steps, percent_complete=launch_percent)
+        == "launch_ready"
+    )
+
+
+def test_build_onboarding_readiness_uses_blocked_status_when_critical_exists():
+    snapshot = build_onboarding_readiness(
+        org_id=uuid.uuid4(),
+        signals=OnboardingSignals(
+            org_settings_configured=False,
+            org_admin_count=0,
+            active_user_count=1,
+            successful_import_count=0,
+            mapping_count=0,
+            active_integration_count=0,
+            total_integration_count=1,
+            protocol_configured=False,
+            test_run_passed=False,
+            export_validation_passed=False,
+        ),
+    )
+
+    assert snapshot.status == "blocked"
+    blocked = {step.key for step in snapshot.steps if step.status == "blocked"}
+    assert "org_settings" in blocked
+    assert "integrations" in blocked
+    assert len(snapshot.blockers) >= 1


### PR DESCRIPTION
### Motivation
- Provide a single, testable service that aggregates onboarding signals across org settings, users/roles, imports, mappings, integrations, vehicle QR rollout, driver protocol, test runs, and export validation to drive UI and automation readiness workflows.
- Classify onboarding blockers with explicit severity buckets and map them to step-level blocking behavior so API routes and background jobs can make consistent readiness decisions.
- Support distinct pilot vs launch readiness semantics with configurable threshold logic to surface when an org meets pilot or launch milestones.

### Description
- Added onboarding progress primitives and step derivation in `backend/app/onboarding/progress.py`, including the `OnboardingSignals` contract, canonical step definitions, `derive_step_statuses`, and `completion_percent` helpers.
- Implemented blocker classification in `backend/app/onboarding/blockers.py` with `critical`/`important` severities and conversion to `ReadinessBlocker` models, plus `blocked_step_keys` helper.
- Implemented pilot/launch threshold evaluation and required-step sets in `backend/app/onboarding/readiness.py` to return `blocked`, `pilot_ready`, `launch_ready`, `in_progress`, or `not_started` states.
- Implemented the onboarding aggregation service in `backend/app/onboarding/service.py` exposing `collect_onboarding_signals`, `build_onboarding_readiness`, and `get_org_onboarding_readiness`, and composing steps, blockers, integration validation, import job summary, QR deployment, and test-run summaries into an `OrgLaunchReadiness` snapshot.
- Added unit tests in `backend/tests/test_onboarding_service.py` covering blocker classification, pilot/launch transitions, and blocked-step propagation.

### Testing
- Ran formatter/linter: `ruff format app/onboarding tests/test_onboarding_service.py` and `ruff check app/onboarding tests/test_onboarding_service.py`, which completed with no remaining issues.
- Executed unit tests: `pytest tests/test_onboarding_service.py -v`, which ran the onboarding tests and resulted in `3 passed`.
- All automated checks and the added unit tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de79c1bbb48321a3982d80baa8eac2)