### PR TITLE
Add integration provider upsert, validation diagnostics, and persisted validation results

### DIFF
--- a/backend/app/api/routes_integrations.py
+++ b/backend/app/api/routes_integrations.py
@@ -28,8 +28,10 @@ from app.api.schemas import (
     EvidenceRetryActionResponse,
     EvidenceSummaryResponse,
     IntegrationConnectionHealthResponse,
+    IntegrationConnectionUpsertRequest,
     IntegrationConnectionUpdateRequest,
     IntegrationConnectionValidateResponse,
+    IntegrationValidationResultResponse,
     IntegrationOperationDiagnosticsResponse,
     OrgLaunchReadinessResponse,
     OrgInviteUserRequest,
@@ -64,6 +66,7 @@ from app.db.models import (
     EvidenceRequest,
     IntegrationConnection,
     IntegrationOperation,
+    IntegrationValidationResult,
     OrgUserInvite,
     Org,
     User,
@@ -123,6 +126,7 @@ _PILOT_MIN_MAPPED_DRIVERS = 3
 _PILOT_MIN_MAPPED_VEHICLES = 3
 _ASSIGNMENT_CONFIDENCE_MEDIUM_THRESHOLD = 0.7
 _ASSIGNMENT_CONFIDENCE_HIGH_THRESHOLD = 0.9
+_PILOT_REQUIRED_DOMAINS = {"telematics", "messaging"}
 
 
 def _first_org_id(context) -> uuid.UUID:
@@ -388,6 +392,76 @@ def _build_org_mapping_issues(
         )
 
     return OrgMappingsIssuesResponse(issues=issues)
+
+
+def _evaluate_integration_validation(
+    *,
+    db: Session,
+    org_id: uuid.UUID,
+    row: IntegrationConnection,
+) -> tuple[str, str, str, list[str], bool, str]:
+    messages: list[str] = []
+
+    credential_status = "pass"
+    if not row.credentials_ref:
+        credential_status = "fail"
+        messages.append(
+            f"Add credentials for {row.provider}/{row.domain} to enable validation."
+        )
+    elif row.status == "inactive":
+        credential_status = "fail"
+        messages.append(
+            f"Enable {row.provider}/{row.domain}; inactive integrations cannot pass validation."
+        )
+
+    org_connections = (
+        db.query(IntegrationConnection).filter(IntegrationConnection.org_id == org_id).all()
+    )
+    active_domains = {
+        str(connection.domain).lower()
+        for connection in org_connections
+        if connection.status == "active" and connection.domain
+    }
+    missing_required_domains = sorted(_PILOT_REQUIRED_DOMAINS - active_domains)
+    if not missing_required_domains:
+        capability_status = "pass"
+    elif row.domain and str(row.domain).lower() in _PILOT_REQUIRED_DOMAINS:
+        capability_status = "partial_support"
+        messages.append(
+            "Pilot readiness requires both telematics and messaging providers; "
+            f"still missing: {', '.join(missing_required_domains)}."
+        )
+    else:
+        capability_status = "fail"
+        messages.append(
+            "Selected provider does not satisfy pilot-required capabilities. "
+            "Configure active telematics and messaging integrations."
+        )
+
+    mapping_summary = _build_org_mapping_summary(db, org_id=org_id)
+    if (
+        mapping_summary.pilot_readiness.enough_mapped_drivers_for_pilot
+        and mapping_summary.pilot_readiness.enough_mapped_vehicles_for_pilot
+    ):
+        mapping_status = "pass"
+    elif mapping_summary.drivers.mapped > 0 or mapping_summary.vehicles.mapped > 0:
+        mapping_status = "partial_support"
+        messages.append(
+            "Mapping is partially complete. Map at least "
+            f"{_PILOT_MIN_MAPPED_DRIVERS} drivers and {_PILOT_MIN_MAPPED_VEHICLES} vehicles."
+        )
+    else:
+        mapping_status = "fail"
+        messages.append(
+            "No provider mappings found. Map drivers and vehicles before pilot launch."
+        )
+
+    valid = all(
+        status == "pass"
+        for status in (credential_status, capability_status, mapping_status)
+    )
+    message = "Connection validated" if valid else "Validation failed with actionable blockers"
+    return credential_status, capability_status, mapping_status, messages, valid, message
 
 
 def _run_vehicle_import_background(
@@ -1224,6 +1298,82 @@ def list_org_integrations(
     ]
 
 
+@router.post(
+    "/org/integrations",
+    response_model=IntegrationConnectionHealthResponse,
+)
+def upsert_org_integration(
+    payload: IntegrationConnectionUpsertRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(_integration_admin),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = _first_org_id(context)
+    row = (
+        db.query(IntegrationConnection)
+        .filter(
+            IntegrationConnection.org_id == org_id,
+            IntegrationConnection.provider == payload.provider,
+            IntegrationConnection.domain == payload.domain,
+        )
+        .first()
+    )
+    if row is None:
+        row = IntegrationConnection(
+            org_id=org_id,
+            provider=payload.provider,
+            domain=payload.domain,
+        )
+
+    row.status = payload.status
+    row.credentials_ref = payload.credentials_ref
+    row.config_json = payload.config_json
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+
+    return IntegrationConnectionHealthResponse(
+        integration_id=row.connection_id,
+        provider=row.provider,
+        domain=row.domain,
+        status=row.status,
+        healthy=row.status in {"active", "pending"},
+        reason=None
+        if row.status in {"active", "pending"}
+        else "Connection not healthy",
+        last_synced_at_utc=row.last_synced_at_utc,
+        updated_at_utc=row.updated_at_utc,
+    )
+
+
+@router.get(
+    "/org/integrations/validation-results",
+    response_model=list[IntegrationValidationResultResponse],
+)
+def list_org_integration_validation_results(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    rows = (
+        db.query(IntegrationValidationResult)
+        .filter(IntegrationValidationResult.org_id.in_(context.org_ids))
+        .order_by(IntegrationValidationResult.validated_at_utc.desc())
+        .all()
+    )
+    return [
+        IntegrationValidationResultResponse(
+            integration_id=row.connection_id,
+            credentialStatus=row.credential_status,
+            capabilityStatus=row.capability_status,
+            mappingStatus=row.mapping_status,
+            messages=list(row.messages_json or []),
+            timestamp=row.validated_at_utc,
+        )
+        for row in rows
+    ]
+
+
 @router.get(
     "/org/integrations/{integration_id}",
     response_model=IntegrationConnectionHealthResponse,
@@ -1279,14 +1429,36 @@ def validate_org_integration(
     if row is None:
         raise HTTPException(status_code=404, detail="Integration not found")
 
-    valid = bool(row.credentials_ref) and row.status != "inactive"
+    (
+        credential_status,
+        capability_status,
+        mapping_status,
+        messages,
+        valid,
+        message,
+    ) = _evaluate_integration_validation(db=db, org_id=row.org_id, row=row)
+    validation = IntegrationValidationResult(
+        org_id=row.org_id,
+        connection_id=row.connection_id,
+        credential_status=credential_status,
+        capability_status=capability_status,
+        mapping_status=mapping_status,
+        messages_json=messages,
+        validated_at_utc=datetime.now(timezone.utc),
+    )
+    db.add(validation)
+    db.commit()
+
     return IntegrationConnectionValidateResponse(
         integration_id=row.connection_id,
         valid=valid,
         status=row.status,
-        message="Connection validated"
-        if valid
-        else "Connection missing credentials or disabled",
+        message=message,
+        credentialStatus=credential_status,
+        capabilityStatus=capability_status,
+        mappingStatus=mapping_status,
+        messages=messages,
+        timestamp=validation.validated_at_utc,
     )
 
 

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -1332,6 +1332,7 @@ class IntegrationHealthItem(BaseModel):
 
 
 IntegrationConnectionStatus = Literal["pending", "active", "inactive", "error"]
+IntegrationValidationStatus = Literal["pass", "fail", "partial_support"]
 IntegrationOperationStatus = Literal[
     "requested",
     "submitted_to_provider",
@@ -1367,11 +1368,33 @@ class IntegrationConnectionUpdateRequest(BaseModel):
     config_json: dict[str, Any] | None = None
 
 
+class IntegrationConnectionUpsertRequest(BaseModel):
+    provider: str = Field(min_length=1, max_length=128)
+    domain: str = Field(min_length=1, max_length=128)
+    status: IntegrationConnectionStatus = "pending"
+    credentials_ref: str | None = None
+    config_json: dict[str, Any] = Field(default_factory=dict)
+
+
 class IntegrationConnectionValidateResponse(BaseModel):
     integration_id: uuid.UUID
     valid: bool
     status: IntegrationConnectionStatus
     message: str
+    credentialStatus: IntegrationValidationStatus
+    capabilityStatus: IntegrationValidationStatus
+    mappingStatus: IntegrationValidationStatus
+    messages: list[str] = Field(default_factory=list)
+    timestamp: datetime
+
+
+class IntegrationValidationResultResponse(BaseModel):
+    integration_id: uuid.UUID | None = None
+    credentialStatus: IntegrationValidationStatus
+    capabilityStatus: IntegrationValidationStatus
+    mappingStatus: IntegrationValidationStatus
+    messages: list[str] = Field(default_factory=list)
+    timestamp: datetime
 
 
 class IntegrationOperationDiagnosticsResponse(BaseModel):

--- a/backend/app/db/migrations/versions/0022_add_integration_validation_results_table.py
+++ b/backend/app/db/migrations/versions/0022_add_integration_validation_results_table.py
@@ -1,0 +1,95 @@
+"""add integration validation results table
+
+Revision ID: 0022
+Revises: 0021
+Create Date: 2026-04-14 00:00:00.000000
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0022"
+down_revision: Union[str, None] = "0021"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "integration_validation_results",
+        sa.Column(
+            "validation_result_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("connection_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("credential_status", sa.Text(), nullable=False),
+        sa.Column("capability_status", sa.Text(), nullable=False),
+        sa.Column("mapping_status", sa.Text(), nullable=False),
+        sa.Column(
+            "messages_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'"),
+        ),
+        sa.Column(
+            "validated_at_utc",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "created_at_utc",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at_utc",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.ForeignKeyConstraint(
+            ["connection_id"], ["integration_connections.connection_id"]
+        ),
+    )
+    op.create_index(
+        "ix_integration_validation_results_org_id",
+        "integration_validation_results",
+        ["org_id"],
+    )
+    op.create_index(
+        "ix_integration_validation_results_connection_id",
+        "integration_validation_results",
+        ["connection_id"],
+    )
+    op.create_index(
+        "ix_integration_validation_results_validated_at_utc",
+        "integration_validation_results",
+        ["validated_at_utc"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_integration_validation_results_validated_at_utc",
+        table_name="integration_validation_results",
+    )
+    op.drop_index(
+        "ix_integration_validation_results_connection_id",
+        table_name="integration_validation_results",
+    )
+    op.drop_index(
+        "ix_integration_validation_results_org_id",
+        table_name="integration_validation_results",
+    )
+    op.drop_table("integration_validation_results")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -752,6 +752,41 @@ class IntegrationOperation(Base):
     )
 
 
+class IntegrationValidationResult(Base):
+    """Persisted integration validation outcomes for org onboarding UX."""
+
+    __tablename__ = "integration_validation_results"
+
+    validation_result_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    connection_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("integration_connections.connection_id"),
+        nullable=True,
+        index=True,
+    )
+    credential_status = Column(Text, nullable=False)
+    capability_status = Column(Text, nullable=False)
+    mapping_status = Column(Text, nullable=False)
+    messages_json = Column(
+        JSONB, nullable=False, default=list, server_default=text("'[]'")
+    )
+    validated_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now(), index=True
+    )
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
 class IntegrationOperationStatusHistory(Base):
     """Append-only status transitions for integration operations."""
 

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -21,6 +21,7 @@ from app.db.models import (
     Org,
     UserOrg,
     IntegrationConnection,
+    IntegrationValidationResult,
     IntegrationOperation,
     EvidenceRequest,
     Driver,
@@ -525,6 +526,55 @@ class TestIntegrationDiagnosticsRoutes:
         assert detail_resp.status_code == 200
         assert detail_resp.json()["provider"] == "samsara"
 
+    def test_org_integration_provider_selection_and_credentials_upsert(
+        self, client, db_session, test_user, test_org
+    ):
+        test_user.role = "org_admin"
+        db_session.add(test_user)
+        db_session.commit()
+        headers = {
+            "Authorization": f"Bearer {create_access_token({'sub': str(test_user.id), 'role': 'org_admin'})}"
+        }
+
+        create_resp = client.post(
+            "/org/integrations",
+            headers=headers,
+            json={
+                "provider": "twilio",
+                "domain": "messaging",
+                "status": "active",
+                "credentials_ref": "vault://twilio-primary",
+                "config_json": {"accountSid": "AC123"},
+            },
+        )
+        assert create_resp.status_code == 200
+
+        update_resp = client.post(
+            "/org/integrations",
+            headers=headers,
+            json={
+                "provider": "twilio",
+                "domain": "messaging",
+                "status": "active",
+                "credentials_ref": "vault://twilio-updated",
+                "config_json": {"accountSid": "AC999"},
+            },
+        )
+        assert update_resp.status_code == 200
+
+        rows = (
+            db_session.query(IntegrationConnection)
+            .filter(
+                IntegrationConnection.org_id == test_org.id,
+                IntegrationConnection.provider == "twilio",
+                IntegrationConnection.domain == "messaging",
+            )
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].credentials_ref == "vault://twilio-updated"
+        assert rows[0].config_json["accountSid"] == "AC999"
+
     def test_org_users_list_invite_patch_role_resend_deactivate(
         self, client, db_session, test_org, test_user
     ):
@@ -707,6 +757,57 @@ class TestIntegrationDiagnosticsRoutes:
             headers=org_admin_headers,
         )
         assert allowed.status_code == 200
+        payload = allowed.json()
+        assert "credentialStatus" in payload
+        assert "capabilityStatus" in payload
+        assert "mappingStatus" in payload
+        assert "messages" in payload
+        assert "timestamp" in payload
+
+    def test_integration_validation_results_endpoint_and_partial_support(
+        self, client, db_session, test_org, test_user
+    ):
+        test_user.role = "org_admin"
+        db_session.add(test_user)
+        db_session.commit()
+        headers = {
+            "Authorization": f"Bearer {create_access_token({'sub': str(test_user.id), 'role': 'org_admin'})}"
+        }
+
+        telematics = IntegrationConnection(
+            org_id=test_org.id,
+            provider="samsara",
+            domain="telematics",
+            status="active",
+            credentials_ref="vault://samsara",
+        )
+        db_session.add(telematics)
+        db_session.commit()
+        db_session.refresh(telematics)
+
+        validate_resp = client.post(
+            f"/org/integrations/{telematics.connection_id}/validate", headers=headers
+        )
+        assert validate_resp.status_code == 200
+        payload = validate_resp.json()
+        assert payload["credentialStatus"] == "pass"
+        assert payload["capabilityStatus"] == "partial_support"
+        assert payload["mappingStatus"] == "fail"
+        assert payload["valid"] is False
+        assert len(payload["messages"]) > 0
+
+        list_resp = client.get(
+            "/org/integrations/validation-results",
+            headers=headers,
+        )
+        assert list_resp.status_code == 200
+        listed = list_resp.json()
+        assert len(listed) == 1
+        assert listed[0]["integration_id"] == str(telematics.connection_id)
+        assert listed[0]["capabilityStatus"] == "partial_support"
+
+        stored = db_session.query(IntegrationValidationResult).all()
+        assert len(stored) == 1
 
     @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_get_incident_returns_created_at(


### PR DESCRIPTION
### Motivation
- Provide a simple org-scoped provider selection and credential save/update flow so admins can create or update an integration by `(provider, domain)` without creating duplicates.
- Surface actionable pass/fail/partial-support validation information for the UI and persist validation runs for historical inspection.
- Enforce pilot readiness rules (minimum telematics + messaging) and treat partial configurations as `partial_support` to guide remediation.

### Description
- Add `POST /org/integrations` to upsert an `IntegrationConnection` per `(org_id, provider, domain)` and persist `status`, `credentials_ref`, and `config_json` via `IntegrationConnectionUpsertRequest`.
- Extend `POST /org/integrations/{integration_id}/validate` to compute `credentialStatus`, `capabilityStatus`, and `mappingStatus`, return actionable `messages` and a `timestamp`, and persist each run to a new `integration_validation_results` table.
- Add `GET /org/integrations/validation-results` to list recent validation runs as `IntegrationValidationResultResponse` including `credentialStatus`, `capabilityStatus`, `mappingStatus`, `messages`, and `timestamp`.
- Implement pilot readiness logic requiring active `telematics` and `messaging` domains (returns `partial_support` when only one required domain is satisfied) and mapping readiness checks; surface clear user-facing messages when checks fail.
- Add DB model `IntegrationValidationResult` and Alembic migration `0022_add_integration_validation_results_table.py`.
- Update API schemas (`IntegrationConnectionUpsertRequest`, extended `IntegrationConnectionValidateResponse`, `IntegrationValidationResultResponse`) and expand tests to cover provider upsert, validate response contract, partial-support behavior, persistence, and listing.

### Testing
- Ran linter: `make lint` (ruff checks) and the lint step passed.
- Ran API tests: `cd backend && pytest tests/test_api_endpoints.py -q` which completed successfully (tests in that file passed; output showed 82 passed with 3 warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb2c14f108321855eb8e9ef62b209)