### PR TITLE
Add org mapping summary & issues endpoints with pilot readiness flags

### DIFF
--- a/backend/app/api/routes_integrations.py
+++ b/backend/app/api/routes_integrations.py
@@ -31,6 +31,13 @@ from app.api.schemas import (
     OrgLaunchReadinessResponse,
     OrgInviteUserRequest,
     OrgInviteUserResponse,
+    OrgMappingsAssignmentConfidence,
+    OrgMappingsIssue,
+    OrgMappingsIssuesResponse,
+    OrgMappingsPilotReadinessFlags,
+    OrgMappingsStaleWarnings,
+    OrgMappingsSummaryCounts,
+    OrgMappingsSummaryResponse,
     OrgOnboardingStepUpdateRequest,
     OrgSettingsResponse,
     OrgSettingsUpdateRequest,
@@ -54,6 +61,10 @@ from app.db.models import (
     User,
     UserOrg,
     DriverImportJob,
+    Driver,
+    DriverVehicleAssignment,
+    ExternalMapping,
+    OrgVehicleRegistry,
     VehicleImportJob,
 )
 from app.db.session import get_db
@@ -95,6 +106,10 @@ router = APIRouter()
 
 _integration_admin = require_user_role("system_admin", "org_admin")
 _org_user_admin = require_user_role("system_admin", "org_admin")
+_PILOT_MIN_MAPPED_DRIVERS = 3
+_PILOT_MIN_MAPPED_VEHICLES = 3
+_ASSIGNMENT_CONFIDENCE_MEDIUM_THRESHOLD = 0.7
+_ASSIGNMENT_CONFIDENCE_HIGH_THRESHOLD = 0.9
 
 
 def _first_org_id(context) -> uuid.UUID:
@@ -150,6 +165,187 @@ def _role_violations(*, role_counts: dict[str, int]) -> list[str]:
     if safety_capable_count < 1:
         violations.append("no safety manager assigned")
     return violations
+
+
+def _build_org_mapping_summary(
+    db: Session, *, org_id: uuid.UUID
+) -> OrgMappingsSummaryResponse:
+    active_drivers = (
+        db.query(Driver)
+        .filter(Driver.org_id == org_id, Driver.is_active.is_(True))
+        .all()
+    )
+    active_vehicles = (
+        db.query(OrgVehicleRegistry)
+        .filter(
+            OrgVehicleRegistry.org_id == org_id,
+            OrgVehicleRegistry.is_active.is_(True),
+        )
+        .all()
+    )
+    active_driver_ids = {str(row.driver_id).lower() for row in active_drivers}
+    active_vehicle_unit_numbers = {row.unit_number.lower() for row in active_vehicles}
+
+    mapped_driver_ids = {
+        row.internal_entity_id.lower()
+        for row in db.query(ExternalMapping)
+        .filter(
+            ExternalMapping.org_id == org_id,
+            ExternalMapping.internal_entity_type == "driver",
+            ExternalMapping.status == "active",
+        )
+        .all()
+    }
+    mapped_vehicle_unit_numbers = {
+        row.internal_entity_id.lower()
+        for row in db.query(ExternalMapping)
+        .filter(
+            ExternalMapping.org_id == org_id,
+            ExternalMapping.internal_entity_type == "vehicle",
+            ExternalMapping.status == "active",
+        )
+        .all()
+    }
+
+    mapped_drivers = len(active_driver_ids.intersection(mapped_driver_ids))
+    mapped_vehicles = len(
+        active_vehicle_unit_numbers.intersection(mapped_vehicle_unit_numbers)
+    )
+
+    assigned_driver_ids = {
+        str(row.driver_id).lower()
+        for row in db.query(DriverVehicleAssignment)
+        .filter(
+            DriverVehicleAssignment.org_id == org_id,
+            DriverVehicleAssignment.unassigned_at_utc.is_(None),
+        )
+        .all()
+    }
+    assigned_mapped_drivers = len(
+        assigned_driver_ids.intersection(active_driver_ids.intersection(mapped_driver_ids))
+    )
+    assignment_score = (
+        assigned_mapped_drivers / mapped_drivers if mapped_drivers > 0 else 0.0
+    )
+    if assignment_score >= _ASSIGNMENT_CONFIDENCE_HIGH_THRESHOLD:
+        assignment_level = "high"
+    elif assignment_score >= _ASSIGNMENT_CONFIDENCE_MEDIUM_THRESHOLD:
+        assignment_level = "medium"
+    else:
+        assignment_level = "low"
+
+    blocking_credential_count = (
+        db.query(IntegrationConnection)
+        .filter(
+            IntegrationConnection.org_id == org_id,
+            IntegrationConnection.status.in_(["inactive", "error"]),
+            IntegrationConnection.credentials_ref.is_(None),
+        )
+        .count()
+    )
+    no_blocking_integration_credentials = blocking_credential_count == 0
+    enough_mapped_drivers_for_pilot = mapped_drivers >= _PILOT_MIN_MAPPED_DRIVERS
+    enough_mapped_vehicles_for_pilot = mapped_vehicles >= _PILOT_MIN_MAPPED_VEHICLES
+
+    return OrgMappingsSummaryResponse(
+        drivers=OrgMappingsSummaryCounts(
+            total=len(active_driver_ids),
+            mapped=mapped_drivers,
+            unmapped=max(0, len(active_driver_ids) - mapped_drivers),
+        ),
+        vehicles=OrgMappingsSummaryCounts(
+            total=len(active_vehicle_unit_numbers),
+            mapped=mapped_vehicles,
+            unmapped=max(0, len(active_vehicle_unit_numbers) - mapped_vehicles),
+        ),
+        assignment_confidence=OrgMappingsAssignmentConfidence(
+            level=assignment_level,
+            score=round(assignment_score, 4),
+            assigned_mapped_drivers=assigned_mapped_drivers,
+            mapped_drivers=mapped_drivers,
+        ),
+        stale_warnings=OrgMappingsStaleWarnings(
+            placeholder_supported=True,
+            stale_count=0,
+            stale_warning_codes=[],
+        ),
+        pilot_readiness=OrgMappingsPilotReadinessFlags(
+            enough_mapped_drivers_for_pilot=enough_mapped_drivers_for_pilot,
+            enough_mapped_vehicles_for_pilot=enough_mapped_vehicles_for_pilot,
+            no_blocking_integration_credentials=no_blocking_integration_credentials,
+            pilot_scope_ready=(
+                enough_mapped_drivers_for_pilot
+                and enough_mapped_vehicles_for_pilot
+                and no_blocking_integration_credentials
+            ),
+        ),
+    )
+
+
+def _build_org_mapping_issues(
+    summary: OrgMappingsSummaryResponse,
+) -> OrgMappingsIssuesResponse:
+    issues: list[OrgMappingsIssue] = []
+
+    if summary.drivers.unmapped > 0:
+        issues.append(
+            OrgMappingsIssue(
+                code="MAPPED_DRIVERS_REQUIRED",
+                message=(
+                    f"{summary.drivers.unmapped} active driver(s) are not mapped to a provider reference."
+                ),
+                severity="error",
+                blocker_panel_action="open_driver_mappings",
+            )
+        )
+
+    if summary.vehicles.unmapped > 0:
+        issues.append(
+            OrgMappingsIssue(
+                code="MAPPED_VEHICLES_REQUIRED",
+                message=(
+                    f"{summary.vehicles.unmapped} active vehicle(s) are not mapped to a provider reference."
+                ),
+                severity="error",
+                blocker_panel_action="open_vehicle_mappings",
+            )
+        )
+
+    if summary.assignment_confidence.level == "low":
+        issues.append(
+            OrgMappingsIssue(
+                code="ASSIGNMENT_CONFIDENCE_LOW",
+                message=(
+                    "Driver-to-vehicle assignment confidence is low for currently mapped drivers."
+                ),
+                severity="warning",
+                blocker_panel_action="review_driver_assignments",
+            )
+        )
+
+    if not summary.pilot_readiness.no_blocking_integration_credentials:
+        issues.append(
+            OrgMappingsIssue(
+                code="BLOCKING_INTEGRATION_CREDENTIALS",
+                message=(
+                    "One or more integration connections are missing required credentials."
+                ),
+                severity="error",
+                blocker_panel_action="fix_integration_credentials",
+            )
+        )
+
+    if summary.stale_warnings.stale_count > 0:
+        issues.append(
+            OrgMappingsIssue(
+                code="STALE_MAPPING_WARNINGS",
+                message="Stale mapping warnings were detected and require review.",
+                severity="warning",
+                blocker_panel_action="review_stale_mapping_warnings",
+            )
+        )
+
+    return OrgMappingsIssuesResponse(issues=issues)
 
 
 def _run_vehicle_import_background(
@@ -304,6 +500,25 @@ def get_org_onboarding_status(
     context = build_user_auth_context(db, current_user)
     readiness = get_org_onboarding_readiness(db, org_id=_first_org_id(context))
     return _to_readiness_response(readiness)
+
+
+@router.get("/org/mappings/summary", response_model=OrgMappingsSummaryResponse)
+def get_org_mappings_summary(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    return _build_org_mapping_summary(db, org_id=_first_org_id(context))
+
+
+@router.get("/org/mappings/issues", response_model=OrgMappingsIssuesResponse)
+def get_org_mappings_issues(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    summary = _build_org_mapping_summary(db, org_id=_first_org_id(context))
+    return _build_org_mapping_issues(summary)
 
 
 @router.post("/org/onboarding/mark-step", response_model=OrgLaunchReadinessResponse)

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -741,6 +741,57 @@ class OrgOnboardingStepUpdateRequest(BaseModel):
     source: ShortText = "manual"
 
 
+class OrgMappingsSummaryCounts(BaseModel):
+    total: int = Field(default=0, ge=0)
+    mapped: int = Field(default=0, ge=0)
+    unmapped: int = Field(default=0, ge=0)
+
+
+class OrgMappingsAssignmentConfidence(BaseModel):
+    level: Literal["low", "medium", "high"] = "low"
+    score: float = Field(default=0.0, ge=0.0, le=1.0)
+    assigned_mapped_drivers: int = Field(default=0, ge=0)
+    mapped_drivers: int = Field(default=0, ge=0)
+
+
+class OrgMappingsStaleWarnings(BaseModel):
+    placeholder_supported: bool = True
+    stale_count: int = Field(default=0, ge=0)
+    stale_warning_codes: list[ShortText] = Field(default_factory=list)
+
+
+class OrgMappingsPilotReadinessFlags(BaseModel):
+    enough_mapped_drivers_for_pilot: bool = False
+    enough_mapped_vehicles_for_pilot: bool = False
+    no_blocking_integration_credentials: bool = False
+    pilot_scope_ready: bool = False
+
+
+class OrgMappingsSummaryResponse(BaseModel):
+    drivers: OrgMappingsSummaryCounts = Field(default_factory=OrgMappingsSummaryCounts)
+    vehicles: OrgMappingsSummaryCounts = Field(default_factory=OrgMappingsSummaryCounts)
+    assignment_confidence: OrgMappingsAssignmentConfidence = Field(
+        default_factory=OrgMappingsAssignmentConfidence
+    )
+    stale_warnings: OrgMappingsStaleWarnings = Field(
+        default_factory=OrgMappingsStaleWarnings
+    )
+    pilot_readiness: OrgMappingsPilotReadinessFlags = Field(
+        default_factory=OrgMappingsPilotReadinessFlags
+    )
+
+
+class OrgMappingsIssue(BaseModel):
+    code: ShortText
+    message: str
+    severity: Literal["warning", "error"] = "warning"
+    blocker_panel_action: ShortText
+
+
+class OrgMappingsIssuesResponse(BaseModel):
+    issues: list[OrgMappingsIssue] = Field(default_factory=list)
+
+
 class OrgUserSummary(BaseModel):
     user_id: uuid.UUID
     email: EmailStrLike

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -2273,6 +2273,190 @@ class TestDriverImportJobs:
         assert resp.status_code == 404
 
 
+class TestOrgMappingsReadiness:
+    def test_org_mapping_summary_counts_readiness_and_confidence(
+        self, client, db_session, test_org, auth_headers
+    ):
+        driver_one = Driver(
+            org_id=test_org.id,
+            phone_e164="+15551110001",
+            display_name="Driver One",
+            is_active=True,
+        )
+        driver_two = Driver(
+            org_id=test_org.id,
+            phone_e164="+15551110002",
+            display_name="Driver Two",
+            is_active=True,
+        )
+        driver_three = Driver(
+            org_id=test_org.id,
+            phone_e164="+15551110003",
+            display_name="Driver Three",
+            is_active=True,
+        )
+        db_session.add_all([driver_one, driver_two, driver_three])
+        db_session.commit()
+        db_session.refresh(driver_one)
+        db_session.refresh(driver_two)
+        db_session.refresh(driver_three)
+
+        db_session.add_all(
+            [
+                OrgVehicleRegistry(
+                    org_id=test_org.id,
+                    unit_number="UNIT-001",
+                    is_active=True,
+                ),
+                OrgVehicleRegistry(
+                    org_id=test_org.id,
+                    unit_number="UNIT-002",
+                    is_active=True,
+                ),
+                OrgVehicleRegistry(
+                    org_id=test_org.id,
+                    unit_number="UNIT-003",
+                    is_active=True,
+                ),
+            ]
+        )
+        db_session.add_all(
+            [
+                ExternalMapping(
+                    org_id=test_org.id,
+                    provider="samsara",
+                    domain="fleet",
+                    internal_entity_type="driver",
+                    internal_entity_id=str(driver_one.driver_id),
+                    external_reference="drv-1",
+                    status="active",
+                ),
+                ExternalMapping(
+                    org_id=test_org.id,
+                    provider="samsara",
+                    domain="fleet",
+                    internal_entity_type="driver",
+                    internal_entity_id=str(driver_two.driver_id),
+                    external_reference="drv-2",
+                    status="active",
+                ),
+                ExternalMapping(
+                    org_id=test_org.id,
+                    provider="samsara",
+                    domain="fleet",
+                    internal_entity_type="driver",
+                    internal_entity_id=str(driver_three.driver_id),
+                    external_reference="drv-3",
+                    status="active",
+                ),
+                ExternalMapping(
+                    org_id=test_org.id,
+                    provider="samsara",
+                    domain="fleet",
+                    internal_entity_type="vehicle",
+                    internal_entity_id="UNIT-001",
+                    external_reference="veh-1",
+                    status="active",
+                ),
+                ExternalMapping(
+                    org_id=test_org.id,
+                    provider="samsara",
+                    domain="fleet",
+                    internal_entity_type="vehicle",
+                    internal_entity_id="UNIT-002",
+                    external_reference="veh-2",
+                    status="active",
+                ),
+                ExternalMapping(
+                    org_id=test_org.id,
+                    provider="samsara",
+                    domain="fleet",
+                    internal_entity_type="vehicle",
+                    internal_entity_id="UNIT-003",
+                    external_reference="veh-3",
+                    status="active",
+                ),
+            ]
+        )
+        db_session.add(
+            DriverVehicleAssignment(
+                org_id=test_org.id,
+                driver_id=driver_one.driver_id,
+                adc_vehicle_id="UNIT-001",
+                source="manual",
+            )
+        )
+        db_session.add(
+            IntegrationConnection(
+                org_id=test_org.id,
+                provider="samsara",
+                domain="fleet",
+                status="active",
+                credentials_ref="vault://samsara",
+            )
+        )
+        db_session.commit()
+
+        response = client.get("/org/mappings/summary", headers=auth_headers)
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["drivers"] == {"total": 3, "mapped": 3, "unmapped": 0}
+        assert payload["vehicles"] == {"total": 3, "mapped": 3, "unmapped": 0}
+        assert payload["assignment_confidence"]["level"] == "low"
+        assert payload["assignment_confidence"]["score"] == pytest.approx(
+            1 / 3, rel=1e-3
+        )
+        assert payload["stale_warnings"]["placeholder_supported"] is True
+        assert payload["pilot_readiness"] == {
+            "enough_mapped_drivers_for_pilot": True,
+            "enough_mapped_vehicles_for_pilot": True,
+            "no_blocking_integration_credentials": True,
+            "pilot_scope_ready": True,
+        }
+
+    def test_org_mapping_issues_return_panel_aligned_codes_and_actions(
+        self, client, db_session, test_org, auth_headers
+    ):
+        driver = Driver(
+            org_id=test_org.id,
+            phone_e164="+15551119999",
+            display_name="Needs Mapping",
+            is_active=True,
+        )
+        db_session.add(driver)
+        db_session.add(
+            OrgVehicleRegistry(
+                org_id=test_org.id,
+                unit_number="UNIT-404",
+                is_active=True,
+            )
+        )
+        db_session.add(
+            IntegrationConnection(
+                org_id=test_org.id,
+                provider="motive",
+                domain="fleet",
+                status="error",
+                credentials_ref=None,
+            )
+        )
+        db_session.commit()
+
+        response = client.get("/org/mappings/issues", headers=auth_headers)
+        assert response.status_code == 200
+        payload = response.json()
+        codes = {item["code"] for item in payload["issues"]}
+        assert "MAPPED_DRIVERS_REQUIRED" in codes
+        assert "MAPPED_VEHICLES_REQUIRED" in codes
+        assert "ASSIGNMENT_CONFIDENCE_LOW" in codes
+        assert "BLOCKING_INTEGRATION_CREDENTIALS" in codes
+        actions = {item["blocker_panel_action"] for item in payload["issues"]}
+        assert "open_driver_mappings" in actions
+        assert "open_vehicle_mappings" in actions
+        assert "review_driver_assignments" in actions
+        assert "fix_integration_credentials" in actions
+
+
 # ── Health check ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
### Motivation
- Surface mapping health signals (mapped/unmapped counts, assignment confidence, stale warnings) to support onboarding and pilot readiness decisions.
- Provide pilot-scope readiness flags so the UI can quickly determine if an org meets minimal pilot thresholds and whether integration credentials block progress.
- Emit issue codes/messages that map directly to blocker-panel actions for consistent operator workflows.

### Description
- Added typed response contracts in `backend/app/api/schemas.py` for mapping summaries, assignment confidence, stale-warnings placeholders, pilot readiness flags, and issue payloads (`OrgMappingsSummaryResponse`, `OrgMappingsIssue`, etc.).
- Implemented `_build_org_mapping_summary` and `_build_org_mapping_issues` and new endpoints `GET /org/mappings/summary` and `GET /org/mappings/issues` in `backend/app/api/routes_integrations.py`, including assignment confidence scoring and pilot readiness flags (`enough_mapped_drivers_for_pilot`, `enough_mapped_vehicles_for_pilot`, `no_blocking_integration_credentials`, `pilot_scope_ready`).
- Added thresholds and constants for pilot minima and assignment confidence levels and a placeholder `stale_warnings` payload to reserve the shape for future stale-detection logic.
- Added tests in `backend/tests/test_api_endpoints.py` that validate summary counts, assignment confidence calculation, pilot readiness flags, and that issue responses include panel-aligned codes and `blocker_panel_action` values.

### Testing
- Ran linting with `ruff check app tests` which completed successfully.
- Ran `pytest tests/test_api_endpoints.py -q` with the new endpoint tests, all tests passed (78 passed).
- Ran `pytest tests/test_runtime_contract_snapshot.py -q` which passed (1 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dea86f156c832199ee51e1f919d390)