### PR TITLE
Add async org vehicle CSV import jobs and status/results endpoint

### DIFF
--- a/backend/app/api/routes_integrations.py
+++ b/backend/app/api/routes_integrations.py
@@ -6,7 +6,7 @@ import uuid
 from dataclasses import asdict
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
 from sqlalchemy.orm import Session
 
 from app.api.schemas import (
@@ -28,6 +28,9 @@ from app.api.schemas import (
     OrgUserInviteSummary,
     OrgUserSummary,
     OrgUsersResponse,
+    VehicleImportJobCreateRequest,
+    VehicleImportJobCreateResponse,
+    VehicleImportJobResponse,
 )
 from app.core.config import settings
 from app.core.deps import get_current_user, require_user_role
@@ -40,6 +43,7 @@ from app.db.models import (
     Org,
     User,
     UserOrg,
+    VehicleImportJob,
 )
 from app.db.session import get_db
 from app.integrations.webhooks.handlers import (
@@ -54,6 +58,7 @@ from app.security.authn import build_user_auth_context
 from app.observability.redaction import redact_payload_for_storage
 from app.services.dashcam_capture_service import queue_dashcam_capture
 from app.services.telematics_capture_service import queue_telematics_capture
+from app.services.vehicle_import_service import create_vehicle_import_job, run_vehicle_import_job
 from app.onboarding.progress import STEP_DEFINITIONS
 from app.onboarding.service import (
     collect_onboarding_signals,
@@ -119,6 +124,45 @@ def _role_violations(*, role_counts: dict[str, int]) -> list[str]:
     if safety_capable_count < 1:
         violations.append("no safety manager assigned")
     return violations
+
+
+def _run_vehicle_import_background(
+    db: Session,
+    *,
+    job_id: uuid.UUID,
+    org_id: uuid.UUID,
+    csv_content: str,
+    header_mapping: dict[str, str],
+    inactive_unit_numbers: list[str],
+) -> None:
+    run_vehicle_import_job(
+        db,
+        job_id=job_id,
+        org_id=org_id,
+        csv_content=csv_content,
+        header_mapping=header_mapping,
+        inactive_unit_numbers={item.strip().lower() for item in inactive_unit_numbers if item.strip()},
+    )
+
+
+def _to_vehicle_import_job_response(job: VehicleImportJob) -> VehicleImportJobResponse:
+    return VehicleImportJobResponse(
+        job_id=job.job_id,
+        provider=job.provider,
+        status=job.status,
+        started_at_utc=job.started_at_utc,
+        completed_at_utc=job.completed_at_utc,
+        records_total=job.records_total,
+        records_processed=job.records_processed,
+        records_imported=job.records_imported,
+        records_updated=job.records_updated,
+        records_skipped=job.records_skipped,
+        records_errored=job.records_errored,
+        warnings=job.warnings_json or [],
+        outcomes=job.outcomes_json or {},
+        summary=job.summary_json or {},
+        error_message=job.error_message,
+    )
 
 
 @router.get("/org/settings", response_model=OrgSettingsResponse)
@@ -220,6 +264,52 @@ def mark_org_onboarding_step(
     )
     readiness = get_org_onboarding_readiness(db, org_id=org_id)
     return _to_readiness_response(readiness)
+
+
+@router.post(
+    "/org/vehicles/import",
+    response_model=VehicleImportJobCreateResponse,
+    status_code=202,
+)
+def create_org_vehicle_import_job(
+    payload: VehicleImportJobCreateRequest,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = _first_org_id(context)
+    job = create_vehicle_import_job(db, org_id=org_id, provider=payload.provider)
+    background_tasks.add_task(
+        _run_vehicle_import_background,
+        db,
+        job_id=job.job_id,
+        org_id=org_id,
+        csv_content=payload.csv_content,
+        header_mapping=payload.header_mapping,
+        inactive_unit_numbers=payload.inactive_unit_numbers,
+    )
+    return VehicleImportJobCreateResponse(job_id=job.job_id, status=job.status)
+
+
+@router.get(
+    "/org/vehicles/import-jobs/{job_id}",
+    response_model=VehicleImportJobResponse,
+)
+def get_org_vehicle_import_job(
+    job_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    row = (
+        db.query(VehicleImportJob)
+        .filter(VehicleImportJob.job_id == job_id, VehicleImportJob.org_id == _first_org_id(context))
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Import job not found")
+    return _to_vehicle_import_job_response(row)
 
 
 @router.get("/org/users", response_model=OrgUsersResponse)

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -1311,6 +1311,50 @@ class IntegrationOperationDiagnosticsResponse(BaseModel):
     updated_at_utc: datetime | None = None
 
 
+class VehicleImportJobCreateRequest(BaseModel):
+    provider: str = Field(min_length=1, max_length=128)
+    csv_content: str = Field(min_length=1)
+    header_mapping: dict[str, str] = Field(default_factory=dict)
+    inactive_unit_numbers: list[str] = Field(default_factory=list)
+
+
+class VehicleImportJobCreateResponse(BaseModel):
+    job_id: uuid.UUID
+    status: ImportJobStatus
+
+
+class VehicleImportJobSummary(BaseModel):
+    missing_qr_count: int = Field(default=0, ge=0)
+    missing_provider_mapping_count: int = Field(default=0, ge=0)
+    duplicate_like_count: int = Field(default=0, ge=0)
+    inactive_count: int = Field(default=0, ge=0)
+
+
+class VehicleImportJobOutcome(BaseModel):
+    imported: list[str] = Field(default_factory=list)
+    updated: list[str] = Field(default_factory=list)
+    skipped: list[str] = Field(default_factory=list)
+    errored: list[str] = Field(default_factory=list)
+
+
+class VehicleImportJobResponse(BaseModel):
+    job_id: uuid.UUID
+    provider: str
+    status: ImportJobStatus
+    started_at_utc: datetime | None = None
+    completed_at_utc: datetime | None = None
+    records_total: int = Field(default=0, ge=0)
+    records_processed: int = Field(default=0, ge=0)
+    records_imported: int = Field(default=0, ge=0)
+    records_updated: int = Field(default=0, ge=0)
+    records_skipped: int = Field(default=0, ge=0)
+    records_errored: int = Field(default=0, ge=0)
+    warnings: list[str] = Field(default_factory=list)
+    outcomes: VehicleImportJobOutcome = Field(default_factory=VehicleImportJobOutcome)
+    summary: VehicleImportJobSummary = Field(default_factory=VehicleImportJobSummary)
+    error_message: str | None = None
+
+
 class EvidenceRequestSummary(BaseModel):
     evidence_request_id: uuid.UUID
     operation_id: uuid.UUID | None = None

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1440,6 +1440,76 @@ class DriverVehicleAssignment(Base):
     )
 
 
+class OrgVehicleRegistry(Base):
+    """Organization vehicle records imported from provider feeds and CSV uploads."""
+
+    __tablename__ = "org_vehicle_registry"
+
+    vehicle_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    unit_number = Column(Text, nullable=False)
+    vin = Column(Text, nullable=True)
+    provider = Column(Text, nullable=True)
+    provider_vehicle_id = Column(Text, nullable=True)
+    is_active = Column(Boolean, nullable=False, default=True, server_default=text("true"))
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_org_vehicle_registry_org_unit", "org_id", "unit_number", unique=True),
+        Index("ix_org_vehicle_registry_org_provider_ext", "org_id", "provider", "provider_vehicle_id"),
+    )
+
+
+class VehicleImportJob(Base):
+    """Asynchronous vehicle import job state and review summary."""
+
+    __tablename__ = "vehicle_import_jobs"
+
+    job_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    provider = Column(Text, nullable=False)
+    status = Column(
+        Enum("pending", "running", "succeeded", "failed", name="vehicle_import_job_status"),
+        nullable=False,
+        default="pending",
+        server_default="pending",
+        index=True,
+    )
+    records_total = Column(Integer, nullable=False, default=0, server_default=text("0"))
+    records_processed = Column(Integer, nullable=False, default=0, server_default=text("0"))
+    records_imported = Column(Integer, nullable=False, default=0, server_default=text("0"))
+    records_updated = Column(Integer, nullable=False, default=0, server_default=text("0"))
+    records_skipped = Column(Integer, nullable=False, default=0, server_default=text("0"))
+    records_errored = Column(Integer, nullable=False, default=0, server_default=text("0"))
+    warnings_json = Column(JSONB, nullable=False, default=list, server_default=text("'[]'"))
+    outcomes_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    summary_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    error_message = Column(Text, nullable=True)
+    started_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    completed_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
 class VehicleQrToken(Base):
     """Vehicle QR tokens for driver app onboarding."""
 

--- a/backend/app/services/vehicle_import_service.py
+++ b/backend/app/services/vehicle_import_service.py
@@ -1,0 +1,251 @@
+"""Vehicle CSV import job services."""
+
+from __future__ import annotations
+
+import csv
+import io
+import uuid
+from collections import defaultdict
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.db.models import ExternalMapping, OrgVehicleRegistry, VehicleImportJob, VehicleQrToken
+
+CANONICAL_HEADER_ALIASES = {
+    "unit_number": {"unitnumber", "unit_number", "unit", "trucknumber", "vehicleunit"},
+    "vin": {"vin", "vehiclevin"},
+    "provider_vehicle_id": {"providervehicleid", "externalid", "providerid"},
+    "is_active": {"isactive", "active", "status"},
+}
+
+
+def _normalize_header(name: str) -> str:
+    return "".join(ch for ch in name.strip().lower() if ch.isalnum() or ch == "_")
+
+
+def _build_header_map(fieldnames: list[str], explicit: dict[str, str]) -> tuple[dict[str, str], list[str]]:
+    warnings: list[str] = []
+    normalized_to_original = {_normalize_header(name): name for name in fieldnames}
+
+    resolved: dict[str, str] = {}
+    for canonical in CANONICAL_HEADER_ALIASES:
+        requested = explicit.get(canonical)
+        if requested:
+            key = _normalize_header(requested)
+            original = normalized_to_original.get(key)
+            if original is None:
+                warnings.append(
+                    f"Header mapping for '{canonical}' points to missing column '{requested}'."
+                )
+                continue
+            resolved[canonical] = original
+            continue
+
+        for alias in CANONICAL_HEADER_ALIASES[canonical]:
+            original = normalized_to_original.get(alias)
+            if original:
+                resolved[canonical] = original
+                break
+
+    if "unit_number" not in resolved:
+        warnings.append("Unable to resolve required unitNumber header mapping.")
+    return resolved, warnings
+
+
+def _row_is_active(raw: str | None) -> bool:
+    if raw is None:
+        return True
+    normalized = raw.strip().lower()
+    if not normalized:
+        return True
+    if normalized in {"inactive", "disabled", "false", "0", "no"}:
+        return False
+    return True
+
+
+def create_vehicle_import_job(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    provider: str,
+) -> VehicleImportJob:
+    now = datetime.now(timezone.utc)
+    job = VehicleImportJob(
+        org_id=org_id,
+        provider=provider.strip(),
+        status="pending",
+        started_at_utc=now,
+        warnings_json=[],
+        outcomes_json={"imported": [], "updated": [], "skipped": [], "errored": []},
+        summary_json={
+            "missing_qr_count": 0,
+            "missing_provider_mapping_count": 0,
+            "duplicate_like_count": 0,
+            "inactive_count": 0,
+        },
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+    return job
+
+
+def run_vehicle_import_job(
+    db: Session,
+    *,
+    job_id: uuid.UUID,
+    org_id: uuid.UUID,
+    csv_content: str,
+    header_mapping: dict[str, str],
+    inactive_unit_numbers: set[str],
+) -> VehicleImportJob:
+    job = db.query(VehicleImportJob).filter(VehicleImportJob.job_id == job_id, VehicleImportJob.org_id == org_id).first()
+    if job is None:
+        raise ValueError("job_not_found")
+
+    job.status = "running"
+    db.add(job)
+    db.commit()
+
+    try:
+        reader = csv.DictReader(io.StringIO(csv_content))
+        if reader.fieldnames is None:
+            raise ValueError("CSV missing headers")
+
+        resolved_headers, mapping_warnings = _build_header_map(reader.fieldnames, header_mapping)
+        warnings = list(mapping_warnings)
+
+        outcomes = {"imported": [], "updated": [], "skipped": [], "errored": []}
+        summary = {
+            "missing_qr_count": 0,
+            "missing_provider_mapping_count": 0,
+            "duplicate_like_count": 0,
+            "inactive_count": 0,
+        }
+
+        existing_by_unit = {
+            row.unit_number.lower(): row
+            for row in db.query(OrgVehicleRegistry).filter(OrgVehicleRegistry.org_id == org_id).all()
+        }
+        unit_to_qr = {
+            row.adc_vehicle_id.lower()
+            for row in db.query(VehicleQrToken)
+            .filter(VehicleQrToken.org_id == org_id, VehicleQrToken.status == "active")
+            .all()
+        }
+        provider_mapped_units = {
+            row.internal_entity_id.lower()
+            for row in db.query(ExternalMapping)
+            .filter(
+                ExternalMapping.org_id == org_id,
+                ExternalMapping.internal_entity_type == "vehicle",
+                ExternalMapping.status == "active",
+            )
+            .all()
+        }
+
+        seen_units: set[str] = set()
+        vin_to_units: defaultdict[str, set[str]] = defaultdict(set)
+        staged_rows: list[dict[str, str | bool | None]] = []
+
+        for line_no, row in enumerate(reader, start=2):
+            unit_col = resolved_headers.get("unit_number")
+            vin_col = resolved_headers.get("vin")
+            provider_vehicle_col = resolved_headers.get("provider_vehicle_id")
+            active_col = resolved_headers.get("is_active")
+
+            raw_unit = (row.get(unit_col, "") if unit_col else "") or ""
+            unit_number = raw_unit.strip()
+            vin = ((row.get(vin_col, "") if vin_col else "") or "").strip() or None
+            provider_vehicle_id = (
+                ((row.get(provider_vehicle_col, "") if provider_vehicle_col else "") or "").strip()
+                or None
+            )
+            row_active = _row_is_active(row.get(active_col) if active_col else None)
+            if unit_number.lower() in inactive_unit_numbers:
+                row_active = False
+
+            if not unit_number:
+                outcomes["errored"].append(f"line {line_no}: unitNumber is required")
+                continue
+
+            lowered_unit = unit_number.lower()
+            if lowered_unit in seen_units:
+                outcomes["errored"].append(f"line {line_no}: duplicate unitNumber '{unit_number}' in CSV")
+                continue
+            seen_units.add(lowered_unit)
+
+            if vin:
+                vin_to_units[vin].add(lowered_unit)
+
+            staged_rows.append(
+                {
+                    "line_no": str(line_no),
+                    "unit_number": unit_number,
+                    "vin": vin,
+                    "provider_vehicle_id": provider_vehicle_id,
+                    "is_active": row_active,
+                }
+            )
+
+        for vin, units in vin_to_units.items():
+            if len(units) > 1:
+                warnings.append(f"VIN '{vin}' appears on multiple unitNumber values.")
+                summary["duplicate_like_count"] += len(units)
+
+        for staged in staged_rows:
+            unit_number = str(staged["unit_number"])
+            lowered_unit = unit_number.lower()
+            existing = existing_by_unit.get(lowered_unit)
+            if existing is None:
+                existing = OrgVehicleRegistry(
+                    org_id=org_id,
+                    unit_number=unit_number,
+                    vin=staged["vin"],
+                    provider=job.provider,
+                    provider_vehicle_id=staged["provider_vehicle_id"],
+                    is_active=bool(staged["is_active"]),
+                )
+                db.add(existing)
+                outcomes["imported"].append(unit_number)
+                existing_by_unit[lowered_unit] = existing
+            else:
+                existing.vin = staged["vin"]
+                existing.provider = job.provider
+                existing.provider_vehicle_id = staged["provider_vehicle_id"]
+                existing.is_active = bool(staged["is_active"])
+                outcomes["updated"].append(unit_number)
+
+            if not bool(staged["is_active"]):
+                summary["inactive_count"] += 1
+                outcomes["skipped"].append(f"{unit_number}: inactive")
+
+            if lowered_unit not in unit_to_qr:
+                summary["missing_qr_count"] += 1
+            if lowered_unit not in provider_mapped_units:
+                summary["missing_provider_mapping_count"] += 1
+
+        job.records_total = len(staged_rows)
+        job.records_processed = len(staged_rows)
+        job.records_imported = len(outcomes["imported"])
+        job.records_updated = len(outcomes["updated"])
+        job.records_skipped = len(outcomes["skipped"])
+        job.records_errored = len(outcomes["errored"])
+        job.warnings_json = warnings
+        job.outcomes_json = outcomes
+        job.summary_json = summary
+        job.status = "succeeded" if not outcomes["errored"] else "failed"
+        job.completed_at_utc = datetime.now(timezone.utc)
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+        return job
+    except Exception as exc:
+        job.status = "failed"
+        job.error_message = str(exc)
+        job.completed_at_utc = datetime.now(timezone.utc)
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+        return job

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -23,6 +23,9 @@ from app.db.models import (
     IntegrationConnection,
     IntegrationOperation,
     EvidenceRequest,
+    ExternalMapping,
+    VehicleQrToken,
+    OrgVehicleRegistry,
 )
 from app.db.session import get_db
 from app.core.security import hash_password, create_access_token
@@ -2067,6 +2070,80 @@ class TestListExports:
         assert data[0]["incident_id"] == str(visible_incident.incident_id)
         assert data[0]["status"] == "processing"
         assert "created_at_utc" in data[0]
+
+
+class TestVehicleImportJobs:
+    def test_create_vehicle_import_job_and_read_results(
+        self, client, db_session, test_org, auth_headers
+    ):
+        db_session.add(
+            VehicleQrToken(
+                qr_token="qr-token-1",
+                org_id=test_org.id,
+                adc_vehicle_id="UNIT-001",
+                status="active",
+            )
+        )
+        db_session.add(
+            ExternalMapping(
+                org_id=test_org.id,
+                provider="samsara",
+                domain="fleet",
+                internal_entity_type="vehicle",
+                internal_entity_id="unit-001",
+                external_reference="provider-veh-1",
+                status="active",
+            )
+        )
+        db_session.commit()
+
+        csv_content = (
+            "unitNumber,vin,providerVehicleId,status\n"
+            "UNIT-001,1HGBH41JXMN109186,provider-veh-1,active\n"
+            "UNIT-002,1HGBH41JXMN109186,provider-veh-2,inactive\n"
+            "UNIT-002,2HGBH41JXMN109187,provider-veh-3,active\n"
+            ",2HGBH41JXMN109188,provider-veh-4,active\n"
+        )
+
+        create_resp = client.post(
+            "/org/vehicles/import",
+            headers=auth_headers,
+            json={
+                "provider": "samsara",
+                "csv_content": csv_content,
+                "header_mapping": {"unit_number": "unitNumber"},
+                "inactive_unit_numbers": ["UNIT-002"],
+            },
+        )
+        assert create_resp.status_code == 202
+        job_id = create_resp.json()["job_id"]
+
+        read_resp = client.get(f"/org/vehicles/import-jobs/{job_id}", headers=auth_headers)
+        assert read_resp.status_code == 200
+        payload = read_resp.json()
+        assert payload["status"] == "failed"
+        assert payload["records_total"] == 2
+        assert payload["records_processed"] == 2
+        assert payload["records_imported"] == 2
+        assert payload["records_updated"] == 0
+        assert payload["records_skipped"] == 1
+        assert payload["records_errored"] == 2
+        assert payload["summary"]["missing_qr_count"] == 1
+        assert payload["summary"]["missing_provider_mapping_count"] == 1
+        assert payload["summary"]["duplicate_like_count"] == 2
+        assert payload["summary"]["inactive_count"] == 1
+        assert any("VIN" in warning for warning in payload["warnings"])
+        assert any("duplicate unitNumber" in row for row in payload["outcomes"]["errored"])
+        assert any("unitNumber is required" in row for row in payload["outcomes"]["errored"])
+
+        vehicles = db_session.query(OrgVehicleRegistry).filter(OrgVehicleRegistry.org_id == test_org.id).all()
+        assert len(vehicles) == 2
+        unit_two = next(item for item in vehicles if item.unit_number == "UNIT-002")
+        assert unit_two.is_active is False
+
+    def test_get_vehicle_import_job_not_found(self, client, auth_headers):
+        resp = client.get(f"/org/vehicles/import-jobs/{uuid.uuid4()}", headers=auth_headers)
+        assert resp.status_code == 404
 
 
 # ── Health check ────────────────────────────────────────────────────

--- a/migrations/versions/20260414_0003_add_vehicle_import_jobs.py
+++ b/migrations/versions/20260414_0003_add_vehicle_import_jobs.py
@@ -1,0 +1,96 @@
+"""Add organization vehicle registry and async vehicle import jobs.
+
+Revision ID: 20260414_0003
+Revises: 20260411_0002
+Create Date: 2026-04-14
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "20260414_0003"
+down_revision = "20260411_0002"
+branch_labels = None
+depends_on = None
+
+
+vehicle_import_job_status = sa.Enum(
+    "pending",
+    "running",
+    "succeeded",
+    "failed",
+    name="vehicle_import_job_status",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    vehicle_import_job_status.create(bind, checkfirst=True)
+
+    op.create_table(
+        "org_vehicle_registry",
+        sa.Column("vehicle_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("unit_number", sa.Text(), nullable=False),
+        sa.Column("vin", sa.Text(), nullable=True),
+        sa.Column("provider", sa.Text(), nullable=True),
+        sa.Column("provider_vehicle_id", sa.Text(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("vehicle_id"),
+    )
+    op.create_index("ix_org_vehicle_registry_org_id", "org_vehicle_registry", ["org_id"])
+    op.create_index(
+        "ix_org_vehicle_registry_org_unit",
+        "org_vehicle_registry",
+        ["org_id", "unit_number"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_org_vehicle_registry_org_provider_ext",
+        "org_vehicle_registry",
+        ["org_id", "provider", "provider_vehicle_id"],
+    )
+
+    op.create_table(
+        "vehicle_import_jobs",
+        sa.Column("job_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("status", vehicle_import_job_status, nullable=False, server_default="pending"),
+        sa.Column("records_total", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("records_processed", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("records_imported", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("records_updated", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("records_skipped", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("records_errored", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("warnings_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'[]'")),
+        sa.Column("outcomes_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("summary_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("started_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("completed_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("created_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("job_id"),
+    )
+    op.create_index("ix_vehicle_import_jobs_org_id", "vehicle_import_jobs", ["org_id"])
+    op.create_index("ix_vehicle_import_jobs_status", "vehicle_import_jobs", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_vehicle_import_jobs_status", table_name="vehicle_import_jobs")
+    op.drop_index("ix_vehicle_import_jobs_org_id", table_name="vehicle_import_jobs")
+    op.drop_table("vehicle_import_jobs")
+
+    op.drop_index("ix_org_vehicle_registry_org_provider_ext", table_name="org_vehicle_registry")
+    op.drop_index("ix_org_vehicle_registry_org_unit", table_name="org_vehicle_registry")
+    op.drop_index("ix_org_vehicle_registry_org_id", table_name="org_vehicle_registry")
+    op.drop_table("org_vehicle_registry")
+
+    vehicle_import_job_status.drop(op.get_bind(), checkfirst=True)


### PR DESCRIPTION
### Motivation
- Provide an async import flow for org vehicle CSV uploads so large imports run in background and UI can poll for progress and results. 
- Surface row-level validation, mapping warnings, and review-summary metrics required by import review panels (missing QR, missing provider mapping, duplicate-like records, inactive counts). 
- Persist import job counters and categorized outcomes to enable robust retries, audits, and UI inspection.

### Description
- Add two API routes: `POST /org/vehicles/import` to create a persisted `VehicleImportJob` and schedule background processing, and `GET /org/vehicles/import-jobs/{job_id}` to return job status, counters, categorized outcomes, warnings, and a review `summary` (see `backend/app/api/routes_integrations.py`).
- Implement `vehicle_import_service` with CSV header mapping resolution, mapping warnings, and row validation rules: `unitNumber` is required, duplicate `unitNumber` rows in the CSV are errored, VINs appearing on multiple unitNumbers emit warnings and increment `duplicate_like_count`, explicit `inactive_unit_numbers` and CSV active/status columns drive inactive handling; missing QR and missing provider mapping counts are computed (see `backend/app/services/vehicle_import_service.py`).
- Persist two new models: `OrgVehicleRegistry` (stores imported vehicle rows) and `VehicleImportJob` (job state, counters, `warnings_json`, `outcomes_json`, and `summary_json`) in `backend/app/db/models.py`, plus an Alembic migration to create tables and the `vehicle_import_job_status` enum (`migrations/versions/20260414_0003_add_vehicle_import_jobs.py`).
- Extend API contracts with request/response models for create/get flows and structured `outcomes`/`summary` fields used by the frontend review UI (`backend/app/api/schemas.py`).
- Wire background execution via FastAPI `BackgroundTasks` to call the import runner and return an accepted response with `job_id` immediately, and include tests that exercise job creation, result reading, validations, warnings, summary values, persistence outcomes, and 404 behavior (`backend/tests/test_api_endpoints.py`).

### Testing
- Ran linter via `make lint` which executed `ruff check` and completed with no failures. 
- Ran the API endpoint tests with `cd backend && pytest tests/test_api_endpoints.py -q` and observed `74 passed, 3 warnings` (all new import tests included and green).
- Included an Alembic migration file to be applied in DB migrations (`migrations/versions/20260414_0003_add_vehicle_import_jobs.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9e0c151883219d58d63f860bda6e)