### PR TITLE
Add org user endpoints and readiness role enforcement

### DIFF
--- a/backend/app/api/routes_integrations.py
+++ b/backend/app/api/routes_integrations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import asdict
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from sqlalchemy.orm import Session
@@ -18,9 +19,15 @@ from app.api.schemas import (
     IntegrationConnectionValidateResponse,
     IntegrationOperationDiagnosticsResponse,
     OrgLaunchReadinessResponse,
+    OrgInviteUserRequest,
+    OrgInviteUserResponse,
     OrgOnboardingStepUpdateRequest,
     OrgSettingsResponse,
     OrgSettingsUpdateRequest,
+    OrgPatchUserRoleRequest,
+    OrgUserInviteSummary,
+    OrgUserSummary,
+    OrgUsersResponse,
 )
 from app.core.config import settings
 from app.core.deps import get_current_user, require_user_role
@@ -29,8 +36,10 @@ from app.db.models import (
     EvidenceRequest,
     IntegrationConnection,
     IntegrationOperation,
+    OrgUserInvite,
     Org,
     User,
+    UserOrg,
 )
 from app.db.session import get_db
 from app.integrations.webhooks.handlers import (
@@ -47,13 +56,16 @@ from app.services.dashcam_capture_service import queue_dashcam_capture
 from app.services.telematics_capture_service import queue_telematics_capture
 from app.onboarding.progress import STEP_DEFINITIONS
 from app.onboarding.service import (
+    collect_onboarding_signals,
     get_org_onboarding_readiness,
     set_step_completion_override,
 )
+from app.security.permissions import CANONICAL_ROLES, Capability, has_capability, normalize_role
 
 router = APIRouter()
 
 _integration_admin = require_user_role("system_admin", "org_admin")
+_org_user_admin = require_user_role("system_admin", "org_admin")
 
 
 def _first_org_id(context) -> uuid.UUID:
@@ -79,6 +91,34 @@ def _to_readiness_response(readiness) -> OrgLaunchReadinessResponse:
             "snapshot_created_at_utc": readiness.snapshot_created_at_utc,
         }
     )
+
+
+def _role_counts_for_org(db: Session, *, org_id: uuid.UUID) -> dict[str, int]:
+    rows = (
+        db.query(User.role)
+        .join(UserOrg, UserOrg.user_id == User.id)
+        .filter(UserOrg.org_id == org_id, User.is_active.is_(True))
+        .all()
+    )
+    counts = {role: 0 for role in CANONICAL_ROLES}
+    for (role,) in rows:
+        normalized = normalize_role(role).value
+        counts[normalized] = counts.get(normalized, 0) + 1
+    return counts
+
+
+def _role_violations(*, role_counts: dict[str, int]) -> list[str]:
+    violations: list[str] = []
+    if role_counts.get("org_admin", 0) < 1:
+        violations.append("no org admin assigned")
+    safety_capable_count = sum(
+        count
+        for role, count in role_counts.items()
+        if has_capability(role, Capability.INCIDENT_WRITE)
+    )
+    if safety_capable_count < 1:
+        violations.append("no safety manager assigned")
+    return violations
 
 
 @router.get("/org/settings", response_model=OrgSettingsResponse)
@@ -154,19 +194,211 @@ def mark_org_onboarding_step(
     current_user: User = Depends(get_current_user),
 ):
     context = build_user_auth_context(db, current_user)
+    org_id = _first_org_id(context)
     valid_steps = {item.key for item in STEP_DEFINITIONS}
     if payload.step_key not in valid_steps:
         raise HTTPException(status_code=422, detail="Unknown step_key")
+    if payload.step_key == "users_roles" and payload.completed:
+        signals = collect_onboarding_signals(db, org_id=org_id)
+        if signals.org_admin_count < 1 or signals.safety_capable_user_count < 1:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "users_roles_prerequisites_not_met",
+                    "message": "Cannot complete users_roles step until role requirements are satisfied.",
+                    "role_counts": _role_counts_for_org(db, org_id=org_id),
+                    "violations": _role_violations(role_counts=_role_counts_for_org(db, org_id=org_id)),
+                },
+            )
     set_step_completion_override(
         db,
-        org_id=_first_org_id(context),
+        org_id=org_id,
         step_key=payload.step_key,
         is_completed=payload.completed,
         actor_user_id=current_user.id,
         source=payload.source,
     )
-    readiness = get_org_onboarding_readiness(db, org_id=_first_org_id(context))
+    readiness = get_org_onboarding_readiness(db, org_id=org_id)
     return _to_readiness_response(readiness)
+
+
+@router.get("/org/users", response_model=OrgUsersResponse)
+def list_org_users(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = _first_org_id(context)
+    users = (
+        db.query(User)
+        .join(UserOrg, UserOrg.user_id == User.id)
+        .filter(UserOrg.org_id == org_id)
+        .order_by(User.created_at_utc.asc())
+        .all()
+    )
+    invites = (
+        db.query(OrgUserInvite)
+        .filter(OrgUserInvite.org_id == org_id)
+        .order_by(OrgUserInvite.created_at_utc.desc())
+        .all()
+    )
+    role_counts = _role_counts_for_org(db, org_id=org_id)
+    return OrgUsersResponse(
+        users=[
+            OrgUserSummary(
+                user_id=row.id,
+                email=row.email,
+                role=normalize_role(row.role).value,
+                is_active=bool(row.is_active),
+                created_at_utc=row.created_at_utc,
+            )
+            for row in users
+        ],
+        invites=[
+            OrgUserInviteSummary(
+                invite_id=row.invite_id,
+                email=row.email,
+                role=normalize_role(row.role).value,
+                status=row.status,
+                created_at_utc=row.created_at_utc,
+                last_sent_at_utc=row.last_sent_at_utc,
+                deactivated_at_utc=row.deactivated_at_utc,
+            )
+            for row in invites
+        ],
+        role_counts=role_counts,
+        violations=_role_violations(role_counts=role_counts),
+    )
+
+
+@router.post("/org/users/invite", response_model=OrgInviteUserResponse, status_code=201)
+def invite_org_user(
+    payload: OrgInviteUserRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(_org_user_admin),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = _first_org_id(context)
+    invite = OrgUserInvite(
+        org_id=org_id,
+        email=payload.email.lower(),
+        role=normalize_role(payload.role).value,
+        status="pending",
+        invited_by_user_id=current_user.id,
+    )
+    db.add(invite)
+    db.commit()
+    db.refresh(invite)
+    role_counts = _role_counts_for_org(db, org_id=org_id)
+    return OrgInviteUserResponse(
+        invite=OrgUserInviteSummary(
+            invite_id=invite.invite_id,
+            email=invite.email,
+            role=normalize_role(invite.role).value,
+            status=invite.status,
+            created_at_utc=invite.created_at_utc,
+            last_sent_at_utc=invite.last_sent_at_utc,
+            deactivated_at_utc=invite.deactivated_at_utc,
+        ),
+        role_counts=role_counts,
+        violations=_role_violations(role_counts=role_counts),
+    )
+
+
+@router.patch("/org/users/{user_id}/role", response_model=OrgUsersResponse)
+def patch_org_user_role(
+    user_id: uuid.UUID,
+    payload: OrgPatchUserRoleRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(_org_user_admin),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = _first_org_id(context)
+    row = (
+        db.query(User)
+        .join(UserOrg, UserOrg.user_id == User.id)
+        .filter(UserOrg.org_id == org_id, User.id == user_id)
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    row.role = normalize_role(payload.role).value
+    db.add(row)
+    db.commit()
+    return list_org_users(db=db, current_user=current_user)
+
+
+@router.post("/org/users/invite/{invite_id}/resend", response_model=OrgInviteUserResponse)
+def resend_org_user_invite(
+    invite_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(_org_user_admin),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = _first_org_id(context)
+    row = (
+        db.query(OrgUserInvite)
+        .filter(OrgUserInvite.invite_id == invite_id, OrgUserInvite.org_id == org_id)
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Invite not found")
+    if row.status != "pending":
+        raise HTTPException(status_code=409, detail="Invite is not active")
+    row.last_sent_at_utc = datetime.now(timezone.utc)
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    role_counts = _role_counts_for_org(db, org_id=org_id)
+    return OrgInviteUserResponse(
+        invite=OrgUserInviteSummary(
+            invite_id=row.invite_id,
+            email=row.email,
+            role=normalize_role(row.role).value,
+            status=row.status,
+            created_at_utc=row.created_at_utc,
+            last_sent_at_utc=row.last_sent_at_utc,
+            deactivated_at_utc=row.deactivated_at_utc,
+        ),
+        role_counts=role_counts,
+        violations=_role_violations(role_counts=role_counts),
+    )
+
+
+@router.post("/org/users/invite/{invite_id}/deactivate", response_model=OrgInviteUserResponse)
+def deactivate_org_user_invite(
+    invite_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(_org_user_admin),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = _first_org_id(context)
+    row = (
+        db.query(OrgUserInvite)
+        .filter(OrgUserInvite.invite_id == invite_id, OrgUserInvite.org_id == org_id)
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Invite not found")
+    row.status = "deactivated"
+    row.deactivated_at_utc = datetime.now(timezone.utc)
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    role_counts = _role_counts_for_org(db, org_id=org_id)
+    return OrgInviteUserResponse(
+        invite=OrgUserInviteSummary(
+            invite_id=row.invite_id,
+            email=row.email,
+            role=normalize_role(row.role).value,
+            status=row.status,
+            created_at_utc=row.created_at_utc,
+            last_sent_at_utc=row.last_sent_at_utc,
+            deactivated_at_utc=row.deactivated_at_utc,
+        ),
+        role_counts=role_counts,
+        violations=_role_violations(role_counts=role_counts),
+    )
 
 
 @router.get("/org/integrations", response_model=list[IntegrationConnectionHealthResponse])

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -741,6 +741,49 @@ class OrgOnboardingStepUpdateRequest(BaseModel):
     source: ShortText = "manual"
 
 
+class OrgUserSummary(BaseModel):
+    user_id: uuid.UUID
+    email: EmailStrLike
+    role: UserRole
+    is_active: bool = True
+    created_at_utc: Optional[datetime] = None
+
+
+class OrgUserInviteSummary(BaseModel):
+    invite_id: uuid.UUID
+    email: EmailStrLike
+    role: UserRole
+    status: Literal["pending", "deactivated", "accepted"] = "pending"
+    created_at_utc: Optional[datetime] = None
+    last_sent_at_utc: Optional[datetime] = None
+    deactivated_at_utc: Optional[datetime] = None
+
+
+class OrgUsersViolationsResponse(BaseModel):
+    violations: list[ShortText] = Field(default_factory=list)
+    role_counts: dict[str, int] = Field(default_factory=dict)
+
+
+class OrgUsersResponse(OrgUsersViolationsResponse):
+    users: list[OrgUserSummary] = Field(default_factory=list)
+    invites: list[OrgUserInviteSummary] = Field(default_factory=list)
+
+
+class OrgInviteUserRequest(BaseModel):
+    email: EmailStrLike
+    role: UserRole = "safety_manager"
+
+
+class OrgInviteUserResponse(BaseModel):
+    invite: OrgUserInviteSummary
+    role_counts: dict[str, int] = Field(default_factory=dict)
+    violations: list[ShortText] = Field(default_factory=list)
+
+
+class OrgPatchUserRoleRequest(BaseModel):
+    role: UserRole
+
+
 # ── Exports ─────────────────────────────────────────────────────────
 
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -89,6 +89,26 @@ class UserOrg(Base):
     )
 
 
+class OrgUserInvite(Base):
+    """Pending invite for a user to join an organization."""
+
+    __tablename__ = "org_user_invites"
+
+    invite_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True)
+    email = Column(Text, nullable=False, index=True)
+    role = Column(Text, nullable=False, default=Role.SAFETY_MANAGER.value)
+    status = Column(Text, nullable=False, default="pending", index=True)
+    invited_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    last_sent_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    deactivated_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+
+
 # ── Core domain models ─────────────────────────────────────────────
 
 

--- a/backend/app/onboarding/blockers.py
+++ b/backend/app/onboarding/blockers.py
@@ -50,9 +50,25 @@ def classify_blockers(*, signals: OnboardingSignals) -> list[ClassifiedBlocker]:
     if signals.org_admin_count == 0:
         blockers.append(
             ClassifiedBlocker(
-                code="org_admin_missing",
-                title="Organization admin missing",
-                detail="At least one org_admin account is required to administer launch settings.",
+                code="no_org_admin_assigned",
+                title="No org admin assigned",
+                detail=(
+                    "Assign at least one org_admin user to unlock onboarding roles readiness "
+                    f"(current org_admin_count={signals.org_admin_count})."
+                ),
+                severity="critical",
+                blocking_step_key="users_roles",
+            )
+        )
+    if signals.safety_capable_user_count == 0:
+        blockers.append(
+            ClassifiedBlocker(
+                code="no_safety_manager_assigned",
+                title="No safety manager assigned",
+                detail=(
+                    "Assign at least one safety-capable user to support safety workflows "
+                    f"(current safety_capable_user_count={signals.safety_capable_user_count})."
+                ),
                 severity="critical",
                 blocking_step_key="users_roles",
             )

--- a/backend/app/onboarding/progress.py
+++ b/backend/app/onboarding/progress.py
@@ -14,6 +14,7 @@ class OnboardingSignals:
 
     org_settings_configured: bool = False
     org_admin_count: int = 0
+    safety_capable_user_count: int = 0
     active_user_count: int = 0
     successful_import_count: int = 0
     failed_import_count: int = 0
@@ -59,7 +60,7 @@ def derive_step_statuses(
         if signals.org_settings_configured
         else "not_started",
         "users_roles": "completed"
-        if signals.org_admin_count > 0 and signals.active_user_count > 0
+        if signals.org_admin_count > 0 and signals.safety_capable_user_count > 0
         else "in_progress"
         if signals.active_user_count > 0
         else "not_started",

--- a/backend/app/onboarding/service.py
+++ b/backend/app/onboarding/service.py
@@ -37,6 +37,7 @@ from app.onboarding.progress import (
     derive_step_statuses,
 )
 from app.onboarding.readiness import derive_readiness_status
+from app.security.permissions import Capability, has_capability
 
 
 def _organization_basics_complete(org: Org) -> bool:
@@ -80,6 +81,9 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
         user for user in user_rows if bool(getattr(user, "is_active", True))
     ]
     org_admin_count = sum(1 for user in active_users if str(user.role) == "org_admin")
+    safety_capable_user_count = sum(
+        1 for user in active_users if has_capability(user.role, Capability.INCIDENT_WRITE)
+    )
 
     import_operations = (
         db.query(IntegrationOperation)
@@ -177,6 +181,7 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
     return OnboardingSignals(
         org_settings_configured=org_settings_configured,
         org_admin_count=org_admin_count,
+        safety_capable_user_count=safety_capable_user_count,
         active_user_count=len(active_users),
         successful_import_count=successful_import_count,
         failed_import_count=failed_import_count,

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -401,6 +401,20 @@ class TestIntegrationDiagnosticsRoutes:
         assert org_settings_step["metadata"]["completion_source"] == "dashboard"
         assert org_settings_step["metadata"]["completed_by_user_id"]
 
+    def test_users_roles_step_gate_requires_org_admin_and_safety_capable(
+        self, client, auth_headers
+    ):
+        mark = client.post(
+            "/org/onboarding/mark-step",
+            headers=auth_headers,
+            json={"step_key": "users_roles", "completed": True, "source": "dashboard"},
+        )
+        assert mark.status_code == 409
+        detail = mark.json()["detail"]
+        assert detail["code"] == "users_roles_prerequisites_not_met"
+        assert "no org admin assigned" in detail["violations"]
+        assert "no safety manager assigned" not in detail["violations"]
+
     def test_org_settings_completion_rule_updates_onboarding_status(
         self, client, auth_headers
     ):
@@ -455,6 +469,75 @@ class TestIntegrationDiagnosticsRoutes:
         )
         assert detail_resp.status_code == 200
         assert detail_resp.json()["provider"] == "samsara"
+
+    def test_org_users_list_invite_patch_role_resend_deactivate(
+        self, client, db_session, test_org, test_user
+    ):
+        org_admin = User(
+            email="org-admin@example.com",
+            password_hash=hash_password("password123"),
+            role="org_admin",
+        )
+        db_session.add(org_admin)
+        db_session.commit()
+        db_session.refresh(org_admin)
+        db_session.add(UserOrg(user_id=org_admin.id, org_id=test_org.id))
+        db_session.commit()
+
+        admin_headers = {
+            "Authorization": f"Bearer {create_access_token({'sub': str(org_admin.id), 'role': 'org_admin'})}"
+        }
+
+        list_resp = client.get("/org/users", headers=admin_headers)
+        assert list_resp.status_code == 200
+        payload = list_resp.json()
+        assert len(payload["users"]) == 2
+        assert payload["role_counts"]["org_admin"] == 1
+        assert payload["role_counts"]["safety_manager"] == 1
+        assert payload["violations"] == []
+
+        invite_resp = client.post(
+            "/org/users/invite",
+            headers=admin_headers,
+            json={"email": "invitee@example.com", "role": "safety_manager"},
+        )
+        assert invite_resp.status_code == 201
+        invite_payload = invite_resp.json()
+        assert invite_payload["invite"]["status"] == "pending"
+        invite_id = invite_payload["invite"]["invite_id"]
+
+        resend_resp = client.post(
+            f"/org/users/invite/{invite_id}/resend",
+            headers=admin_headers,
+        )
+        assert resend_resp.status_code == 200
+        assert resend_resp.json()["invite"]["status"] == "pending"
+
+        deactivate_resp = client.post(
+            f"/org/users/invite/{invite_id}/deactivate",
+            headers=admin_headers,
+        )
+        assert deactivate_resp.status_code == 200
+        assert deactivate_resp.json()["invite"]["status"] == "deactivated"
+
+        patch_role = client.patch(
+            f"/org/users/{test_user.id}/role",
+            headers=admin_headers,
+            json={"role": "org_admin"},
+        )
+        assert patch_role.status_code == 200
+        updated_user = next(
+            item for item in patch_role.json()["users"] if item["user_id"] == str(test_user.id)
+        )
+        assert updated_user["role"] == "org_admin"
+
+    def test_org_user_admin_permissions_enforced(self, client, auth_headers):
+        invite_resp = client.post(
+            "/org/users/invite",
+            headers=auth_headers,
+            json={"email": "invitee@example.com", "role": "safety_manager"},
+        )
+        assert invite_resp.status_code == 403
 
     def test_integration_operations_and_evidence_summary(
         self, client, db_session, test_org, test_user, auth_headers

--- a/backend/tests/test_onboarding_service.py
+++ b/backend/tests/test_onboarding_service.py
@@ -15,6 +15,7 @@ def test_classify_blockers_severity_buckets():
         signals=OnboardingSignals(
             org_settings_configured=False,
             org_admin_count=0,
+            safety_capable_user_count=0,
             successful_import_count=0,
             mapping_count=0,
             active_integration_count=0,
@@ -35,6 +36,7 @@ def test_readiness_status_transitions_pilot_and_launch():
         signals=OnboardingSignals(
             org_settings_configured=True,
             org_admin_count=1,
+            safety_capable_user_count=1,
             active_user_count=2,
             successful_import_count=1,
             mapping_count=0,
@@ -56,6 +58,7 @@ def test_readiness_status_transitions_pilot_and_launch():
         signals=OnboardingSignals(
             org_settings_configured=True,
             org_admin_count=1,
+            safety_capable_user_count=1,
             active_user_count=2,
             successful_import_count=1,
             mapping_count=3,
@@ -83,6 +86,7 @@ def test_build_onboarding_readiness_uses_blocked_status_when_critical_exists():
         signals=OnboardingSignals(
             org_settings_configured=False,
             org_admin_count=0,
+            safety_capable_user_count=0,
             active_user_count=1,
             successful_import_count=0,
             mapping_count=0,


### PR DESCRIPTION
### Motivation
- Provide APIs to manage organization users and invites and ensure onboarding cannot mark the users/roles step complete until required role coverage exists. 
- Surface role counts and violations into onboarding readiness so UI/automation can show why the users/roles step is blocked.

### Description
- Added API contracts and handlers for org user management: `GET /org/users`, `POST /org/users/invite`, `PATCH /org/users/{user_id}/role`, `POST /org/users/invite/{invite_id}/resend`, and `POST /org/users/invite/{invite_id}/deactivate` and corresponding Pydantic schemas.
- Persisted invites via new `OrgUserInvite` model with `status`, `last_sent_at_utc`, and `deactivated_at_utc` fields.
- Implemented role counting and violation helpers (`_role_counts_for_org`, `_role_violations`) and wired `role_counts` + `violations` into responses for users and invite endpoints.
- Enforced readiness gate in onboarding: completing the `users_roles` step now requires at least one `org_admin` and at least one safety-capable user (determined by capability checks against `Capability.INCIDENT_WRITE`), returning a `409` with `role_counts` and `violations` if unmet.
- Updated onboarding signal collection and step derivation to track `safety_capable_user_count` and added explicit blockers `no_org_admin_assigned` and `no_safety_manager_assigned` with count-aware details.
- Permission checks for user/invite actions are enforced via existing role dependency (`system_admin`, `org_admin`).
- Tests updated/added to cover listing, invite create/resend/deactivate, patching roles, permission gating, and onboarding readiness behavior.

### Testing
- Ran linting: `ruff check app tests` (all checks passed).
- Ran targeted test suites: `pytest -q tests/test_onboarding_service.py tests/test_api_endpoints.py` with final result `75 passed, 3 warnings`.
- Also ran `ruff check` on modified files during development and fixed issues until clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de85b89fac8321b67a07c55a72fbfd)