### PR TITLE
Add org vehicle QR deployment lifecycle and onboarding QR coverage APIs

### DIFF
--- a/backend/app/api/routes_driver.py
+++ b/backend/app/api/routes_driver.py
@@ -43,6 +43,7 @@ from app.db.models import (
     OtpChallenge,
     VehicleQrToken,
     Incident,
+    OrgVehicleRegistry,
 )
 from app.db.session import get_db
 from app.domain.system_event_types import SystemEventType
@@ -300,6 +301,17 @@ def resolve_qr(
         },
     )
     db.add(event)
+    vehicle = (
+        db.query(OrgVehicleRegistry)
+        .filter(
+            OrgVehicleRegistry.org_id == token_row.org_id,
+            OrgVehicleRegistry.unit_number == token_row.adc_vehicle_id,
+        )
+        .first()
+    )
+    if vehicle is not None:
+        vehicle.qr_deployment_status = "confirmed"
+        vehicle.qr_confirmed_at_utc = datetime.now(timezone.utc)
     db.commit()
 
     logger.info(

--- a/backend/app/api/routes_integrations.py
+++ b/backend/app/api/routes_integrations.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import uuid
 from dataclasses import asdict
 from datetime import datetime, timezone
+import hashlib
+import secrets
 
 from fastapi import (
     APIRouter,
@@ -14,6 +16,7 @@ from fastapi import (
     Request,
     Response,
 )
+from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
 from app.api.schemas import (
@@ -48,6 +51,10 @@ from app.api.schemas import (
     VehicleImportJobCreateRequest,
     VehicleImportJobCreateResponse,
     VehicleImportJobResponse,
+    VehicleQrBulkGenerateRequest,
+    VehicleQrBulkGenerateResponse,
+    VehicleQrGenerateResponse,
+    VehicleQrStatsResponse,
 )
 from app.core.config import settings
 from app.core.deps import get_current_user, require_user_role
@@ -66,6 +73,8 @@ from app.db.models import (
     ExternalMapping,
     OrgVehicleRegistry,
     VehicleImportJob,
+    VehicleQrToken,
+    Event,
 )
 from app.db.session import get_db
 from app.integrations.webhooks.handlers import (
@@ -101,6 +110,8 @@ from app.security.permissions import (
     has_capability,
     normalize_role,
 )
+from app.domain.system_event_types import SystemEventType
+from app.services.pdf_render import render_pdf
 
 router = APIRouter()
 
@@ -246,6 +257,11 @@ def _build_org_mapping_summary(
     no_blocking_integration_credentials = blocking_credential_count == 0
     enough_mapped_drivers_for_pilot = mapped_drivers >= _PILOT_MIN_MAPPED_DRIVERS
     enough_mapped_vehicles_for_pilot = mapped_vehicles >= _PILOT_MIN_MAPPED_VEHICLES
+    qr_stats = _vehicle_qr_stats(db, org_id=org_id)
+    enough_qr_generated = qr_stats.generated_count >= qr_stats.required_vehicle_count
+    enough_qr_distributed = (
+        qr_stats.distributed_count >= qr_stats.required_vehicle_count
+    )
 
     return OrgMappingsSummaryResponse(
         drivers=OrgMappingsSummaryCounts(
@@ -272,10 +288,14 @@ def _build_org_mapping_summary(
         pilot_readiness=OrgMappingsPilotReadinessFlags(
             enough_mapped_drivers_for_pilot=enough_mapped_drivers_for_pilot,
             enough_mapped_vehicles_for_pilot=enough_mapped_vehicles_for_pilot,
+            enough_qr_generated_for_required_vehicles=enough_qr_generated,
+            enough_qr_distributed_for_required_vehicles=enough_qr_distributed,
             no_blocking_integration_credentials=no_blocking_integration_credentials,
             pilot_scope_ready=(
                 enough_mapped_drivers_for_pilot
                 and enough_mapped_vehicles_for_pilot
+                and enough_qr_generated
+                and enough_qr_distributed
                 and no_blocking_integration_credentials
             ),
         ),
@@ -335,6 +355,26 @@ def _build_org_mapping_issues(
             )
         )
 
+    if not summary.pilot_readiness.enough_qr_generated_for_required_vehicles:
+        issues.append(
+            OrgMappingsIssue(
+                code="VEHICLE_QR_GENERATION_REQUIRED",
+                message="Required pilot vehicles are missing generated QR codes.",
+                severity="error",
+                blocker_panel_action="generate_vehicle_qr",
+            )
+        )
+
+    if not summary.pilot_readiness.enough_qr_distributed_for_required_vehicles:
+        issues.append(
+            OrgMappingsIssue(
+                code="VEHICLE_QR_DISTRIBUTION_REQUIRED",
+                message="Required pilot vehicles have QR codes that are not yet distributed.",
+                severity="error",
+                blocker_panel_action="distribute_vehicle_qr",
+            )
+        )
+
     if summary.stale_warnings.stale_count > 0:
         issues.append(
             OrgMappingsIssue(
@@ -366,6 +406,85 @@ def _run_vehicle_import_background(
         inactive_unit_numbers={
             item.strip().lower() for item in inactive_unit_numbers if item.strip()
         },
+    )
+
+
+def _get_required_vehicle(
+    db: Session, *, org_id: uuid.UUID, vehicle_id: str
+) -> OrgVehicleRegistry:
+    vehicle = (
+        db.query(OrgVehicleRegistry)
+        .filter(
+            OrgVehicleRegistry.org_id == org_id,
+            OrgVehicleRegistry.unit_number == vehicle_id,
+            OrgVehicleRegistry.is_active.is_(True),
+        )
+        .first()
+    )
+    if vehicle is None:
+        raise HTTPException(status_code=404, detail="Vehicle not found")
+    return vehicle
+
+
+def _emit_vehicle_qr_event(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    actor_id: uuid.UUID,
+    action: str,
+    vehicle_id: str,
+    payload: dict,
+) -> None:
+    db.add(
+        Event(
+            org_id=org_id,
+            incident_id=None,
+            event_type=action,
+            actor_type="admin",
+            actor_id=str(actor_id),
+            payload={"adc_vehicle_id": vehicle_id, **payload},
+        )
+    )
+
+
+def _vehicle_qr_stats(db: Session, *, org_id: uuid.UUID) -> VehicleQrStatsResponse:
+    required_rows = (
+        db.query(OrgVehicleRegistry)
+        .filter(
+            OrgVehicleRegistry.org_id == org_id,
+            OrgVehicleRegistry.is_active.is_(True),
+        )
+        .all()
+    )
+    required_ids = {row.unit_number for row in required_rows}
+    generated_ids = {
+        row.adc_vehicle_id
+        for row in db.query(VehicleQrToken)
+        .filter(
+            VehicleQrToken.org_id == org_id,
+            VehicleQrToken.status == "active",
+        )
+        .all()
+    }
+    distributed_count = sum(
+        1
+        for row in required_rows
+        if row.qr_deployment_status in {"distributed", "confirmed"}
+    )
+    confirmed_count = sum(
+        1 for row in required_rows if row.qr_deployment_status == "confirmed"
+    )
+    blockers: list[str] = []
+    if len(required_ids - generated_ids) > 0:
+        blockers.append("required_vehicles_not_generated")
+    if distributed_count < len(required_rows):
+        blockers.append("required_vehicles_not_distributed")
+    return VehicleQrStatsResponse(
+        required_vehicle_count=len(required_rows),
+        generated_count=len(required_ids.intersection(generated_ids)),
+        distributed_count=distributed_count,
+        confirmed_count=confirmed_count,
+        coverage_blockers=blockers,
     )
 
 
@@ -605,6 +724,226 @@ def get_org_vehicle_import_job(
     if row is None:
         raise HTTPException(status_code=404, detail="Import job not found")
     return _to_vehicle_import_job_response(row)
+
+
+@router.post(
+    "/org/vehicles/{vehicle_id}/generate-qr",
+    response_model=VehicleQrGenerateResponse,
+)
+def generate_vehicle_qr(
+    vehicle_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = _first_org_id(context)
+    vehicle = _get_required_vehicle(db, org_id=org_id, vehicle_id=vehicle_id)
+
+    active_token = (
+        db.query(VehicleQrToken)
+        .filter(
+            VehicleQrToken.org_id == org_id,
+            VehicleQrToken.adc_vehicle_id == vehicle.unit_number,
+            VehicleQrToken.status == "active",
+        )
+        .first()
+    )
+    if active_token is None:
+        active_token = VehicleQrToken(
+            qr_token=secrets.token_urlsafe(32),
+            org_id=org_id,
+            adc_vehicle_id=vehicle.unit_number,
+            status="active",
+        )
+        db.add(active_token)
+
+    vehicle.qr_deployment_status = "generated"
+    vehicle.qr_generated_at_utc = datetime.now(timezone.utc)
+    token_hash = hashlib.sha256(active_token.qr_token.encode()).hexdigest()
+    _emit_vehicle_qr_event(
+        db,
+        org_id=org_id,
+        actor_id=current_user.id,
+        action="vehicle_qr_generated",
+        vehicle_id=vehicle.unit_number,
+        payload={"token_sha256": token_hash},
+    )
+    db.commit()
+    return VehicleQrGenerateResponse(
+        vehicle_id=vehicle.unit_number,
+        qr_token=active_token.qr_token,
+        deployment_status=vehicle.qr_deployment_status,
+    )
+
+
+@router.post(
+    "/org/vehicles/bulk-generate-qr",
+    response_model=VehicleQrBulkGenerateResponse,
+)
+def bulk_generate_vehicle_qr(
+    payload: VehicleQrBulkGenerateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = _first_org_id(context)
+    generated: list[VehicleQrGenerateResponse] = []
+    skipped: list[str] = []
+    for vehicle_id in payload.vehicle_ids:
+        vehicle = (
+            db.query(OrgVehicleRegistry)
+            .filter(
+                OrgVehicleRegistry.org_id == org_id,
+                OrgVehicleRegistry.unit_number == vehicle_id,
+                OrgVehicleRegistry.is_active.is_(True),
+            )
+            .first()
+        )
+        if vehicle is None:
+            skipped.append(vehicle_id)
+            continue
+        token = (
+            db.query(VehicleQrToken)
+            .filter(
+                VehicleQrToken.org_id == org_id,
+                VehicleQrToken.adc_vehicle_id == vehicle.unit_number,
+                VehicleQrToken.status == "active",
+            )
+            .first()
+        )
+        if token is None:
+            token = VehicleQrToken(
+                qr_token=secrets.token_urlsafe(32),
+                org_id=org_id,
+                adc_vehicle_id=vehicle.unit_number,
+                status="active",
+            )
+            db.add(token)
+        vehicle.qr_deployment_status = "generated"
+        vehicle.qr_generated_at_utc = datetime.now(timezone.utc)
+        _emit_vehicle_qr_event(
+            db,
+            org_id=org_id,
+            actor_id=current_user.id,
+            action="vehicle_qr_generated",
+            vehicle_id=vehicle.unit_number,
+            payload={"bulk": True},
+        )
+        generated.append(
+            VehicleQrGenerateResponse(
+                vehicle_id=vehicle.unit_number,
+                qr_token=token.qr_token,
+                deployment_status="generated",
+            )
+        )
+    db.commit()
+    return VehicleQrBulkGenerateResponse(
+        generated_count=len(generated),
+        skipped_count=len(skipped),
+        generated=generated,
+        skipped_vehicle_ids=skipped,
+    )
+
+
+@router.post("/org/vehicles/{vehicle_id}/rotate-qr", response_model=VehicleQrGenerateResponse)
+def rotate_vehicle_qr(
+    vehicle_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = _first_org_id(context)
+    vehicle = _get_required_vehicle(db, org_id=org_id, vehicle_id=vehicle_id)
+    active_tokens = (
+        db.query(VehicleQrToken)
+        .filter(
+            VehicleQrToken.org_id == org_id,
+            VehicleQrToken.adc_vehicle_id == vehicle.unit_number,
+            VehicleQrToken.status == "active",
+        )
+        .all()
+    )
+    for row in active_tokens:
+        row.status = "rotated"
+    token = VehicleQrToken(
+        qr_token=secrets.token_urlsafe(32),
+        org_id=org_id,
+        adc_vehicle_id=vehicle.unit_number,
+        status="active",
+        rotated_from_token=active_tokens[0].qr_token if active_tokens else None,
+    )
+    db.add(token)
+    vehicle.qr_deployment_status = "generated"
+    vehicle.qr_generated_at_utc = datetime.now(timezone.utc)
+    _emit_vehicle_qr_event(
+        db,
+        org_id=org_id,
+        actor_id=current_user.id,
+        action=SystemEventType.VEHICLE_QR_ROTATED.value,
+        vehicle_id=vehicle.unit_number,
+        payload={"token_sha256": hashlib.sha256(token.qr_token.encode()).hexdigest()},
+    )
+    db.commit()
+    return VehicleQrGenerateResponse(
+        vehicle_id=vehicle.unit_number,
+        qr_token=token.qr_token,
+        deployment_status="generated",
+    )
+
+
+@router.get("/org/vehicles/{vehicle_id}/qr/printable")
+def download_vehicle_qr_printable(
+    vehicle_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = _first_org_id(context)
+    vehicle = _get_required_vehicle(db, org_id=org_id, vehicle_id=vehicle_id)
+    token = (
+        db.query(VehicleQrToken)
+        .filter(
+            VehicleQrToken.org_id == org_id,
+            VehicleQrToken.adc_vehicle_id == vehicle.unit_number,
+            VehicleQrToken.status == "active",
+        )
+        .first()
+    )
+    if token is None:
+        raise HTTPException(status_code=404, detail="QR token not generated for vehicle")
+    vehicle.qr_deployment_status = "distributed"
+    vehicle.qr_distributed_at_utc = datetime.now(timezone.utc)
+    pdf_bytes = render_pdf(
+        "vehicle_qr_printable",
+        {"vehicle_id": vehicle.unit_number, "qr_token": token.qr_token},
+    )
+    _emit_vehicle_qr_event(
+        db,
+        org_id=org_id,
+        actor_id=current_user.id,
+        action="vehicle_qr_distributed",
+        vehicle_id=vehicle.unit_number,
+        payload={"artifact_type": "printable_pdf"},
+    )
+    db.commit()
+    return StreamingResponse(
+        iter([pdf_bytes]),
+        media_type="application/pdf",
+        headers={
+            "Content-Disposition": (
+                f'attachment; filename="vehicle-{vehicle.unit_number}-qr.pdf"'
+            )
+        },
+    )
+
+
+@router.get("/org/onboarding/qr-stats", response_model=VehicleQrStatsResponse)
+def get_org_onboarding_qr_stats(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    return _vehicle_qr_stats(db, org_id=_first_org_id(context))
 
 
 @router.post(

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -708,8 +708,35 @@ class VehicleQrDeploymentResponse(BaseModel):
     status: OnboardingReadinessStepStatus = "not_started"
     vehicles_total: int = Field(default=0, ge=0)
     qr_codes_generated: int = Field(default=0, ge=0)
-    qr_codes_activated: int = Field(default=0, ge=0)
+    qr_codes_distributed: int = Field(default=0, ge=0)
+    qr_codes_confirmed: int = Field(default=0, ge=0)
     last_rotated_at_utc: Optional[datetime] = None
+    coverage_blockers: list[ShortText] = Field(default_factory=list)
+
+
+class VehicleQrGenerateResponse(BaseModel):
+    vehicle_id: ShortText
+    qr_token: QrToken
+    deployment_status: Literal["generated", "distributed", "confirmed"] = "generated"
+
+
+class VehicleQrBulkGenerateRequest(BaseModel):
+    vehicle_ids: list[ShortText] = Field(default_factory=list, max_length=500)
+
+
+class VehicleQrBulkGenerateResponse(BaseModel):
+    generated_count: int = Field(default=0, ge=0)
+    skipped_count: int = Field(default=0, ge=0)
+    generated: list[VehicleQrGenerateResponse] = Field(default_factory=list)
+    skipped_vehicle_ids: list[ShortText] = Field(default_factory=list)
+
+
+class VehicleQrStatsResponse(BaseModel):
+    required_vehicle_count: int = Field(default=0, ge=0)
+    generated_count: int = Field(default=0, ge=0)
+    distributed_count: int = Field(default=0, ge=0)
+    confirmed_count: int = Field(default=0, ge=0)
+    coverage_blockers: list[ShortText] = Field(default_factory=list)
 
 
 class TestIncidentRunResponse(BaseModel):
@@ -763,6 +790,8 @@ class OrgMappingsStaleWarnings(BaseModel):
 class OrgMappingsPilotReadinessFlags(BaseModel):
     enough_mapped_drivers_for_pilot: bool = False
     enough_mapped_vehicles_for_pilot: bool = False
+    enough_qr_generated_for_required_vehicles: bool = False
+    enough_qr_distributed_for_required_vehicles: bool = False
     no_blocking_integration_credentials: bool = False
     pilot_scope_ready: bool = False
 

--- a/backend/app/db/migrations/versions/0021_add_vehicle_qr_deployment_fields.py
+++ b/backend/app/db/migrations/versions/0021_add_vehicle_qr_deployment_fields.py
@@ -1,0 +1,73 @@
+"""add vehicle qr deployment lifecycle fields
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-04-14 00:00:00.000000
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0021"
+down_revision: Union[str, None] = "0020"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+_vehicle_qr_status = sa.Enum(
+    "not_generated",
+    "generated",
+    "distributed",
+    "confirmed",
+    name="vehicle_qr_deployment_status",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    _vehicle_qr_status.create(bind, checkfirst=True)
+
+    op.add_column(
+        "org_vehicle_registry",
+        sa.Column(
+            "qr_deployment_status",
+            _vehicle_qr_status,
+            nullable=False,
+            server_default="not_generated",
+        ),
+    )
+    op.add_column(
+        "org_vehicle_registry",
+        sa.Column("qr_generated_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "org_vehicle_registry",
+        sa.Column("qr_distributed_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "org_vehicle_registry",
+        sa.Column("qr_confirmed_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_org_vehicle_registry_qr_deployment_status",
+        "org_vehicle_registry",
+        ["qr_deployment_status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_org_vehicle_registry_qr_deployment_status",
+        table_name="org_vehicle_registry",
+    )
+    op.drop_column("org_vehicle_registry", "qr_confirmed_at_utc")
+    op.drop_column("org_vehicle_registry", "qr_distributed_at_utc")
+    op.drop_column("org_vehicle_registry", "qr_generated_at_utc")
+    op.drop_column("org_vehicle_registry", "qr_deployment_status")
+
+    bind = op.get_bind()
+    _vehicle_qr_status.drop(bind, checkfirst=True)

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1467,6 +1467,22 @@ class OrgVehicleRegistry(Base):
     is_active = Column(
         Boolean, nullable=False, default=True, server_default=text("true")
     )
+    qr_deployment_status = Column(
+        Enum(
+            "not_generated",
+            "generated",
+            "distributed",
+            "confirmed",
+            name="vehicle_qr_deployment_status",
+        ),
+        nullable=False,
+        default="not_generated",
+        server_default="not_generated",
+        index=True,
+    )
+    qr_generated_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    qr_distributed_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    qr_confirmed_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
     created_at_utc = Column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
     )

--- a/backend/app/onboarding/blockers.py
+++ b/backend/app/onboarding/blockers.py
@@ -119,13 +119,13 @@ def classify_blockers(*, signals: OnboardingSignals) -> list[ClassifiedBlocker]:
 
     if (
         signals.vehicles_total > 0
-        and signals.qr_codes_activated < signals.vehicles_total
+        and signals.qr_codes_distributed < signals.vehicles_total
     ):
         blockers.append(
             ClassifiedBlocker(
                 code="vehicle_qr_incomplete",
                 title="Vehicle QR rollout incomplete",
-                detail="Generate and activate QR tokens for all active vehicles.",
+                detail="Generate and distribute QR tokens for all required active vehicles.",
                 severity="important",
                 blocking_step_key="vehicle_qr",
             )

--- a/backend/app/onboarding/models.py
+++ b/backend/app/onboarding/models.py
@@ -71,8 +71,10 @@ class VehicleQrDeployment:
     status: QrDeploymentStatus
     vehicles_total: int
     qr_codes_generated: int
-    qr_codes_activated: int
+    qr_codes_distributed: int
+    qr_codes_confirmed: int
     last_rotated_at_utc: datetime | None = None
+    coverage_blockers: list[str] = field(default_factory=list)
 
 
 @dataclass(slots=True)

--- a/backend/app/onboarding/progress.py
+++ b/backend/app/onboarding/progress.py
@@ -25,7 +25,8 @@ class OnboardingSignals:
     total_integration_count: int = 0
     vehicles_total: int = 0
     qr_codes_generated: int = 0
-    qr_codes_activated: int = 0
+    qr_codes_distributed: int = 0
+    qr_codes_confirmed: int = 0
     last_qr_rotation_at_utc: datetime | None = None
     protocol_configured: bool = False
     test_run_passed: bool = False
@@ -87,7 +88,7 @@ def derive_step_statuses(
         else "not_started",
         "vehicle_qr": "completed"
         if signals.vehicles_total > 0
-        and signals.qr_codes_activated >= signals.vehicles_total
+        and signals.qr_codes_distributed >= signals.vehicles_total
         else "in_progress"
         if signals.qr_codes_generated > 0
         else "not_started",

--- a/backend/app/onboarding/service.py
+++ b/backend/app/onboarding/service.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import distinct, func
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.db.models import (
     DriverInstructionSet,
     DriverInstructionStep,
     DriverImportJob,
-    DriverVehicleAssignment,
     Event,
     Export,
     ExternalMapping,
@@ -20,6 +19,7 @@ from app.db.models import (
     IntegrationOperation,
     Org,
     OrgOnboardingStepCompletion,
+    OrgVehicleRegistry,
     User,
     UserOrg,
     VehicleQrToken,
@@ -126,17 +126,39 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
     )
 
     vehicles_total = (
-        db.query(func.count(distinct(DriverVehicleAssignment.adc_vehicle_id)))
-        .filter(DriverVehicleAssignment.org_id == org_id)
+        db.query(func.count(OrgVehicleRegistry.vehicle_id))
+        .filter(
+            OrgVehicleRegistry.org_id == org_id,
+            OrgVehicleRegistry.is_active.is_(True),
+        )
         .scalar()
         or 0
     )
     qr_rows = db.query(VehicleQrToken).filter(VehicleQrToken.org_id == org_id).all()
     qr_codes_generated = len(qr_rows)
-    qr_codes_activated = sum(1 for row in qr_rows if row.status == "active")
     qr_rotation_times = [
         row.created_at_utc for row in qr_rows if row.created_at_utc is not None
     ]
+    qr_codes_distributed = (
+        db.query(func.count(OrgVehicleRegistry.vehicle_id))
+        .filter(
+            OrgVehicleRegistry.org_id == org_id,
+            OrgVehicleRegistry.is_active.is_(True),
+            OrgVehicleRegistry.qr_deployment_status.in_(["distributed", "confirmed"]),
+        )
+        .scalar()
+        or 0
+    )
+    qr_codes_confirmed = (
+        db.query(func.count(OrgVehicleRegistry.vehicle_id))
+        .filter(
+            OrgVehicleRegistry.org_id == org_id,
+            OrgVehicleRegistry.is_active.is_(True),
+            OrgVehicleRegistry.qr_deployment_status == "confirmed",
+        )
+        .scalar()
+        or 0
+    )
 
     instruction_set = (
         db.query(DriverInstructionSet)
@@ -205,7 +227,8 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
         total_integration_count=len(integration_rows),
         vehicles_total=vehicles_total,
         qr_codes_generated=qr_codes_generated,
-        qr_codes_activated=qr_codes_activated,
+        qr_codes_distributed=qr_codes_distributed,
+        qr_codes_confirmed=qr_codes_confirmed,
         last_qr_rotation_at_utc=max(qr_rotation_times) if qr_rotation_times else None,
         protocol_configured=protocol_configured,
         test_run_passed=test_run_passed,
@@ -290,14 +313,27 @@ def build_onboarding_readiness(
     qr_deployment = VehicleQrDeployment(
         status="completed"
         if signals.vehicles_total > 0
-        and signals.qr_codes_activated >= signals.vehicles_total
+        and signals.qr_codes_distributed >= signals.vehicles_total
         else "in_progress"
         if signals.qr_codes_generated > 0
         else "not_started",
         vehicles_total=signals.vehicles_total,
         qr_codes_generated=signals.qr_codes_generated,
-        qr_codes_activated=signals.qr_codes_activated,
+        qr_codes_distributed=signals.qr_codes_distributed,
+        qr_codes_confirmed=signals.qr_codes_confirmed,
         last_rotated_at_utc=signals.last_qr_rotation_at_utc,
+        coverage_blockers=[
+            *(
+                []
+                if signals.qr_codes_generated >= signals.vehicles_total
+                else ["required_vehicles_not_generated"]
+            ),
+            *(
+                []
+                if signals.qr_codes_distributed >= signals.vehicles_total
+                else ["required_vehicles_not_distributed"]
+            ),
+        ],
     )
 
     return OrgLaunchReadiness(

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -2307,16 +2307,41 @@ class TestOrgMappingsReadiness:
                     org_id=test_org.id,
                     unit_number="UNIT-001",
                     is_active=True,
+                    qr_deployment_status="distributed",
                 ),
                 OrgVehicleRegistry(
                     org_id=test_org.id,
                     unit_number="UNIT-002",
                     is_active=True,
+                    qr_deployment_status="distributed",
                 ),
                 OrgVehicleRegistry(
                     org_id=test_org.id,
                     unit_number="UNIT-003",
                     is_active=True,
+                    qr_deployment_status="confirmed",
+                ),
+            ]
+        )
+        db_session.add_all(
+            [
+                VehicleQrToken(
+                    qr_token="qr-u1",
+                    org_id=test_org.id,
+                    adc_vehicle_id="UNIT-001",
+                    status="active",
+                ),
+                VehicleQrToken(
+                    qr_token="qr-u2",
+                    org_id=test_org.id,
+                    adc_vehicle_id="UNIT-002",
+                    status="active",
+                ),
+                VehicleQrToken(
+                    qr_token="qr-u3",
+                    org_id=test_org.id,
+                    adc_vehicle_id="UNIT-003",
+                    status="active",
                 ),
             ]
         )
@@ -2410,6 +2435,8 @@ class TestOrgMappingsReadiness:
         assert payload["pilot_readiness"] == {
             "enough_mapped_drivers_for_pilot": True,
             "enough_mapped_vehicles_for_pilot": True,
+            "enough_qr_generated_for_required_vehicles": True,
+            "enough_qr_distributed_for_required_vehicles": True,
             "no_blocking_integration_credentials": True,
             "pilot_scope_ready": True,
         }
@@ -2450,11 +2477,69 @@ class TestOrgMappingsReadiness:
         assert "MAPPED_VEHICLES_REQUIRED" in codes
         assert "ASSIGNMENT_CONFIDENCE_LOW" in codes
         assert "BLOCKING_INTEGRATION_CREDENTIALS" in codes
+        assert "VEHICLE_QR_GENERATION_REQUIRED" in codes
+        assert "VEHICLE_QR_DISTRIBUTION_REQUIRED" in codes
         actions = {item["blocker_panel_action"] for item in payload["issues"]}
         assert "open_driver_mappings" in actions
         assert "open_vehicle_mappings" in actions
         assert "review_driver_assignments" in actions
         assert "fix_integration_credentials" in actions
+
+
+class TestVehicleQrDeploymentEndpoints:
+    def test_generate_bulk_rotate_printable_and_stats(
+        self, client, db_session, test_org, auth_headers
+    ):
+        db_session.add_all(
+            [
+                OrgVehicleRegistry(
+                    org_id=test_org.id,
+                    unit_number="UNIT-A",
+                    is_active=True,
+                ),
+                OrgVehicleRegistry(
+                    org_id=test_org.id,
+                    unit_number="UNIT-B",
+                    is_active=True,
+                ),
+            ]
+        )
+        db_session.commit()
+
+        one = client.post("/org/vehicles/UNIT-A/generate-qr", headers=auth_headers)
+        assert one.status_code == 200
+        first_token = one.json()["qr_token"]
+        assert one.json()["deployment_status"] == "generated"
+
+        bulk = client.post(
+            "/org/vehicles/bulk-generate-qr",
+            headers=auth_headers,
+            json={"vehicle_ids": ["UNIT-A", "UNIT-B", "UNKNOWN"]},
+        )
+        assert bulk.status_code == 200
+        payload = bulk.json()
+        assert payload["generated_count"] == 2
+        assert payload["skipped_count"] == 1
+        assert "UNKNOWN" in payload["skipped_vehicle_ids"]
+
+        rotated = client.post("/org/vehicles/UNIT-A/rotate-qr", headers=auth_headers)
+        assert rotated.status_code == 200
+        assert rotated.json()["qr_token"] != first_token
+
+        printable = client.get(
+            "/org/vehicles/UNIT-A/qr/printable",
+            headers=auth_headers,
+        )
+        assert printable.status_code == 200
+        assert printable.headers["content-type"].startswith("application/pdf")
+
+        stats = client.get("/org/onboarding/qr-stats", headers=auth_headers)
+        assert stats.status_code == 200
+        stats_payload = stats.json()
+        assert stats_payload["required_vehicle_count"] == 2
+        assert stats_payload["generated_count"] == 2
+        assert stats_payload["distributed_count"] == 1
+        assert "required_vehicles_not_distributed" in stats_payload["coverage_blockers"]
 
 
 # ── Health check ────────────────────────────────────────────────────

--- a/backend/tests/test_onboarding_service.py
+++ b/backend/tests/test_onboarding_service.py
@@ -66,7 +66,7 @@ def test_readiness_status_transitions_pilot_and_launch():
             total_integration_count=1,
             vehicles_total=2,
             qr_codes_generated=2,
-            qr_codes_activated=2,
+            qr_codes_distributed=2,
             protocol_configured=True,
             test_run_passed=True,
             export_validation_passed=True,


### PR DESCRIPTION
### Motivation
- Provide a full lifecycle for vehicle QR rollouts (generate → distribute → confirm) so onboarding readiness and pilot coverage can be accurately measured and acted on.
- Enable admin workflows to generate/rotate/print QR tokens and expose QR coverage stats for onboarding/dashboard UIs.

### Description
- Added QR lifecycle columns to vehicle registry: `qr_deployment_status` enum (`not_generated`, `generated`, `distributed`, `confirmed`) and timestamps `qr_generated_at_utc`, `qr_distributed_at_utc`, `qr_confirmed_at_utc`, plus Alembic migration `0021` to create the enum/columns/index. (`OrgVehicleRegistry` model).
- Implemented org-scoped QR management endpoints: `POST /org/vehicles/{vehicle_id}/generate-qr`, `POST /org/vehicles/bulk-generate-qr`, `POST /org/vehicles/{vehicle_id}/rotate-qr`, and `GET /org/vehicles/{vehicle_id}/qr/printable` which update deployment state and emit events; printable returns a PDF via `StreamingResponse` (uses `render_pdf`).
- Added `GET /org/onboarding/qr-stats` to provide required/generated/distributed/confirmed counts and coverage blockers for onboarding cards.
- When a driver resolves a QR (`POST /driver/vehicle/resolve-qr`), the matching `OrgVehicleRegistry` row is marked `confirmed` and `qr_confirmed_at_utc` is set, completing the lifecycle on successful driver scan.
- Extended onboarding signal pipeline, models, and API schemas to include distributed/confirmed counts and coverage blockers, and wired QR coverage into pilot readiness and mapping issues (new flags and blocker codes such as `VEHICLE_QR_GENERATION_REQUIRED` and `VEHICLE_QR_DISTRIBUTION_REQUIRED`).
- Added API request/response schemas for generation/bulk responses and QR stats and updated unit tests to cover the new behavior.

### Testing
- Ran linter: `cd backend && ruff check app tests` and it passed.
- Ran focused API/onboarding/driver-admin tests: `cd backend && pytest tests/test_onboarding_service.py tests/test_api_endpoints.py tests/test_driver_admin_endpoints.py` and all tests passed (test run reported 123 passed, 3 warnings).
- Ran migration integrity check: `cd backend && pytest tests/test_migration_integrity.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deaac21b888321b9de2f0ee38491b9)