### PR TITLE
Add ProtocolSetupStep onboarding contract, gating, and API endpoint

### DIFF
--- a/backend/app/api/routes_integrations.py
+++ b/backend/app/api/routes_integrations.py
@@ -42,6 +42,7 @@ from app.api.schemas import (
     OrgMappingsSummaryCounts,
     OrgMappingsSummaryResponse,
     OrgOnboardingStepUpdateRequest,
+    ProtocolSetupStepResponse,
     OrgSettingsResponse,
     OrgSettingsUpdateRequest,
     OrgPatchUserRoleRequest,
@@ -101,6 +102,7 @@ from app.services.driver_import_service import (
 from app.onboarding.progress import STEP_DEFINITIONS
 from app.onboarding.service import (
     collect_onboarding_signals,
+    get_protocol_setup_step,
     get_org_onboarding_readiness,
     set_step_completion_override,
 )
@@ -619,6 +621,19 @@ def get_org_onboarding_status(
     context = build_user_auth_context(db, current_user)
     readiness = get_org_onboarding_readiness(db, org_id=_first_org_id(context))
     return _to_readiness_response(readiness)
+
+
+@router.get(
+    "/org/onboarding/protocol-setup-step",
+    response_model=ProtocolSetupStepResponse,
+)
+def get_org_onboarding_protocol_setup_step(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    step = get_protocol_setup_step(db, org_id=_first_org_id(context))
+    return ProtocolSetupStepResponse.model_validate(asdict(step))
 
 
 @router.get("/org/mappings/summary", response_model=OrgMappingsSummaryResponse)

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -768,6 +768,16 @@ class OrgOnboardingStepUpdateRequest(BaseModel):
     source: ShortText = "manual"
 
 
+class ProtocolSetupStepResponse(BaseModel):
+    instruction_set_selected: bool = False
+    instruction_source: InstructionScope = "default"
+    safety_contact_configured: bool = False
+    safety_manager_phone: Optional[PhoneE164] = None
+    required_media_prompts_defaulted: bool = False
+    export_profile_defaulted: bool = False
+    export_profiles_available: list[ShortText] = Field(default_factory=list)
+
+
 class OrgMappingsSummaryCounts(BaseModel):
     total: int = Field(default=0, ge=0)
     mapped: int = Field(default=0, ge=0)

--- a/backend/app/onboarding/blockers.py
+++ b/backend/app/onboarding/blockers.py
@@ -131,12 +131,32 @@ def classify_blockers(*, signals: OnboardingSignals) -> list[ClassifiedBlocker]:
             )
         )
 
-    if not signals.protocol_configured:
+    if not signals.protocol_instruction_set_active:
         blockers.append(
             ClassifiedBlocker(
-                code="driver_protocol_missing",
-                title="Driver protocol not configured",
-                detail="Enable driver acknowledgement workflow and publish instruction steps.",
+                code="driver_protocol_instruction_set_missing",
+                title="Driver instruction set missing",
+                detail="Select an active instruction set with at least one enabled instruction step.",
+                severity="critical",
+                blocking_step_key="driver_protocol",
+            )
+        )
+    if not signals.safety_contact_configured:
+        blockers.append(
+            ClassifiedBlocker(
+                code="driver_protocol_safety_contact_missing",
+                title="Safety contact not configured",
+                detail="Configure a safety contact phone number for the protocol escalation workflow.",
+                severity="critical",
+                blocking_step_key="driver_protocol",
+            )
+        )
+    if not signals.export_profiles_available:
+        blockers.append(
+            ClassifiedBlocker(
+                code="driver_protocol_export_profile_missing",
+                title="No export profile available",
+                detail="At least one export profile must be available before protocol setup can complete.",
                 severity="critical",
                 blocking_step_key="driver_protocol",
             )

--- a/backend/app/onboarding/models.py
+++ b/backend/app/onboarding/models.py
@@ -87,6 +87,17 @@ class TestIncidentRun:
 
 
 @dataclass(slots=True)
+class ProtocolSetupStep:
+    instruction_set_selected: bool
+    instruction_source: str
+    safety_contact_configured: bool
+    safety_manager_phone: str | None
+    required_media_prompts_defaulted: bool
+    export_profile_defaulted: bool
+    export_profiles_available: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
 class OrgLaunchReadiness:
     org_id: str
     status: ReadinessStatus

--- a/backend/app/onboarding/progress.py
+++ b/backend/app/onboarding/progress.py
@@ -28,6 +28,11 @@ class OnboardingSignals:
     qr_codes_distributed: int = 0
     qr_codes_confirmed: int = 0
     last_qr_rotation_at_utc: datetime | None = None
+    protocol_instruction_set_active: bool = False
+    safety_contact_configured: bool = False
+    export_profiles_available: bool = False
+    required_media_prompts_defaulted: bool = False
+    export_profile_defaulted: bool = False
     protocol_configured: bool = False
     test_run_passed: bool = False
     export_validation_passed: bool = False

--- a/backend/app/onboarding/service.py
+++ b/backend/app/onboarding/service.py
@@ -29,6 +29,7 @@ from app.onboarding.models import (
     ImportJob,
     IntegrationValidationResult,
     OrgLaunchReadiness,
+    ProtocolSetupStep,
     TestIncidentRun,
     VehicleQrDeployment,
 )
@@ -39,6 +40,7 @@ from app.onboarding.progress import (
 )
 from app.onboarding.readiness import derive_readiness_status
 from app.security.permissions import Capability, has_capability
+from app.domain.packet_profiles import DEFAULT_PROFILE_BY_EXPORT_TYPE
 
 
 def _organization_basics_complete(org: Org) -> bool:
@@ -160,9 +162,11 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
         or 0
     )
 
+    active_scope = org.instruction_source or "default"
     instruction_set = (
         db.query(DriverInstructionSet)
         .filter(DriverInstructionSet.org_id == org_id)
+        .filter(DriverInstructionSet.scope == active_scope)
         .order_by(DriverInstructionSet.created_at_utc.desc())
         .first()
     )
@@ -177,7 +181,18 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
             )
             .count()
         )
-    protocol_configured = bool(org.require_driver_ack and enabled_step_count > 0)
+    protocol_instruction_set_active = bool(
+        instruction_set is not None and enabled_step_count > 0
+    )
+    safety_contact_configured = bool(org.safety_manager_phone)
+    export_profiles_available = len(DEFAULT_PROFILE_BY_EXPORT_TYPE) > 0
+    required_media_prompts_defaulted = protocol_instruction_set_active
+    export_profile_defaulted = export_profiles_available
+    protocol_configured = bool(
+        protocol_instruction_set_active
+        and safety_contact_configured
+        and export_profiles_available
+    )
 
     test_run_event = (
         db.query(Event)
@@ -230,6 +245,11 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
         qr_codes_distributed=qr_codes_distributed,
         qr_codes_confirmed=qr_codes_confirmed,
         last_qr_rotation_at_utc=max(qr_rotation_times) if qr_rotation_times else None,
+        protocol_instruction_set_active=protocol_instruction_set_active,
+        safety_contact_configured=safety_contact_configured,
+        export_profiles_available=export_profiles_available,
+        required_media_prompts_defaulted=required_media_prompts_defaulted,
+        export_profile_defaulted=export_profile_defaulted,
         protocol_configured=protocol_configured,
         test_run_passed=test_run_passed,
         export_validation_passed=export_validation_passed,
@@ -358,6 +378,32 @@ def get_org_onboarding_readiness(
     overrides = list_step_completion_overrides(db, org_id=org_id)
     return build_onboarding_readiness(
         org_id=org_id, signals=signals, step_completion_overrides=overrides
+    )
+
+
+def get_protocol_setup_step(
+    db: Session, *, org_id: uuid.UUID
+) -> ProtocolSetupStep:
+    signals = collect_onboarding_signals(db, org_id=org_id)
+    org = db.query(Org).filter(Org.id == org_id).first()
+    if org is None:
+        return ProtocolSetupStep(
+            instruction_set_selected=False,
+            instruction_source="default",
+            safety_contact_configured=False,
+            safety_manager_phone=None,
+            required_media_prompts_defaulted=False,
+            export_profile_defaulted=False,
+            export_profiles_available=[],
+        )
+    return ProtocolSetupStep(
+        instruction_set_selected=signals.protocol_instruction_set_active,
+        instruction_source=org.instruction_source or "default",
+        safety_contact_configured=signals.safety_contact_configured,
+        safety_manager_phone=org.safety_manager_phone,
+        required_media_prompts_defaulted=signals.required_media_prompts_defaulted,
+        export_profile_defaulted=signals.export_profile_defaulted,
+        export_profiles_available=sorted(DEFAULT_PROFILE_BY_EXPORT_TYPE.values()),
     )
 
 

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -24,6 +24,8 @@ from app.db.models import (
     IntegrationOperation,
     EvidenceRequest,
     Driver,
+    DriverInstructionSet,
+    DriverInstructionStep,
     DriverVehicleAssignment,
     ExternalMapping,
     VehicleQrToken,
@@ -459,6 +461,45 @@ class TestIntegrationDiagnosticsRoutes:
             item for item in refreshed.json()["steps"] if item["key"] == "org_settings"
         )
         assert refreshed_step["status"] == "completed"
+
+    def test_onboarding_protocol_setup_step_contract(
+        self, client, db_session, test_org, auth_headers
+    ):
+        initial = client.get(
+            "/org/onboarding/protocol-setup-step", headers=auth_headers
+        )
+        assert initial.status_code == 200
+        payload = initial.json()
+        assert payload["instruction_set_selected"] is False
+        assert payload["safety_contact_configured"] is False
+        assert payload["required_media_prompts_defaulted"] is False
+        assert payload["export_profile_defaulted"] is True
+        assert len(payload["export_profiles_available"]) >= 1
+
+        test_org.safety_manager_phone = "+15551234567"
+        test_org.instruction_source = "default"
+        db_session.add(test_org)
+        db_session.flush()
+        instruction_set = DriverInstructionSet(org_id=test_org.id, scope="default")
+        db_session.add(instruction_set)
+        db_session.flush()
+        db_session.add(
+            DriverInstructionStep(
+                instruction_set_id=instruction_set.instruction_set_id,
+                step_order=1,
+                title="Document the scene",
+                body="Capture photos and videos when safe.",
+                enabled=True,
+            )
+        )
+        db_session.commit()
+
+        refreshed = client.get("/org/onboarding/status", headers=auth_headers)
+        assert refreshed.status_code == 200
+        driver_protocol_step = next(
+            item for item in refreshed.json()["steps"] if item["key"] == "driver_protocol"
+        )
+        assert driver_protocol_step["status"] == "completed"
 
     def test_org_integrations_and_details(
         self, client, db_session, test_org, auth_headers

--- a/backend/tests/test_onboarding_service.py
+++ b/backend/tests/test_onboarding_service.py
@@ -115,3 +115,30 @@ def test_driver_import_step_completion_signal():
     )
     by_key = {step.key: step for step in steps}
     assert by_key["driversImported"].status == "completed"
+
+
+def test_protocol_setup_completion_rule_and_blockers():
+    blockers = classify_blockers(
+        signals=OnboardingSignals(
+            protocol_instruction_set_active=False,
+            safety_contact_configured=False,
+            export_profiles_available=False,
+            protocol_configured=False,
+        )
+    )
+    blocker_codes = {blocker.code for blocker in blockers}
+    assert "driver_protocol_instruction_set_missing" in blocker_codes
+    assert "driver_protocol_safety_contact_missing" in blocker_codes
+    assert "driver_protocol_export_profile_missing" in blocker_codes
+
+    steps = derive_step_statuses(
+        signals=OnboardingSignals(
+            protocol_instruction_set_active=True,
+            safety_contact_configured=True,
+            export_profiles_available=True,
+            protocol_configured=True,
+        ),
+        blocked_step_keys=set(),
+    )
+    by_key = {step.key: step for step in steps}
+    assert by_key["driver_protocol"].status == "completed"

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -493,6 +493,20 @@ export function resetDriverProtocolInstructions(scope?: string) {
   );
 }
 
+export interface ProtocolSetupStepData {
+  instruction_set_selected: boolean;
+  instruction_source: "default" | "company" | "insurer";
+  safety_contact_configured: boolean;
+  safety_manager_phone: string | null;
+  required_media_prompts_defaulted: boolean;
+  export_profile_defaulted: boolean;
+  export_profiles_available: string[];
+}
+
+export function getProtocolSetupStepData() {
+  return request<ProtocolSetupStepData>("/org/onboarding/protocol-setup-step");
+}
+
 /* ── Admin vehicles ─────────────────────────────────────────────── */
 
 export interface AdminVehicle {


### PR DESCRIPTION
### Motivation

- Introduce explicit backend support and a frontend page contract for the protocol setup step so the UI can render and drive driver-protocol setup.
- Enforce a strict MVP completion rule for the driver protocol step: an active instruction set for the org's selected instruction scope, a configured safety contact, and at least one export profile available.
- Surface missing prerequisites as readiness blockers so failures are visible in onboarding/readiness flows.

### Description

- Added a new `ProtocolSetupStep` dataclass to the onboarding domain to represent page-ready protocol setup data (instruction set selected, instruction source, safety contact flags, required media/export defaults, and available export profiles). (`backend/app/onboarding/models.py`)
- Extended `OnboardingSignals` with protocol-related flags and updated `collect_onboarding_signals` to detect the active instruction set for the org's `instruction_source`, whether a safety contact is configured, and whether export profiles exist; these flags are used to derive `protocol_configured`. (`backend/app/onboarding/progress.py`, `backend/app/onboarding/service.py`)
- Replaced the single generic driver-protocol blocker with explicit prerequisite blockers (`driver_protocol_instruction_set_missing`, `driver_protocol_safety_contact_missing`, `driver_protocol_export_profile_missing`) and wire them to block the `driver_protocol` step. (`backend/app/onboarding/blockers.py`)
- Exposed a new API contract `ProtocolSetupStepResponse` and route `GET /org/onboarding/protocol-setup-step` returning the `ProtocolSetupStep` payload for frontend consumption. (`backend/app/api/schemas.py`, `backend/app/api/routes_integrations.py`)
- Added a TypeScript interface and helper `getProtocolSetupStepData()` to the frontend API wrapper so pages/components can request the setup payload. (`frontend/lib/api.ts`)
- Added and updated unit/integration tests validating blocker classification, driver protocol completion rule, and the new protocol setup endpoint contract and end-to-end readiness transition. (`backend/tests/test_onboarding_service.py`, `backend/tests/test_api_endpoints.py`)

### Testing

- Ran backend unit tests: `cd backend && pytest tests/test_onboarding_service.py tests/test_api_endpoints.py -q` and the broader test suite; all tests passed (reported `85 passed`).
- Ran backend linter: `cd backend && ruff check app tests` and formatter checks; linter passed.
- Ran frontend checks: `cd frontend && npm run lint` and `cd frontend && npm run typecheck`; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb0140aa083219c568f0d34ae7763)