### PR TITLE
Add async org driver CSV import jobs with categorized outcomes and onboarding signal

### DIFF
--- a/backend/app/api/routes_integrations.py
+++ b/backend/app/api/routes_integrations.py
@@ -6,10 +6,20 @@ import uuid
 from dataclasses import asdict
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Request,
+    Response,
+)
 from sqlalchemy.orm import Session
 
 from app.api.schemas import (
+    DriverImportJobCreateRequest,
+    DriverImportJobCreateResponse,
+    DriverImportJobResponse,
     EvidenceRequestSummary,
     EvidenceRetryActionRequest,
     EvidenceRetryActionResponse,
@@ -43,6 +53,7 @@ from app.db.models import (
     Org,
     User,
     UserOrg,
+    DriverImportJob,
     VehicleImportJob,
 )
 from app.db.session import get_db
@@ -58,14 +69,27 @@ from app.security.authn import build_user_auth_context
 from app.observability.redaction import redact_payload_for_storage
 from app.services.dashcam_capture_service import queue_dashcam_capture
 from app.services.telematics_capture_service import queue_telematics_capture
-from app.services.vehicle_import_service import create_vehicle_import_job, run_vehicle_import_job
+from app.services.phone_normalize import normalize_phone
+from app.services.vehicle_import_service import (
+    create_vehicle_import_job,
+    run_vehicle_import_job,
+)
+from app.services.driver_import_service import (
+    create_driver_import_job,
+    run_driver_import_job,
+)
 from app.onboarding.progress import STEP_DEFINITIONS
 from app.onboarding.service import (
     collect_onboarding_signals,
     get_org_onboarding_readiness,
     set_step_completion_override,
 )
-from app.security.permissions import CANONICAL_ROLES, Capability, has_capability, normalize_role
+from app.security.permissions import (
+    CANONICAL_ROLES,
+    Capability,
+    has_capability,
+    normalize_role,
+)
 
 router = APIRouter()
 
@@ -86,7 +110,9 @@ def _to_readiness_response(readiness) -> OrgLaunchReadinessResponse:
             "steps": [asdict(item) for item in readiness.steps],
             "blockers": [asdict(item) for item in readiness.blockers],
             "import_jobs": [asdict(item) for item in readiness.import_jobs],
-            "integration_validations": [asdict(item) for item in readiness.integration_validations],
+            "integration_validations": [
+                asdict(item) for item in readiness.integration_validations
+            ],
             "vehicle_qr_deployment": asdict(readiness.vehicle_qr_deployment)
             if readiness.vehicle_qr_deployment is not None
             else None,
@@ -141,12 +167,61 @@ def _run_vehicle_import_background(
         org_id=org_id,
         csv_content=csv_content,
         header_mapping=header_mapping,
-        inactive_unit_numbers={item.strip().lower() for item in inactive_unit_numbers if item.strip()},
+        inactive_unit_numbers={
+            item.strip().lower() for item in inactive_unit_numbers if item.strip()
+        },
     )
 
 
 def _to_vehicle_import_job_response(job: VehicleImportJob) -> VehicleImportJobResponse:
     return VehicleImportJobResponse(
+        job_id=job.job_id,
+        provider=job.provider,
+        status=job.status,
+        started_at_utc=job.started_at_utc,
+        completed_at_utc=job.completed_at_utc,
+        records_total=job.records_total,
+        records_processed=job.records_processed,
+        records_imported=job.records_imported,
+        records_updated=job.records_updated,
+        records_skipped=job.records_skipped,
+        records_errored=job.records_errored,
+        warnings=job.warnings_json or [],
+        outcomes=job.outcomes_json or {},
+        summary=job.summary_json or {},
+        error_message=job.error_message,
+    )
+
+
+def _run_driver_import_background(
+    db: Session,
+    *,
+    job_id: uuid.UUID,
+    org_id: uuid.UUID,
+    csv_content: str,
+    header_mapping: dict[str, str],
+    inactive_mobile_phones: list[str],
+) -> None:
+    inactive_phones: set[str] = set()
+    for raw in inactive_mobile_phones:
+        if not raw or not raw.strip():
+            continue
+        try:
+            inactive_phones.add(normalize_phone(raw))
+        except ValueError:
+            continue
+    run_driver_import_job(
+        db,
+        job_id=job_id,
+        org_id=org_id,
+        csv_content=csv_content,
+        header_mapping=header_mapping,
+        inactive_phones=inactive_phones,
+    )
+
+
+def _to_driver_import_job_response(job: DriverImportJob) -> DriverImportJobResponse:
+    return DriverImportJobResponse(
         job_id=job.job_id,
         provider=job.provider,
         status=job.status,
@@ -251,7 +326,9 @@ def mark_org_onboarding_step(
                     "code": "users_roles_prerequisites_not_met",
                     "message": "Cannot complete users_roles step until role requirements are satisfied.",
                     "role_counts": _role_counts_for_org(db, org_id=org_id),
-                    "violations": _role_violations(role_counts=_role_counts_for_org(db, org_id=org_id)),
+                    "violations": _role_violations(
+                        role_counts=_role_counts_for_org(db, org_id=org_id)
+                    ),
                 },
             )
     set_step_completion_override(
@@ -304,12 +381,64 @@ def get_org_vehicle_import_job(
     context = build_user_auth_context(db, current_user)
     row = (
         db.query(VehicleImportJob)
-        .filter(VehicleImportJob.job_id == job_id, VehicleImportJob.org_id == _first_org_id(context))
+        .filter(
+            VehicleImportJob.job_id == job_id,
+            VehicleImportJob.org_id == _first_org_id(context),
+        )
         .first()
     )
     if row is None:
         raise HTTPException(status_code=404, detail="Import job not found")
     return _to_vehicle_import_job_response(row)
+
+
+@router.post(
+    "/org/drivers/import",
+    response_model=DriverImportJobCreateResponse,
+    status_code=202,
+)
+def create_org_driver_import_job(
+    payload: DriverImportJobCreateRequest,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = _first_org_id(context)
+    job = create_driver_import_job(db, org_id=org_id, provider=payload.provider)
+    background_tasks.add_task(
+        _run_driver_import_background,
+        db,
+        job_id=job.job_id,
+        org_id=org_id,
+        csv_content=payload.csv_content,
+        header_mapping=payload.header_mapping,
+        inactive_mobile_phones=payload.inactive_mobile_phones,
+    )
+    return DriverImportJobCreateResponse(job_id=job.job_id, status=job.status)
+
+
+@router.get(
+    "/org/drivers/import-jobs/{job_id}",
+    response_model=DriverImportJobResponse,
+)
+def get_org_driver_import_job(
+    job_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    row = (
+        db.query(DriverImportJob)
+        .filter(
+            DriverImportJob.job_id == job_id,
+            DriverImportJob.org_id == _first_org_id(context),
+        )
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Import job not found")
+    return _to_driver_import_job_response(row)
 
 
 @router.get("/org/users", response_model=OrgUsersResponse)
@@ -418,7 +547,9 @@ def patch_org_user_role(
     return list_org_users(db=db, current_user=current_user)
 
 
-@router.post("/org/users/invite/{invite_id}/resend", response_model=OrgInviteUserResponse)
+@router.post(
+    "/org/users/invite/{invite_id}/resend", response_model=OrgInviteUserResponse
+)
 def resend_org_user_invite(
     invite_id: uuid.UUID,
     db: Session = Depends(get_db),
@@ -455,7 +586,9 @@ def resend_org_user_invite(
     )
 
 
-@router.post("/org/users/invite/{invite_id}/deactivate", response_model=OrgInviteUserResponse)
+@router.post(
+    "/org/users/invite/{invite_id}/deactivate", response_model=OrgInviteUserResponse
+)
 def deactivate_org_user_invite(
     invite_id: uuid.UUID,
     db: Session = Depends(get_db),
@@ -491,7 +624,9 @@ def deactivate_org_user_invite(
     )
 
 
-@router.get("/org/integrations", response_model=list[IntegrationConnectionHealthResponse])
+@router.get(
+    "/org/integrations", response_model=list[IntegrationConnectionHealthResponse]
+)
 def list_org_integrations(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
@@ -510,7 +645,9 @@ def list_org_integrations(
             domain=row.domain,
             status=row.status,
             healthy=row.status in {"active", "pending"},
-            reason=None if row.status in {"active", "pending"} else "Connection not healthy",
+            reason=None
+            if row.status in {"active", "pending"}
+            else "Connection not healthy",
             last_synced_at_utc=row.last_synced_at_utc,
             updated_at_utc=row.updated_at_utc,
         )
@@ -518,7 +655,10 @@ def list_org_integrations(
     ]
 
 
-@router.get("/org/integrations/{integration_id}", response_model=IntegrationConnectionHealthResponse)
+@router.get(
+    "/org/integrations/{integration_id}",
+    response_model=IntegrationConnectionHealthResponse,
+)
 def get_org_integration(
     integration_id: uuid.UUID,
     db: Session = Depends(get_db),
@@ -541,7 +681,9 @@ def get_org_integration(
         domain=row.domain,
         status=row.status,
         healthy=row.status in {"active", "pending"},
-        reason=None if row.status in {"active", "pending"} else "Connection not healthy",
+        reason=None
+        if row.status in {"active", "pending"}
+        else "Connection not healthy",
         last_synced_at_utc=row.last_synced_at_utc,
         updated_at_utc=row.updated_at_utc,
     )
@@ -573,11 +715,16 @@ def validate_org_integration(
         integration_id=row.connection_id,
         valid=valid,
         status=row.status,
-        message="Connection validated" if valid else "Connection missing credentials or disabled",
+        message="Connection validated"
+        if valid
+        else "Connection missing credentials or disabled",
     )
 
 
-@router.patch("/org/integrations/{integration_id}", response_model=IntegrationConnectionHealthResponse)
+@router.patch(
+    "/org/integrations/{integration_id}",
+    response_model=IntegrationConnectionHealthResponse,
+)
 def patch_org_integration(
     integration_id: uuid.UUID,
     payload: IntegrationConnectionUpdateRequest,
@@ -610,13 +757,18 @@ def patch_org_integration(
         domain=row.domain,
         status=row.status,
         healthy=row.status in {"active", "pending"},
-        reason=None if row.status in {"active", "pending"} else "Connection not healthy",
+        reason=None
+        if row.status in {"active", "pending"}
+        else "Connection not healthy",
         last_synced_at_utc=row.last_synced_at_utc,
         updated_at_utc=row.updated_at_utc,
     )
 
 
-@router.post("/org/integrations/{integration_id}/disable", response_model=IntegrationConnectionHealthResponse)
+@router.post(
+    "/org/integrations/{integration_id}/disable",
+    response_model=IntegrationConnectionHealthResponse,
+)
 def disable_org_integration(
     integration_id: uuid.UUID,
     db: Session = Depends(get_db),
@@ -651,7 +803,10 @@ def disable_org_integration(
     )
 
 
-@router.get("/integration-operations", response_model=list[IntegrationOperationDiagnosticsResponse])
+@router.get(
+    "/integration-operations",
+    response_model=list[IntegrationOperationDiagnosticsResponse],
+)
 def list_integration_operations(
     incident_id: uuid.UUID | None = None,
     status: str | None = None,
@@ -660,7 +815,9 @@ def list_integration_operations(
     current_user: User = Depends(_integration_admin),
 ):
     context = build_user_auth_context(db, current_user)
-    query = db.query(IntegrationOperation).filter(IntegrationOperation.org_id.in_(context.org_ids))
+    query = db.query(IntegrationOperation).filter(
+        IntegrationOperation.org_id.in_(context.org_ids)
+    )
     if incident_id is not None:
         query = query.filter(IntegrationOperation.incident_id == incident_id)
     if status is not None:
@@ -694,8 +851,12 @@ def get_integration_operation(
     return _to_diagnostics_response(row)
 
 
-def _to_diagnostics_response(row: IntegrationOperation) -> IntegrationOperationDiagnosticsResponse:
-    response = IntegrationOperationDiagnosticsResponse.model_validate(row, from_attributes=True)
+def _to_diagnostics_response(
+    row: IntegrationOperation,
+) -> IntegrationOperationDiagnosticsResponse:
+    response = IntegrationOperationDiagnosticsResponse.model_validate(
+        row, from_attributes=True
+    )
     response.payload_json = redact_payload_for_storage(response.payload_json)
     response.result_json = redact_payload_for_storage(response.result_json)
     return response
@@ -720,7 +881,9 @@ def list_incident_evidence_requests(
         .order_by(EvidenceRequest.requested_at_utc.desc())
         .all()
     )
-    return [EvidenceRequestSummary.model_validate(row, from_attributes=True) for row in rows]
+    return [
+        EvidenceRequestSummary.model_validate(row, from_attributes=True) for row in rows
+    ]
 
 
 @router.post(
@@ -739,22 +902,30 @@ def retry_incident_evidence_requests(
         EvidenceRequest.org_id.in_(context.org_ids),
     )
     if payload.evidence_request_ids:
-        query = query.filter(EvidenceRequest.evidence_request_id.in_(payload.evidence_request_ids))
+        query = query.filter(
+            EvidenceRequest.evidence_request_id.in_(payload.evidence_request_ids)
+        )
     if payload.retry_failed_only:
         query = query.filter(EvidenceRequest.status == "failed")
 
     rows = query.order_by(EvidenceRequest.requested_at_utc.desc()).all()
     if not rows:
-        return EvidenceRetryActionResponse(incident_id=incident_id, retried_count=0, queued_operation_ids=[])
+        return EvidenceRetryActionResponse(
+            incident_id=incident_id, retried_count=0, queued_operation_ids=[]
+        )
 
     correlation_id = get_request_id() or str(uuid.uuid4())
     operation_ids: list[uuid.UUID] = []
 
     dashcam_ids = [row.evidence_request_id for row in rows if row.domain == "dashcam"]
-    telematics_ids = [row.evidence_request_id for row in rows if row.domain == "telematics"]
+    telematics_ids = [
+        row.evidence_request_id for row in rows if row.domain == "telematics"
+    ]
     org_id = rows[0].org_id
     if org_id is None:
-        raise HTTPException(status_code=422, detail="Evidence requests are missing org_id")
+        raise HTTPException(
+            status_code=422, detail="Evidence requests are missing org_id"
+        )
 
     if dashcam_ids:
         operation_ids.append(
@@ -788,7 +959,9 @@ def retry_incident_evidence_requests(
     )
 
 
-@router.get("/incidents/{incident_id}/evidence-summary", response_model=EvidenceSummaryResponse)
+@router.get(
+    "/incidents/{incident_id}/evidence-summary", response_model=EvidenceSummaryResponse
+)
 def get_incident_evidence_summary(
     incident_id: uuid.UUID,
     db: Session = Depends(get_db),
@@ -820,12 +993,17 @@ def get_incident_evidence_summary(
         status_counts=status_counts,
         provider_counts=provider_counts,
         retryable_failures=retryable_failures,
-        requests=[EvidenceRequestSummary.model_validate(row, from_attributes=True) for row in rows],
+        requests=[
+            EvidenceRequestSummary.model_validate(row, from_attributes=True)
+            for row in rows
+        ],
     )
 
 
 @router.post("/provider-webhooks/twilio/voice")
-async def provider_twilio_voice_webhook(request: Request, db: Session = Depends(get_db)):
+async def provider_twilio_voice_webhook(
+    request: Request, db: Session = Depends(get_db)
+):
     raw_body = await request.body()
     params = parse_form_encoded_body(raw_body)
     signature_valid, signature_error = validate_twilio_signature(
@@ -841,11 +1019,15 @@ async def provider_twilio_voice_webhook(request: Request, db: Session = Depends(
         signature_valid=signature_valid,
         signature_error=signature_error,
     )
-    return Response(status_code=result.status_code, content=result.body.get("detail", "ok"))
+    return Response(
+        status_code=result.status_code, content=result.body.get("detail", "ok")
+    )
 
 
 @router.post("/provider-webhooks/twilio/status")
-async def provider_twilio_status_webhook(request: Request, db: Session = Depends(get_db)):
+async def provider_twilio_status_webhook(
+    request: Request, db: Session = Depends(get_db)
+):
     raw_body = await request.body()
     params = parse_form_encoded_body(raw_body)
     signature_valid, signature_error = validate_twilio_signature(

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -1355,6 +1355,56 @@ class VehicleImportJobResponse(BaseModel):
     error_message: str | None = None
 
 
+class DriverImportJobCreateRequest(BaseModel):
+    provider: str = Field(min_length=1, max_length=128)
+    csv_content: str = Field(min_length=1)
+    header_mapping: dict[str, str] = Field(default_factory=dict)
+    inactive_mobile_phones: list[str] = Field(default_factory=list)
+
+
+class DriverImportJobCreateResponse(BaseModel):
+    job_id: uuid.UUID
+    status: ImportJobStatus
+
+
+class DriverImportJobSummary(BaseModel):
+    invalid_phone_count: int = Field(default=0, ge=0)
+    duplicate_warning_count: int = Field(default=0, ge=0)
+    missing_assignment_count: int = Field(default=0, ge=0)
+    missing_external_mapping_count: int = Field(default=0, ge=0)
+    needs_review_count: int = Field(default=0, ge=0)
+    inactive_count: int = Field(default=0, ge=0)
+
+
+class DriverImportJobOutcome(BaseModel):
+    imported: list[str] = Field(default_factory=list)
+    updated: list[str] = Field(default_factory=list)
+    skipped: list[str] = Field(default_factory=list)
+    errored: list[str] = Field(default_factory=list)
+    invalid_phone: list[str] = Field(default_factory=list)
+    duplicate_warning: list[str] = Field(default_factory=list)
+    missing_assignment_or_mapping: list[str] = Field(default_factory=list)
+    needs_review: list[str] = Field(default_factory=list)
+
+
+class DriverImportJobResponse(BaseModel):
+    job_id: uuid.UUID
+    provider: str
+    status: ImportJobStatus
+    started_at_utc: datetime | None = None
+    completed_at_utc: datetime | None = None
+    records_total: int = Field(default=0, ge=0)
+    records_processed: int = Field(default=0, ge=0)
+    records_imported: int = Field(default=0, ge=0)
+    records_updated: int = Field(default=0, ge=0)
+    records_skipped: int = Field(default=0, ge=0)
+    records_errored: int = Field(default=0, ge=0)
+    warnings: list[str] = Field(default_factory=list)
+    outcomes: DriverImportJobOutcome = Field(default_factory=DriverImportJobOutcome)
+    summary: DriverImportJobSummary = Field(default_factory=DriverImportJobSummary)
+    error_message: str | None = None
+
+
 class EvidenceRequestSummary(BaseModel):
     evidence_request_id: uuid.UUID
     operation_id: uuid.UUID | None = None

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -95,11 +95,15 @@ class OrgUserInvite(Base):
     __tablename__ = "org_user_invites"
 
     invite_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    org_id = Column(UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
     email = Column(Text, nullable=False, index=True)
     role = Column(Text, nullable=False, default=Role.SAFETY_MANAGER.value)
     status = Column(Text, nullable=False, default="pending", index=True)
-    invited_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    invited_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
     created_at_utc = Column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
     )
@@ -1363,7 +1367,9 @@ class OrgOnboardingStepCompletion(Base):
     is_completed = Column(
         Boolean, nullable=False, default=False, server_default=text("false")
     )
-    completed_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    completed_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
     completed_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
     completion_source = Column(Text, nullable=True)
     updated_at_utc = Column(
@@ -1371,7 +1377,12 @@ class OrgOnboardingStepCompletion(Base):
     )
 
     __table_args__ = (
-        Index("ix_org_onboarding_step_completion_org_step", "org_id", "step_key", unique=True),
+        Index(
+            "ix_org_onboarding_step_completion_org_step",
+            "org_id",
+            "step_key",
+            unique=True,
+        ),
     )
 
 
@@ -1453,7 +1464,9 @@ class OrgVehicleRegistry(Base):
     vin = Column(Text, nullable=True)
     provider = Column(Text, nullable=True)
     provider_vehicle_id = Column(Text, nullable=True)
-    is_active = Column(Boolean, nullable=False, default=True, server_default=text("true"))
+    is_active = Column(
+        Boolean, nullable=False, default=True, server_default=text("true")
+    )
     created_at_utc = Column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
     )
@@ -1466,7 +1479,12 @@ class OrgVehicleRegistry(Base):
 
     __table_args__ = (
         Index("ix_org_vehicle_registry_org_unit", "org_id", "unit_number", unique=True),
-        Index("ix_org_vehicle_registry_org_provider_ext", "org_id", "provider", "provider_vehicle_id"),
+        Index(
+            "ix_org_vehicle_registry_org_provider_ext",
+            "org_id",
+            "provider",
+            "provider_vehicle_id",
+        ),
     )
 
 
@@ -1481,21 +1499,101 @@ class VehicleImportJob(Base):
     )
     provider = Column(Text, nullable=False)
     status = Column(
-        Enum("pending", "running", "succeeded", "failed", name="vehicle_import_job_status"),
+        Enum(
+            "pending",
+            "running",
+            "succeeded",
+            "failed",
+            name="vehicle_import_job_status",
+        ),
         nullable=False,
         default="pending",
         server_default="pending",
         index=True,
     )
     records_total = Column(Integer, nullable=False, default=0, server_default=text("0"))
-    records_processed = Column(Integer, nullable=False, default=0, server_default=text("0"))
-    records_imported = Column(Integer, nullable=False, default=0, server_default=text("0"))
-    records_updated = Column(Integer, nullable=False, default=0, server_default=text("0"))
-    records_skipped = Column(Integer, nullable=False, default=0, server_default=text("0"))
-    records_errored = Column(Integer, nullable=False, default=0, server_default=text("0"))
-    warnings_json = Column(JSONB, nullable=False, default=list, server_default=text("'[]'"))
-    outcomes_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
-    summary_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    records_processed = Column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    records_imported = Column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    records_updated = Column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    records_skipped = Column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    records_errored = Column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    warnings_json = Column(
+        JSONB, nullable=False, default=list, server_default=text("'[]'")
+    )
+    outcomes_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    summary_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    error_message = Column(Text, nullable=True)
+    started_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    completed_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class DriverImportJob(Base):
+    """Asynchronous driver import job state and review summary."""
+
+    __tablename__ = "driver_import_jobs"
+
+    job_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    provider = Column(Text, nullable=False)
+    status = Column(
+        Enum(
+            "pending", "running", "succeeded", "failed", name="driver_import_job_status"
+        ),
+        nullable=False,
+        default="pending",
+        server_default="pending",
+        index=True,
+    )
+    records_total = Column(Integer, nullable=False, default=0, server_default=text("0"))
+    records_processed = Column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    records_imported = Column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    records_updated = Column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    records_skipped = Column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    records_errored = Column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    warnings_json = Column(
+        JSONB, nullable=False, default=list, server_default=text("'[]'")
+    )
+    outcomes_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    summary_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
     error_message = Column(Text, nullable=True)
     started_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
     completed_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)

--- a/backend/app/onboarding/progress.py
+++ b/backend/app/onboarding/progress.py
@@ -18,6 +18,8 @@ class OnboardingSignals:
     active_user_count: int = 0
     successful_import_count: int = 0
     failed_import_count: int = 0
+    successful_driver_import_count: int = 0
+    failed_driver_import_count: int = 0
     mapping_count: int = 0
     active_integration_count: int = 0
     total_integration_count: int = 0
@@ -42,6 +44,7 @@ STEP_DEFINITIONS: tuple[StepDefinition, ...] = (
     StepDefinition("org_settings", "Organization basics", 10),
     StepDefinition("users_roles", "Users and roles", 20),
     StepDefinition("imports", "Data imports", 30),
+    StepDefinition("driversImported", "Drivers imported", 35),
     StepDefinition("mappings", "External mappings", 40),
     StepDefinition("integrations", "Integrations", 50),
     StepDefinition("vehicle_qr", "Vehicle QR deployment", 60),
@@ -68,6 +71,13 @@ def derive_step_statuses(
         if signals.successful_import_count > 0 and signals.failed_import_count == 0
         else "in_progress"
         if signals.successful_import_count > 0 or signals.failed_import_count > 0
+        else "not_started",
+        "driversImported": "completed"
+        if signals.successful_driver_import_count > 0
+        and signals.failed_driver_import_count == 0
+        else "in_progress"
+        if signals.successful_driver_import_count > 0
+        or signals.failed_driver_import_count > 0
         else "not_started",
         "mappings": "completed" if signals.mapping_count > 0 else "not_started",
         "integrations": "completed"

--- a/backend/app/onboarding/service.py
+++ b/backend/app/onboarding/service.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from app.db.models import (
     DriverInstructionSet,
     DriverInstructionStep,
+    DriverImportJob,
     DriverVehicleAssignment,
     Event,
     Export,
@@ -82,7 +83,9 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
     ]
     org_admin_count = sum(1 for user in active_users if str(user.role) == "org_admin")
     safety_capable_user_count = sum(
-        1 for user in active_users if has_capability(user.role, Capability.INCIDENT_WRITE)
+        1
+        for user in active_users
+        if has_capability(user.role, Capability.INCIDENT_WRITE)
     )
 
     import_operations = (
@@ -97,6 +100,15 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
         1 for op in import_operations if op.status == "succeeded"
     )
     failed_import_count = sum(1 for op in import_operations if op.status == "failed")
+    driver_import_jobs = (
+        db.query(DriverImportJob).filter(DriverImportJob.org_id == org_id).all()
+    )
+    successful_driver_import_count = sum(
+        1 for row in driver_import_jobs if row.status == "succeeded"
+    )
+    failed_driver_import_count = sum(
+        1 for row in driver_import_jobs if row.status == "failed"
+    )
 
     mapping_count = (
         db.query(ExternalMapping.mapping_id)
@@ -170,6 +182,7 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
         [
             len(active_users) > 0,
             len(import_operations) > 0,
+            len(driver_import_jobs) > 0,
             mapping_count > 0,
             len(integration_rows) > 0,
             qr_codes_generated > 0,
@@ -185,6 +198,8 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
         active_user_count=len(active_users),
         successful_import_count=successful_import_count,
         failed_import_count=failed_import_count,
+        successful_driver_import_count=successful_driver_import_count,
+        failed_driver_import_count=failed_driver_import_count,
         mapping_count=mapping_count,
         active_integration_count=active_integration_count,
         total_integration_count=len(integration_rows),
@@ -224,7 +239,9 @@ def build_onboarding_readiness(
                 "completion_source": completion.completion_source or "unknown",
             }
         else:
-            step.metadata = {"completion_source": completion.completion_source or "unknown"}
+            step.metadata = {
+                "completion_source": completion.completion_source or "unknown"
+            }
         step.updated_at_utc = completion.updated_at_utc
     percent_complete = completion_percent(steps)
     status = derive_readiness_status(steps=steps, percent_complete=percent_complete)
@@ -237,7 +254,18 @@ def build_onboarding_readiness(
             records_total=signals.successful_import_count + signals.failed_import_count,
             records_succeeded=signals.successful_import_count,
             records_failed=signals.failed_import_count,
-        )
+        ),
+        ImportJob(
+            import_job_id="drivers_imported",
+            provider="driver_csv",
+            status="succeeded"
+            if signals.successful_driver_import_count > 0
+            else "pending",
+            records_total=signals.successful_driver_import_count
+            + signals.failed_driver_import_count,
+            records_succeeded=signals.successful_driver_import_count,
+            records_failed=signals.failed_driver_import_count,
+        ),
     ]
 
     integration_validations = [

--- a/backend/app/services/driver_import_service.py
+++ b/backend/app/services/driver_import_service.py
@@ -1,0 +1,325 @@
+"""Driver CSV import job services."""
+
+from __future__ import annotations
+
+import csv
+import io
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.db.models import (
+    Driver,
+    DriverImportJob,
+    DriverVehicleAssignment,
+    ExternalMapping,
+)
+from app.services.phone_normalize import normalize_phone
+
+CANONICAL_HEADER_ALIASES = {
+    "first_name": {"firstname", "first_name", "first"},
+    "last_name": {"lastname", "last_name", "last"},
+    "phone": {"phone", "mobile", "mobilephone", "phone_e164"},
+    "vehicle_id": {
+        "vehicleid",
+        "vehicle_id",
+        "adcvehicleid",
+        "unitnumber",
+        "unit_number",
+    },
+    "provider_driver_id": {
+        "providerdriverid",
+        "provider_driver_id",
+        "externaldriverid",
+    },
+    "is_active": {"isactive", "active", "status"},
+}
+
+
+def _normalize_header(name: str) -> str:
+    return "".join(ch for ch in name.strip().lower() if ch.isalnum() or ch == "_")
+
+
+def _build_header_map(
+    fieldnames: list[str], explicit: dict[str, str]
+) -> tuple[dict[str, str], list[str]]:
+    warnings: list[str] = []
+    normalized_to_original = {_normalize_header(name): name for name in fieldnames}
+
+    resolved: dict[str, str] = {}
+    for canonical in CANONICAL_HEADER_ALIASES:
+        requested = explicit.get(canonical)
+        if requested:
+            key = _normalize_header(requested)
+            original = normalized_to_original.get(key)
+            if original is None:
+                warnings.append(
+                    f"Header mapping for '{canonical}' points to missing column '{requested}'."
+                )
+                continue
+            resolved[canonical] = original
+            continue
+
+        for alias in CANONICAL_HEADER_ALIASES[canonical]:
+            original = normalized_to_original.get(alias)
+            if original:
+                resolved[canonical] = original
+                break
+    return resolved, warnings
+
+
+def _row_is_active(raw: str | None) -> bool:
+    if raw is None:
+        return True
+    normalized = raw.strip().lower()
+    if not normalized:
+        return True
+    if normalized in {"inactive", "disabled", "false", "0", "no"}:
+        return False
+    return True
+
+
+def create_driver_import_job(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    provider: str,
+) -> DriverImportJob:
+    now = datetime.now(timezone.utc)
+    job = DriverImportJob(
+        org_id=org_id,
+        provider=provider.strip(),
+        status="pending",
+        started_at_utc=now,
+        warnings_json=[],
+        outcomes_json={
+            "imported": [],
+            "updated": [],
+            "skipped": [],
+            "errored": [],
+            "invalid_phone": [],
+            "duplicate_warning": [],
+            "missing_assignment_or_mapping": [],
+            "needs_review": [],
+        },
+        summary_json={
+            "invalid_phone_count": 0,
+            "duplicate_warning_count": 0,
+            "missing_assignment_count": 0,
+            "missing_external_mapping_count": 0,
+            "needs_review_count": 0,
+            "inactive_count": 0,
+        },
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+    return job
+
+
+def run_driver_import_job(
+    db: Session,
+    *,
+    job_id: uuid.UUID,
+    org_id: uuid.UUID,
+    csv_content: str,
+    header_mapping: dict[str, str],
+    inactive_phones: set[str],
+) -> DriverImportJob:
+    job = (
+        db.query(DriverImportJob)
+        .filter(DriverImportJob.job_id == job_id, DriverImportJob.org_id == org_id)
+        .first()
+    )
+    if job is None:
+        raise ValueError("job_not_found")
+
+    job.status = "running"
+    db.add(job)
+    db.commit()
+
+    try:
+        reader = csv.DictReader(io.StringIO(csv_content))
+        if reader.fieldnames is None:
+            raise ValueError("CSV missing headers")
+
+        resolved_headers, mapping_warnings = _build_header_map(
+            reader.fieldnames, header_mapping
+        )
+        warnings = list(mapping_warnings)
+
+        outcomes: dict[str, list[str]] = {
+            "imported": [],
+            "updated": [],
+            "skipped": [],
+            "errored": [],
+            "invalid_phone": [],
+            "duplicate_warning": [],
+            "missing_assignment_or_mapping": [],
+            "needs_review": [],
+        }
+        summary = {
+            "invalid_phone_count": 0,
+            "duplicate_warning_count": 0,
+            "missing_assignment_count": 0,
+            "missing_external_mapping_count": 0,
+            "needs_review_count": 0,
+            "inactive_count": 0,
+        }
+
+        existing_by_phone = {
+            row.phone_e164: row
+            for row in db.query(Driver).filter(Driver.org_id == org_id).all()
+        }
+        assigned_driver_ids = {
+            str(row.driver_id)
+            for row in db.query(DriverVehicleAssignment)
+            .filter(
+                DriverVehicleAssignment.org_id == org_id,
+                DriverVehicleAssignment.unassigned_at_utc.is_(None),
+            )
+            .all()
+        }
+        provider_mapped_driver_ids = {
+            row.internal_entity_id.lower()
+            for row in db.query(ExternalMapping)
+            .filter(
+                ExternalMapping.org_id == org_id,
+                ExternalMapping.internal_entity_type == "driver",
+                ExternalMapping.status == "active",
+            )
+            .all()
+        }
+
+        seen_phone_to_line: dict[str, int] = {}
+        staged_rows: list[dict[str, str | bool | None]] = []
+
+        for line_no, row in enumerate(reader, start=2):
+            first_col = resolved_headers.get("first_name")
+            last_col = resolved_headers.get("last_name")
+            phone_col = resolved_headers.get("phone")
+            provider_driver_col = resolved_headers.get("provider_driver_id")
+            active_col = resolved_headers.get("is_active")
+
+            first_name = ((row.get(first_col, "") if first_col else "") or "").strip()
+            last_name = ((row.get(last_col, "") if last_col else "") or "").strip()
+            raw_phone = ((row.get(phone_col, "") if phone_col else "") or "").strip()
+            provider_driver_id = (
+                (row.get(provider_driver_col, "") if provider_driver_col else "") or ""
+            ).strip() or None
+            row_active = _row_is_active(row.get(active_col) if active_col else None)
+
+            if not first_name:
+                outcomes["errored"].append(f"line {line_no}: firstName is required")
+                continue
+            if not last_name:
+                outcomes["errored"].append(f"line {line_no}: lastName is required")
+                continue
+            if not raw_phone:
+                outcomes["errored"].append(f"line {line_no}: mobile phone is required")
+                continue
+
+            try:
+                phone_e164 = normalize_phone(raw_phone)
+            except ValueError:
+                outcomes["errored"].append(
+                    f"line {line_no}: invalid mobile phone '{raw_phone}'"
+                )
+                outcomes["invalid_phone"].append(f"line {line_no}: {raw_phone}")
+                summary["invalid_phone_count"] += 1
+                summary["needs_review_count"] += 1
+                outcomes["needs_review"].append(f"line {line_no}: invalid mobile phone")
+                continue
+
+            if phone_e164 in seen_phone_to_line:
+                first_seen = seen_phone_to_line[phone_e164]
+                message = f"line {line_no}: duplicate mobile phone '{phone_e164}' (already used on line {first_seen})"
+                outcomes["errored"].append(message)
+                outcomes["duplicate_warning"].append(message)
+                summary["duplicate_warning_count"] += 1
+                summary["needs_review_count"] += 1
+                outcomes["needs_review"].append(
+                    f"line {line_no}: duplicate mobile phone"
+                )
+                continue
+            seen_phone_to_line[phone_e164] = line_no
+
+            if phone_e164 in inactive_phones:
+                row_active = False
+
+            staged_rows.append(
+                {
+                    "line_no": str(line_no),
+                    "first_name": first_name,
+                    "last_name": last_name,
+                    "display_name": f"{first_name} {last_name}",
+                    "phone_e164": phone_e164,
+                    "provider_driver_id": provider_driver_id,
+                    "is_active": row_active,
+                }
+            )
+
+        for staged in staged_rows:
+            phone_e164 = str(staged["phone_e164"])
+            display_name = str(staged["display_name"])
+            existing = existing_by_phone.get(phone_e164)
+            if existing is None:
+                existing = Driver(
+                    org_id=org_id,
+                    phone_e164=phone_e164,
+                    display_name=display_name,
+                    is_active=bool(staged["is_active"]),
+                )
+                db.add(existing)
+                db.flush()
+                outcomes["imported"].append(phone_e164)
+                existing_by_phone[phone_e164] = existing
+            else:
+                existing.display_name = display_name
+                existing.is_active = bool(staged["is_active"])
+                outcomes["updated"].append(phone_e164)
+
+            if not bool(staged["is_active"]):
+                summary["inactive_count"] += 1
+                outcomes["skipped"].append(f"{phone_e164}: inactive")
+
+            missing_reasons: list[str] = []
+            if str(existing.driver_id) not in assigned_driver_ids:
+                summary["missing_assignment_count"] += 1
+                missing_reasons.append("assignment")
+            if str(existing.driver_id).lower() not in provider_mapped_driver_ids:
+                summary["missing_external_mapping_count"] += 1
+                missing_reasons.append("external_mapping")
+
+            if missing_reasons:
+                summary["needs_review_count"] += 1
+                details = ", ".join(missing_reasons)
+                message = f"{phone_e164}: missing {details}"
+                outcomes["missing_assignment_or_mapping"].append(message)
+                outcomes["needs_review"].append(message)
+                warnings.append(f"Driver {phone_e164} missing {details}.")
+
+        job.records_total = len(staged_rows)
+        job.records_processed = len(staged_rows)
+        job.records_imported = len(outcomes["imported"])
+        job.records_updated = len(outcomes["updated"])
+        job.records_skipped = len(outcomes["skipped"])
+        job.records_errored = len(outcomes["errored"])
+        job.warnings_json = warnings
+        job.outcomes_json = outcomes
+        job.summary_json = summary
+        job.status = "succeeded" if not outcomes["errored"] else "failed"
+        job.completed_at_utc = datetime.now(timezone.utc)
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+        return job
+    except Exception as exc:
+        job.status = "failed"
+        job.error_message = str(exc)
+        job.completed_at_utc = datetime.now(timezone.utc)
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+        return job

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -23,6 +23,8 @@ from app.db.models import (
     IntegrationConnection,
     IntegrationOperation,
     EvidenceRequest,
+    Driver,
+    DriverVehicleAssignment,
     ExternalMapping,
     VehicleQrToken,
     OrgVehicleRegistry,
@@ -288,7 +290,9 @@ class TestIncidentExportReadiness:
         )
         incident_id = create_resp.json()["incident_id"]
         mock_snapshot.return_value = SimpleNamespace(
-            readiness=SimpleNamespace(state="not_ready", blocking_codes=["evidence_capture_incomplete"]),
+            readiness=SimpleNamespace(
+                state="not_ready", blocking_codes=["evidence_capture_incomplete"]
+            ),
             completeness=SimpleNamespace(percent=45, status="incomplete"),
             blockers=SimpleNamespace(
                 items=[
@@ -333,7 +337,9 @@ class TestIncidentExportReadiness:
         )
         incident_id = create_resp.json()["incident_id"]
         mock_snapshot.return_value = SimpleNamespace(
-            readiness=SimpleNamespace(state="conditionally_ready", blocking_codes=["driver_statement_missing"]),
+            readiness=SimpleNamespace(
+                state="conditionally_ready", blocking_codes=["driver_statement_missing"]
+            ),
             completeness=SimpleNamespace(percent=88, status="mostly_complete"),
             blockers=SimpleNamespace(
                 items=[
@@ -360,7 +366,9 @@ class TestIncidentExportReadiness:
 
 
 class TestIntegrationDiagnosticsRoutes:
-    def test_org_settings_read_and_patch(self, client, db_session, test_org, auth_headers):
+    def test_org_settings_read_and_patch(
+        self, client, db_session, test_org, auth_headers
+    ):
         read = client.get("/org/settings", headers=auth_headers)
         assert read.status_code == 200
         assert read.json()["display_name"] == "Test Org"
@@ -374,7 +382,10 @@ class TestIntegrationDiagnosticsRoutes:
                 "timezone": "America/Chicago",
                 "region": "US",
                 "contacts": [{"name": "Safety Lead", "email": "safety@test.org"}],
-                "implementation_contact": {"name": "Impl Lead", "email": "impl@test.org"},
+                "implementation_contact": {
+                    "name": "Impl Lead",
+                    "email": "impl@test.org",
+                },
                 "logo_url": "https://cdn.example.com/logo.png",
             },
         )
@@ -530,7 +541,9 @@ class TestIntegrationDiagnosticsRoutes:
         )
         assert patch_role.status_code == 200
         updated_user = next(
-            item for item in patch_role.json()["users"] if item["user_id"] == str(test_user.id)
+            item
+            for item in patch_role.json()["users"]
+            if item["user_id"] == str(test_user.id)
         )
         assert updated_user["role"] == "org_admin"
 
@@ -2118,7 +2131,9 @@ class TestVehicleImportJobs:
         assert create_resp.status_code == 202
         job_id = create_resp.json()["job_id"]
 
-        read_resp = client.get(f"/org/vehicles/import-jobs/{job_id}", headers=auth_headers)
+        read_resp = client.get(
+            f"/org/vehicles/import-jobs/{job_id}", headers=auth_headers
+        )
         assert read_resp.status_code == 200
         payload = read_resp.json()
         assert payload["status"] == "failed"
@@ -2133,16 +2148,128 @@ class TestVehicleImportJobs:
         assert payload["summary"]["duplicate_like_count"] == 2
         assert payload["summary"]["inactive_count"] == 1
         assert any("VIN" in warning for warning in payload["warnings"])
-        assert any("duplicate unitNumber" in row for row in payload["outcomes"]["errored"])
-        assert any("unitNumber is required" in row for row in payload["outcomes"]["errored"])
+        assert any(
+            "duplicate unitNumber" in row for row in payload["outcomes"]["errored"]
+        )
+        assert any(
+            "unitNumber is required" in row for row in payload["outcomes"]["errored"]
+        )
 
-        vehicles = db_session.query(OrgVehicleRegistry).filter(OrgVehicleRegistry.org_id == test_org.id).all()
+        vehicles = (
+            db_session.query(OrgVehicleRegistry)
+            .filter(OrgVehicleRegistry.org_id == test_org.id)
+            .all()
+        )
         assert len(vehicles) == 2
         unit_two = next(item for item in vehicles if item.unit_number == "UNIT-002")
         assert unit_two.is_active is False
 
     def test_get_vehicle_import_job_not_found(self, client, auth_headers):
-        resp = client.get(f"/org/vehicles/import-jobs/{uuid.uuid4()}", headers=auth_headers)
+        resp = client.get(
+            f"/org/vehicles/import-jobs/{uuid.uuid4()}", headers=auth_headers
+        )
+        assert resp.status_code == 404
+
+
+class TestDriverImportJobs:
+    def test_create_driver_import_job_and_read_results(
+        self, client, db_session, test_org, auth_headers
+    ):
+        existing = Driver(
+            org_id=test_org.id,
+            phone_e164="+15550001111",
+            display_name="Existing Driver",
+            is_active=True,
+        )
+        db_session.add(existing)
+        db_session.commit()
+        db_session.refresh(existing)
+        db_session.add(
+            DriverVehicleAssignment(
+                org_id=test_org.id,
+                driver_id=existing.driver_id,
+                adc_vehicle_id="UNIT-001",
+                source="manual",
+            )
+        )
+        db_session.add(
+            ExternalMapping(
+                org_id=test_org.id,
+                provider="samsara",
+                domain="fleet",
+                internal_entity_type="driver",
+                internal_entity_id=str(existing.driver_id),
+                external_reference="provider-driver-1",
+                status="active",
+            )
+        )
+        db_session.commit()
+
+        csv_content = (
+            "firstName,lastName,mobile,status\n"
+            "Alice,Example,(555) 000-1111,active\n"
+            "Bob,Builder,invalid-phone,active\n"
+            "Chris,Driver,5550002222,inactive\n"
+            "Dana,Dupe,5550002222,active\n"
+            ",NoFirst,5550003333,active\n"
+            "NoLast,,5550004444,active\n"
+        )
+
+        create_resp = client.post(
+            "/org/drivers/import",
+            headers=auth_headers,
+            json={
+                "provider": "samsara",
+                "csv_content": csv_content,
+                "header_mapping": {"phone": "mobile"},
+                "inactive_mobile_phones": ["5550002222"],
+            },
+        )
+        assert create_resp.status_code == 202
+        job_id = create_resp.json()["job_id"]
+
+        read_resp = client.get(
+            f"/org/drivers/import-jobs/{job_id}", headers=auth_headers
+        )
+        assert read_resp.status_code == 200
+        payload = read_resp.json()
+        assert payload["status"] == "failed"
+        assert payload["records_total"] == 2
+        assert payload["records_processed"] == 2
+        assert payload["records_imported"] == 1
+        assert payload["records_updated"] == 1
+        assert payload["records_skipped"] == 1
+        assert payload["records_errored"] == 4
+        assert payload["summary"]["invalid_phone_count"] == 1
+        assert payload["summary"]["duplicate_warning_count"] == 1
+        assert payload["summary"]["missing_assignment_count"] == 1
+        assert payload["summary"]["missing_external_mapping_count"] == 1
+        assert payload["summary"]["needs_review_count"] == 3
+        assert payload["summary"]["inactive_count"] == 1
+        assert len(payload["outcomes"]["invalid_phone"]) == 1
+        assert len(payload["outcomes"]["duplicate_warning"]) == 1
+        assert len(payload["outcomes"]["missing_assignment_or_mapping"]) == 1
+        assert len(payload["outcomes"]["needs_review"]) == 3
+        assert any(
+            "firstName is required" in row for row in payload["outcomes"]["errored"]
+        )
+        assert any(
+            "lastName is required" in row for row in payload["outcomes"]["errored"]
+        )
+        assert any(
+            "missing assignment, external_mapping" in row for row in payload["warnings"]
+        )
+
+        drivers = db_session.query(Driver).filter(Driver.org_id == test_org.id).all()
+        assert len(drivers) == 2
+        imported = next(row for row in drivers if row.phone_e164 == "+15550002222")
+        assert imported.display_name == "Chris Driver"
+        assert imported.is_active is False
+
+    def test_get_driver_import_job_not_found(self, client, auth_headers):
+        resp = client.get(
+            f"/org/drivers/import-jobs/{uuid.uuid4()}", headers=auth_headers
+        )
         assert resp.status_code == 404
 
 

--- a/backend/tests/test_onboarding_service.py
+++ b/backend/tests/test_onboarding_service.py
@@ -103,3 +103,15 @@ def test_build_onboarding_readiness_uses_blocked_status_when_critical_exists():
     assert "org_settings" in blocked
     assert "integrations" in blocked
     assert len(snapshot.blockers) >= 1
+
+
+def test_driver_import_step_completion_signal():
+    steps = derive_step_statuses(
+        signals=OnboardingSignals(
+            successful_driver_import_count=1,
+            failed_driver_import_count=0,
+        ),
+        blocked_step_keys=set(),
+    )
+    by_key = {step.key: step for step in steps}
+    assert by_key["driversImported"].status == "completed"


### PR DESCRIPTION
### Motivation
- Provide an async CSV import flow for drivers so large imports can be processed off-request and polled by the UI.  
- Surface categorized per-row outcomes and counters (invalid phone, duplicate, missing assignment/mapping, needs review) to enable UI review workflows.  
- Integrate driver-import completion into onboarding readiness so a successful driver import advances the `driversImported` onboarding step.

### Description
- Added a persisted `DriverImportJob` model to track async job lifecycle, counters, timestamps, warnings, outcomes and summary JSON payloads (`backend/app/db/models.py`).
- Implemented `driver_import_service` with CSV parsing, header mapping, required-field validation (first/last name, mobile phone), phone normalization, duplicate detection, inactive handling, assignment/mapping warnings, and categorized outcome buckets (`backend/app/services/driver_import_service.py`).
- Exposed endpoints `POST /org/drivers/import` and `GET /org/drivers/import-jobs/{job_id}` that enqueue a background job and return the job payload/status (routes + background wrapper in `backend/app/api/routes_integrations.py`).
- Extended API schemas for driver import request/response, outcome categories, and summary counters to support UI consumption (`backend/app/api/schemas.py`).
- Integrated driver-import signals into onboarding readiness by adding a `driversImported` step and aggregating driver import job counts into onboarding signals and snapshot (`backend/app/onboarding/progress.py`, `backend/app/onboarding/service.py`).
- Added and updated tests exercising the new import endpoints and onboarding step behaviour (`backend/tests/test_api_endpoints.py`, `backend/tests/test_onboarding_service.py`).

### Testing
- Ran formatter/linter checks via `ruff format` and `ruff check` on touched files and confirmed all checks passed.  
- Executed focused API tests with `pytest tests/test_api_endpoints.py -k "VehicleImportJobs or DriverImportJobs or onboarding_status" -v` which resulted in 6 passed tests and no failures.  
- Ran onboarding tests with `pytest tests/test_onboarding_service.py -v` which resulted in 4 passed tests and no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dea62d59d88321aa54b18d889ee4c5)