### PR TITLE
Add org settings + onboarding status/mark-step endpoints with completion metadata

### DIFF
--- a/backend/app/api/routes_integrations.py
+++ b/backend/app/api/routes_integrations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from dataclasses import asdict
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from sqlalchemy.orm import Session
@@ -16,6 +17,10 @@ from app.api.schemas import (
     IntegrationConnectionUpdateRequest,
     IntegrationConnectionValidateResponse,
     IntegrationOperationDiagnosticsResponse,
+    OrgLaunchReadinessResponse,
+    OrgOnboardingStepUpdateRequest,
+    OrgSettingsResponse,
+    OrgSettingsUpdateRequest,
 )
 from app.core.config import settings
 from app.core.deps import get_current_user, require_user_role
@@ -24,6 +29,7 @@ from app.db.models import (
     EvidenceRequest,
     IntegrationConnection,
     IntegrationOperation,
+    Org,
     User,
 )
 from app.db.session import get_db
@@ -39,10 +45,128 @@ from app.security.authn import build_user_auth_context
 from app.observability.redaction import redact_payload_for_storage
 from app.services.dashcam_capture_service import queue_dashcam_capture
 from app.services.telematics_capture_service import queue_telematics_capture
+from app.onboarding.progress import STEP_DEFINITIONS
+from app.onboarding.service import (
+    get_org_onboarding_readiness,
+    set_step_completion_override,
+)
 
 router = APIRouter()
 
 _integration_admin = require_user_role("system_admin", "org_admin")
+
+
+def _first_org_id(context) -> uuid.UUID:
+    return context.org_ids[0]
+
+
+def _to_readiness_response(readiness) -> OrgLaunchReadinessResponse:
+    return OrgLaunchReadinessResponse.model_validate(
+        {
+            "org_id": readiness.org_id,
+            "status": readiness.status,
+            "percent_complete": readiness.percent_complete,
+            "steps": [asdict(item) for item in readiness.steps],
+            "blockers": [asdict(item) for item in readiness.blockers],
+            "import_jobs": [asdict(item) for item in readiness.import_jobs],
+            "integration_validations": [asdict(item) for item in readiness.integration_validations],
+            "vehicle_qr_deployment": asdict(readiness.vehicle_qr_deployment)
+            if readiness.vehicle_qr_deployment is not None
+            else None,
+            "test_incident_run": asdict(readiness.test_incident_run)
+            if readiness.test_incident_run is not None
+            else None,
+            "snapshot_created_at_utc": readiness.snapshot_created_at_utc,
+        }
+    )
+
+
+@router.get("/org/settings", response_model=OrgSettingsResponse)
+def get_org_settings(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    org = db.query(Org).filter(Org.id == _first_org_id(context)).first()
+    if org is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+    return OrgSettingsResponse(
+        legal_name=org.legal_name,
+        display_name=org.display_name or org.name,
+        timezone=org.timezone,
+        region=org.region,
+        contacts=org.contacts_json or [],
+        implementation_contact=org.implementation_contact_json or None,
+        logo_url=org.logo_url,
+    )
+
+
+@router.patch("/org/settings", response_model=OrgSettingsResponse)
+def patch_org_settings(
+    payload: OrgSettingsUpdateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    org = db.query(Org).filter(Org.id == _first_org_id(context)).first()
+    if org is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    updates = payload.model_dump(exclude_unset=True)
+    for field in ("legal_name", "display_name", "timezone", "region", "logo_url"):
+        if field in updates:
+            setattr(org, field, updates[field])
+    if "display_name" in updates and updates["display_name"]:
+        org.name = updates["display_name"]
+    if "contacts" in updates:
+        org.contacts_json = [item for item in updates["contacts"] or []]
+    if "implementation_contact" in updates:
+        org.implementation_contact_json = updates["implementation_contact"] or {}
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+
+    return OrgSettingsResponse(
+        legal_name=org.legal_name,
+        display_name=org.display_name or org.name,
+        timezone=org.timezone,
+        region=org.region,
+        contacts=org.contacts_json or [],
+        implementation_contact=org.implementation_contact_json or None,
+        logo_url=org.logo_url,
+    )
+
+
+@router.get("/org/onboarding/status", response_model=OrgLaunchReadinessResponse)
+def get_org_onboarding_status(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    readiness = get_org_onboarding_readiness(db, org_id=_first_org_id(context))
+    return _to_readiness_response(readiness)
+
+
+@router.post("/org/onboarding/mark-step", response_model=OrgLaunchReadinessResponse)
+def mark_org_onboarding_step(
+    payload: OrgOnboardingStepUpdateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    valid_steps = {item.key for item in STEP_DEFINITIONS}
+    if payload.step_key not in valid_steps:
+        raise HTTPException(status_code=422, detail="Unknown step_key")
+    set_step_completion_override(
+        db,
+        org_id=_first_org_id(context),
+        step_key=payload.step_key,
+        is_completed=payload.completed,
+        actor_user_id=current_user.id,
+        source=payload.source,
+    )
+    readiness = get_org_onboarding_readiness(db, org_id=_first_org_id(context))
+    return _to_readiness_response(readiness)
 
 
 @router.get("/org/integrations", response_model=list[IntegrationConnectionHealthResponse])

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -632,6 +632,33 @@ class MessagingReliabilityResponse(BaseModel):
     success_rate_pct: int = Field(default=0, ge=0, le=100)
 
 
+class OrgSettingsContact(BaseModel):
+    name: Optional[ShortText] = None
+    title: Optional[ShortText] = None
+    email: Optional[EmailStrLike] = None
+    phone: Optional[ShortText] = None
+
+
+class OrgSettingsResponse(BaseModel):
+    legal_name: Optional[ShortText] = None
+    display_name: Optional[ShortText] = None
+    timezone: Optional[ShortText] = None
+    region: Optional[ShortText] = None
+    contacts: list[OrgSettingsContact] = Field(default_factory=list)
+    implementation_contact: Optional[OrgSettingsContact] = None
+    logo_url: Optional[str] = None
+
+
+class OrgSettingsUpdateRequest(BaseModel):
+    legal_name: Optional[ShortText] = None
+    display_name: Optional[ShortText] = None
+    timezone: Optional[ShortText] = None
+    region: Optional[ShortText] = None
+    contacts: Optional[list[OrgSettingsContact]] = None
+    implementation_contact: Optional[OrgSettingsContact] = None
+    logo_url: Optional[str] = None
+
+
 # ── Onboarding contracts ─────────────────────────────────────────────
 
 
@@ -706,6 +733,12 @@ class OrgLaunchReadinessResponse(BaseModel):
     vehicle_qr_deployment: Optional[VehicleQrDeploymentResponse] = None
     test_incident_run: Optional[TestIncidentRunResponse] = None
     snapshot_created_at_utc: Optional[datetime] = None
+
+
+class OrgOnboardingStepUpdateRequest(BaseModel):
+    step_key: ShortText
+    completed: bool = True
+    source: ShortText = "manual"
 
 
 # ── Exports ─────────────────────────────────────────────────────────

--- a/backend/app/db/migrations/versions/0020_add_org_settings_and_onboarding_completion.py
+++ b/backend/app/db/migrations/versions/0020_add_org_settings_and_onboarding_completion.py
@@ -1,0 +1,89 @@
+"""add org settings fields and onboarding step completion table
+
+Revision ID: 0020_add_org_settings_and_onboarding_completion
+Revises: 0019_add_onboarding_readiness_snapshot_tables
+Create Date: 2026-04-14 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "0020_add_org_settings_and_onboarding_completion"
+down_revision = "0019_add_onboarding_readiness_snapshot_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("orgs", sa.Column("legal_name", sa.Text(), nullable=True))
+    op.add_column("orgs", sa.Column("display_name", sa.Text(), nullable=True))
+    op.add_column("orgs", sa.Column("timezone", sa.Text(), nullable=True))
+    op.add_column("orgs", sa.Column("region", sa.Text(), nullable=True))
+    op.add_column(
+        "orgs",
+        sa.Column(
+            "contacts_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'"),
+        ),
+    )
+    op.add_column(
+        "orgs",
+        sa.Column(
+            "implementation_contact_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+    )
+    op.add_column("orgs", sa.Column("logo_url", sa.Text(), nullable=True))
+
+    op.create_table(
+        "org_onboarding_step_completions",
+        sa.Column("completion_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("step_key", sa.Text(), nullable=False),
+        sa.Column("is_completed", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("completed_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("completed_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("completion_source", sa.Text(), nullable=True),
+        sa.Column("updated_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["completed_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("completion_id"),
+    )
+    op.create_index(
+        "ix_org_onboarding_step_completions_org_id",
+        "org_onboarding_step_completions",
+        ["org_id"],
+    )
+    op.create_index(
+        "ix_org_onboarding_step_completion_org_step",
+        "org_onboarding_step_completions",
+        ["org_id", "step_key"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_org_onboarding_step_completion_org_step",
+        table_name="org_onboarding_step_completions",
+    )
+    op.drop_index(
+        "ix_org_onboarding_step_completions_org_id",
+        table_name="org_onboarding_step_completions",
+    )
+    op.drop_table("org_onboarding_step_completions")
+
+    op.drop_column("orgs", "logo_url")
+    op.drop_column("orgs", "implementation_contact_json")
+    op.drop_column("orgs", "contacts_json")
+    op.drop_column("orgs", "region")
+    op.drop_column("orgs", "timezone")
+    op.drop_column("orgs", "display_name")
+    op.drop_column("orgs", "legal_name")

--- a/backend/app/db/migrations/versions/0020_add_org_settings_and_onboarding_completion.py
+++ b/backend/app/db/migrations/versions/0020_add_org_settings_and_onboarding_completion.py
@@ -8,13 +8,14 @@ Create Date: 2026-04-14 00:00:00.000000
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
+from typing import Union
 
 
 # revision identifiers, used by Alembic.
-revision = "0020_add_org_settings_and_onboarding_completion"
-down_revision = "0019_add_onboarding_readiness_snapshot_tables"
-branch_labels = None
-depends_on = None
+revision: str = "0020"
+down_revision: Union[str, None] = "0019"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
 
 
 def upgrade() -> None:

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -33,6 +33,17 @@ class Org(Base):
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(Text, nullable=False)
+    legal_name = Column(Text, nullable=True)
+    display_name = Column(Text, nullable=True)
+    timezone = Column(Text, nullable=True)
+    region = Column(Text, nullable=True)
+    contacts_json = Column(
+        JSONB, nullable=False, default=list, server_default=text("'[]'")
+    )
+    implementation_contact_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    logo_url = Column(Text, nullable=True)
     require_driver_ack = Column(Boolean, nullable=False, default=False)
     sms_enabled = Column(Boolean, nullable=False, default=False)
     voice_enabled = Column(Boolean, nullable=False, default=False)
@@ -1316,6 +1327,31 @@ class OrgLaunchReadinessBlocker(Base):
             "snapshot_id",
             "is_resolved",
         ),
+    )
+
+
+class OrgOnboardingStepCompletion(Base):
+    """Latest persisted completion metadata for each onboarding step."""
+
+    __tablename__ = "org_onboarding_step_completions"
+
+    completion_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    step_key = Column(Text, nullable=False)
+    is_completed = Column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+    completed_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    completed_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    completion_source = Column(Text, nullable=True)
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        Index("ix_org_onboarding_step_completion_org_step", "org_id", "step_key", unique=True),
     )
 
 

--- a/backend/app/onboarding/progress.py
+++ b/backend/app/onboarding/progress.py
@@ -38,7 +38,7 @@ class StepDefinition:
 
 
 STEP_DEFINITIONS: tuple[StepDefinition, ...] = (
-    StepDefinition("org_settings", "Organization settings", 10),
+    StepDefinition("org_settings", "Organization basics", 10),
     StepDefinition("users_roles", "Users and roles", 20),
     StepDefinition("imports", "Data imports", 30),
     StepDefinition("mappings", "External mappings", 40),

--- a/backend/app/onboarding/service.py
+++ b/backend/app/onboarding/service.py
@@ -18,6 +18,7 @@ from app.db.models import (
     IntegrationConnection,
     IntegrationOperation,
     Org,
+    OrgOnboardingStepCompletion,
     User,
     UserOrg,
     VehicleQrToken,
@@ -38,15 +39,36 @@ from app.onboarding.progress import (
 from app.onboarding.readiness import derive_readiness_status
 
 
+def _organization_basics_complete(org: Org) -> bool:
+    contacts = org.contacts_json or []
+    implementation_contact = org.implementation_contact_json or {}
+    has_contact = any(
+        bool((contact or {}).get("name")) and bool((contact or {}).get("email"))
+        for contact in contacts
+        if isinstance(contact, dict)
+    )
+    has_implementation_contact = bool(implementation_contact.get("name")) and bool(
+        implementation_contact.get("email")
+    )
+    return all(
+        [
+            bool(org.legal_name),
+            bool(org.display_name or org.name),
+            bool(org.timezone),
+            bool(org.region),
+            has_contact,
+            has_implementation_contact,
+        ]
+    )
+
+
 def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingSignals:
     """Collect normalized onboarding signals from persisted org state."""
     org = db.query(Org).filter(Org.id == org_id).first()
     if org is None:
         return OnboardingSignals()
 
-    org_settings_configured = bool(org.safety_manager_phone) and bool(
-        org.sms_enabled or org.voice_enabled
-    )
+    org_settings_configured = _organization_basics_complete(org)
 
     user_rows = (
         db.query(User)
@@ -173,13 +195,32 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
 
 
 def build_onboarding_readiness(
-    *, org_id: uuid.UUID, signals: OnboardingSignals
+    *,
+    org_id: uuid.UUID,
+    signals: OnboardingSignals,
+    step_completion_overrides: dict[str, OrgOnboardingStepCompletion] | None = None,
 ) -> OrgLaunchReadiness:
     """Build a typed readiness snapshot from normalized onboarding signals."""
     classified = classify_blockers(signals=signals)
     steps = derive_step_statuses(
         signals=signals, blocked_step_keys=blocked_step_keys(classified)
     )
+    for step in steps:
+        completion = (step_completion_overrides or {}).get(step.key)
+        if completion is None:
+            continue
+        if completion.is_completed:
+            step.status = "completed"
+            step.completed_at_utc = completion.completed_at_utc
+            step.metadata = {
+                "completed_by_user_id": str(completion.completed_by_user_id)
+                if completion.completed_by_user_id
+                else "",
+                "completion_source": completion.completion_source or "unknown",
+            }
+        else:
+            step.metadata = {"completion_source": completion.completion_source or "unknown"}
+        step.updated_at_utc = completion.updated_at_utc
     percent_complete = completion_percent(steps)
     status = derive_readiness_status(steps=steps, percent_complete=percent_complete)
 
@@ -245,4 +286,48 @@ def get_org_onboarding_readiness(
 ) -> OrgLaunchReadiness:
     """Reusable facade for API routes and background jobs."""
     signals = collect_onboarding_signals(db, org_id=org_id)
-    return build_onboarding_readiness(org_id=org_id, signals=signals)
+    overrides = list_step_completion_overrides(db, org_id=org_id)
+    return build_onboarding_readiness(
+        org_id=org_id, signals=signals, step_completion_overrides=overrides
+    )
+
+
+def list_step_completion_overrides(
+    db: Session, *, org_id: uuid.UUID
+) -> dict[str, OrgOnboardingStepCompletion]:
+    rows = (
+        db.query(OrgOnboardingStepCompletion)
+        .filter(OrgOnboardingStepCompletion.org_id == org_id)
+        .all()
+    )
+    return {row.step_key: row for row in rows}
+
+
+def set_step_completion_override(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    step_key: str,
+    is_completed: bool,
+    actor_user_id: uuid.UUID,
+    source: str,
+) -> OrgOnboardingStepCompletion:
+    row = (
+        db.query(OrgOnboardingStepCompletion)
+        .filter(
+            OrgOnboardingStepCompletion.org_id == org_id,
+            OrgOnboardingStepCompletion.step_key == step_key,
+        )
+        .first()
+    )
+    if row is None:
+        row = OrgOnboardingStepCompletion(org_id=org_id, step_key=step_key)
+    row.is_completed = is_completed
+    row.completed_by_user_id = actor_user_id if is_completed else None
+    row.completed_at_utc = datetime.now(timezone.utc) if is_completed else None
+    row.completion_source = source
+    row.updated_at_utc = datetime.now(timezone.utc)
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -357,6 +357,81 @@ class TestIncidentExportReadiness:
 
 
 class TestIntegrationDiagnosticsRoutes:
+    def test_org_settings_read_and_patch(self, client, db_session, test_org, auth_headers):
+        read = client.get("/org/settings", headers=auth_headers)
+        assert read.status_code == 200
+        assert read.json()["display_name"] == "Test Org"
+
+        update = client.patch(
+            "/org/settings",
+            headers=auth_headers,
+            json={
+                "legal_name": "Test Org LLC",
+                "display_name": "Test Org Display",
+                "timezone": "America/Chicago",
+                "region": "US",
+                "contacts": [{"name": "Safety Lead", "email": "safety@test.org"}],
+                "implementation_contact": {"name": "Impl Lead", "email": "impl@test.org"},
+                "logo_url": "https://cdn.example.com/logo.png",
+            },
+        )
+        assert update.status_code == 200
+        payload = update.json()
+        assert payload["legal_name"] == "Test Org LLC"
+        assert payload["display_name"] == "Test Org Display"
+        assert payload["timezone"] == "America/Chicago"
+        assert payload["contacts"][0]["email"] == "safety@test.org"
+        assert payload["implementation_contact"]["email"] == "impl@test.org"
+        assert payload["logo_url"] == "https://cdn.example.com/logo.png"
+
+    def test_onboarding_status_and_mark_step(self, client, auth_headers):
+        status_before = client.get("/org/onboarding/status", headers=auth_headers)
+        assert status_before.status_code == 200
+
+        mark = client.post(
+            "/org/onboarding/mark-step",
+            headers=auth_headers,
+            json={"step_key": "org_settings", "completed": True, "source": "dashboard"},
+        )
+        assert mark.status_code == 200
+        org_settings_step = next(
+            item for item in mark.json()["steps"] if item["key"] == "org_settings"
+        )
+        assert org_settings_step["status"] == "completed"
+        assert org_settings_step["metadata"]["completion_source"] == "dashboard"
+        assert org_settings_step["metadata"]["completed_by_user_id"]
+
+    def test_org_settings_completion_rule_updates_onboarding_status(
+        self, client, auth_headers
+    ):
+        initial = client.get("/org/onboarding/status", headers=auth_headers)
+        assert initial.status_code == 200
+        initial_step = next(
+            item for item in initial.json()["steps"] if item["key"] == "org_settings"
+        )
+        assert initial_step["status"] in {"blocked", "not_started"}
+
+        updated = client.patch(
+            "/org/settings",
+            headers=auth_headers,
+            json={
+                "legal_name": "Acme Transport LLC",
+                "display_name": "Acme Transport",
+                "timezone": "America/Los_Angeles",
+                "region": "US-West",
+                "contacts": [{"name": "Jane Safety", "email": "jane@acme.test"}],
+                "implementation_contact": {"name": "Bob Ops", "email": "bob@acme.test"},
+            },
+        )
+        assert updated.status_code == 200
+
+        refreshed = client.get("/org/onboarding/status", headers=auth_headers)
+        assert refreshed.status_code == 200
+        refreshed_step = next(
+            item for item in refreshed.json()["steps"] if item["key"] == "org_settings"
+        )
+        assert refreshed_step["status"] == "completed"
+
     def test_org_integrations_and_details(
         self, client, db_session, test_org, auth_headers
     ):


### PR DESCRIPTION
### Motivation
- Provide API support for persisting and exposing organization settings used by onboarding (legal/display name, timezone, contacts, region, implementation contact, logo) so dashboard and setup flows can read/update them.
- Allow manual or programmatic marking of onboarding steps and surface completion metadata to progress/dashboard consumers so step completion (who/when/source) is durable and visible.
- Evaluate the Organization Basics completion rule from stored org settings so readiness computation reflects actual org configuration.

### Description
- Added endpoints `GET /org/settings` and `PATCH /org/settings` with request/response schemas `OrgSettingsUpdateRequest` and `OrgSettingsResponse` to read and update OrgSettings fields.
- Added onboarding endpoints `GET /org/onboarding/status` and `POST /org/onboarding/mark-step` with `OrgOnboardingStepUpdateRequest` to fetch readiness and persist step completion overrides, including validation of `step_key` against `STEP_DEFINITIONS`.
- Extended the `Org` model with fields `legal_name`, `display_name`, `timezone`, `region`, `contacts_json`, `implementation_contact_json`, and `logo_url`, and added a migration `0020_add_org_settings_and_onboarding_completion.py` to add these columns and create the `org_onboarding_step_completions` table (unique index on `(org_id, step_key)`).
- Implemented `OrgOnboardingStepCompletion` model and service helpers `list_step_completion_overrides` and `set_step_completion_override`, wired overrides into `build_onboarding_readiness`, and implemented `_organization_basics_complete(org)` to drive the Organization Basics step.
- Updated onboarding step label to "Organization basics" and ensured readiness responses are serialized into API models (converting dataclasses/models to dicts) so dashboard consumers receive step metadata (`completed_by_user_id`, `completed_at_utc`, `completion_source`).

### Testing
- Ran `make lint` which completed successfully.
- Ran `pytest tests/test_api_endpoints.py tests/test_onboarding_service.py -v` and all targeted tests passed (tests exercised org settings read/update, onboarding status, `mark-step` persistence, and Organization Basics completion rule).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7b63038c8321b6245660d6d35277)