### PR TITLE
Add org test-run APIs, persist per-step results, tie to readiness and exclude test incidents from analytics

### DIFF
--- a/backend/app/api/routes_integrations.py
+++ b/backend/app/api/routes_integrations.py
@@ -48,6 +48,10 @@ from app.api.schemas import (
     OrgSettingsResponse,
     OrgSettingsUpdateRequest,
     OrgPatchUserRoleRequest,
+    TestIncidentRunCreateRequest,
+    TestIncidentRunResponse,
+    TestIncidentRunsResponse,
+    TestIncidentRunStepCompleteRequest,
     OrgUserInviteSummary,
     OrgUserSummary,
     OrgUsersResponse,
@@ -104,9 +108,13 @@ from app.services.driver_import_service import (
 )
 from app.onboarding.progress import STEP_DEFINITIONS
 from app.onboarding.service import (
+    complete_test_incident_run_step,
     collect_onboarding_signals,
+    create_test_incident_run,
+    get_test_incident_run_by_id,
     get_protocol_setup_step,
     get_org_onboarding_readiness,
+    list_test_incident_runs,
     set_step_completion_override,
 )
 from app.security.permissions import (
@@ -153,6 +161,18 @@ def _to_readiness_response(readiness) -> OrgLaunchReadinessResponse:
             else None,
             "snapshot_created_at_utc": readiness.snapshot_created_at_utc,
         }
+    )
+
+
+def _to_test_run_response_row(row) -> TestIncidentRunResponse:
+    return TestIncidentRunResponse(
+        run_id=row.run_id,
+        status=row.status,
+        incident_id=row.incident_id,
+        started_at_utc=row.started_at_utc,
+        completed_at_utc=row.completed_at_utc,
+        step_results=list(row.step_results_json or []),
+        findings=list(row.findings_json or []),
     )
 
 
@@ -695,6 +715,106 @@ def get_org_onboarding_status(
     context = build_user_auth_context(db, current_user)
     readiness = get_org_onboarding_readiness(db, org_id=_first_org_id(context))
     return _to_readiness_response(readiness)
+
+
+@router.post("/org/test-runs", response_model=TestIncidentRunResponse, status_code=201)
+def create_org_test_run(
+    payload: TestIncidentRunCreateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    run = create_test_incident_run(
+        db,
+        org_id=_first_org_id(context),
+        actor_user_id=current_user.id,
+        incident_id=payload.incident_id,
+        findings=payload.findings,
+    )
+    return TestIncidentRunResponse.model_validate(asdict(run))
+
+
+@router.get("/org/test-runs", response_model=TestIncidentRunsResponse)
+def list_org_test_runs(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    rows = list_test_incident_runs(db, org_id=_first_org_id(context))
+    return TestIncidentRunsResponse(runs=[_to_test_run_response_row(row) for row in rows])
+
+
+@router.get("/org/test-runs/{run_id}", response_model=TestIncidentRunResponse)
+def get_org_test_run(
+    run_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    row = get_test_incident_run_by_id(db, org_id=_first_org_id(context), run_id=run_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Test run not found")
+    return _to_test_run_response_row(row)
+
+
+@router.post(
+    "/org/test-runs/{run_id}/complete-step",
+    response_model=TestIncidentRunResponse,
+)
+def complete_org_test_run_step(
+    run_id: uuid.UUID,
+    payload: TestIncidentRunStepCompleteRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    try:
+        run = complete_test_incident_run_step(
+            db,
+            org_id=_first_org_id(context),
+            run_id=run_id,
+            step_key=payload.step_key,
+            step_status=payload.status,
+            result=payload.result,
+            source=payload.source,
+            actor_user_id=current_user.id,
+        )
+    except ValueError as exc:
+        if str(exc) == "not_found":
+            raise HTTPException(status_code=404, detail="Test run not found") from exc
+        raise
+    return TestIncidentRunResponse.model_validate(asdict(run))
+
+
+@router.post("/org/onboarding/export-check", response_model=OrgLaunchReadinessResponse)
+def run_org_onboarding_export_check(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = _first_org_id(context)
+    readiness = get_org_onboarding_readiness(db, org_id=org_id)
+    export_step = next(
+        (item for item in readiness.steps if item.key == "export_validation"), None
+    )
+    if export_step is None or export_step.status != "completed":
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "export_validation_not_ready",
+                "message": "Export validation step is not complete.",
+            },
+        )
+    set_step_completion_override(
+        db,
+        org_id=org_id,
+        step_key="export_validation",
+        is_completed=True,
+        actor_user_id=current_user.id,
+        source="export_check_action",
+    )
+    refreshed = get_org_onboarding_readiness(db, org_id=org_id)
+    return _to_readiness_response(refreshed)
 
 
 @router.get(

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -740,11 +740,30 @@ class VehicleQrStatsResponse(BaseModel):
 
 
 class TestIncidentRunResponse(BaseModel):
+    run_id: Optional[uuid.UUID] = None
     status: OnboardingReadinessStepStatus = "not_started"
     incident_id: Optional[uuid.UUID] = None
     started_at_utc: Optional[datetime] = None
     completed_at_utc: Optional[datetime] = None
+    step_results: list[dict[str, Any]] = Field(default_factory=list)
     findings: list[str] = Field(default_factory=list)
+
+
+class TestIncidentRunCreateRequest(BaseModel):
+    incident_id: Optional[uuid.UUID] = None
+    findings: list[str] = Field(default_factory=list, max_length=100)
+    source: ShortText = "onboarding"
+
+
+class TestIncidentRunStepCompleteRequest(BaseModel):
+    step_key: ShortText
+    status: OnboardingReadinessStepStatus = "completed"
+    result: dict[str, Any] = Field(default_factory=dict)
+    source: ShortText = "onboarding"
+
+
+class TestIncidentRunsResponse(BaseModel):
+    runs: list[TestIncidentRunResponse] = Field(default_factory=list)
 
 
 class OrgLaunchReadinessResponse(BaseModel):

--- a/backend/app/db/migrations/versions/0023_add_org_test_incident_runs.py
+++ b/backend/app/db/migrations/versions/0023_add_org_test_incident_runs.py
@@ -1,0 +1,133 @@
+"""add org test incident runs and test incident flag
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-04-15 00:00:00.000000
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0023"
+down_revision: Union[str, None] = "0022"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+org_test_incident_run_status = sa.Enum(
+    "not_started",
+    "in_progress",
+    "completed",
+    "blocked",
+    name="org_test_incident_run_status",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    org_test_incident_run_status.create(bind, checkfirst=True)
+
+    op.add_column(
+        "incidents",
+        sa.Column(
+            "is_test_incident",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.create_index(
+        "ix_incidents_is_test_incident",
+        "incidents",
+        ["is_test_incident"],
+        unique=False,
+    )
+
+    op.create_table(
+        "org_test_incident_runs",
+        sa.Column(
+            "run_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("incident_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "status",
+            org_test_incident_run_status,
+            nullable=False,
+            server_default="in_progress",
+        ),
+        sa.Column(
+            "step_results_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'"),
+        ),
+        sa.Column(
+            "findings_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'"),
+        ),
+        sa.Column("created_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "started_at_utc",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("completed_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "updated_at_utc",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.ForeignKeyConstraint(["incident_id"], ["incidents.incident_id"]),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["users.id"]),
+    )
+    op.create_index(
+        "ix_org_test_incident_runs_org_id",
+        "org_test_incident_runs",
+        ["org_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_org_test_incident_runs_incident_id",
+        "org_test_incident_runs",
+        ["incident_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_org_test_incident_runs_org_started",
+        "org_test_incident_runs",
+        ["org_id", "started_at_utc"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_org_test_incident_runs_org_started",
+        table_name="org_test_incident_runs",
+    )
+    op.drop_index(
+        "ix_org_test_incident_runs_incident_id",
+        table_name="org_test_incident_runs",
+    )
+    op.drop_index("ix_org_test_incident_runs_org_id", table_name="org_test_incident_runs")
+    op.drop_table("org_test_incident_runs")
+
+    op.drop_index("ix_incidents_is_test_incident", table_name="incidents")
+    op.drop_column("incidents", "is_test_incident")
+
+    bind = op.get_bind()
+    org_test_incident_run_status.drop(bind, checkfirst=True)

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -268,6 +268,9 @@ class Incident(Base):
     first_reviewed_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
     last_activity_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
     ready_for_export_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    is_test_incident = Column(
+        Boolean, nullable=False, default=False, server_default=text("false"), index=True
+    )
     updated_at_utc = Column(
         TIMESTAMP(timezone=True),
         nullable=False,
@@ -1418,6 +1421,55 @@ class OrgOnboardingStepCompletion(Base):
             "step_key",
             unique=True,
         ),
+    )
+
+
+class OrgTestIncidentRun(Base):
+    """Persisted test-incident run metadata for onboarding/admin validation."""
+
+    __tablename__ = "org_test_incident_runs"
+
+    run_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    incident_id = Column(
+        UUID(as_uuid=True), ForeignKey("incidents.incident_id"), nullable=True, index=True
+    )
+    status = Column(
+        Enum(
+            "not_started",
+            "in_progress",
+            "completed",
+            "blocked",
+            name="org_test_incident_run_status",
+        ),
+        nullable=False,
+        default="in_progress",
+        server_default="in_progress",
+    )
+    step_results_json = Column(
+        JSONB, nullable=False, default=list, server_default=text("'[]'")
+    )
+    findings_json = Column(
+        JSONB, nullable=False, default=list, server_default=text("'[]'")
+    )
+    created_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
+    started_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    completed_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_org_test_incident_runs_org_started", "org_id", "started_at_utc"),
     )
 
 

--- a/backend/app/db/repo/incidents.py
+++ b/backend/app/db/repo/incidents.py
@@ -27,6 +27,7 @@ def list_incidents(
     org_ids: list[_uuid.UUID] | None = None,
 ):
     query = db.query(Incident)
+    query = query.filter(Incident.is_test_incident.is_(False))
     if org_ids is not None:
         query = query.filter(Incident.org_id.in_(org_ids))
     return query.offset(skip).limit(limit).all()
@@ -40,6 +41,7 @@ def create_incident(
     adc_driver_id: str | None = None,
     severity: str | None = None,
     org_id: _uuid.UUID | None = None,
+    is_test_incident: bool = False,
 ):
     incident = Incident(
         status=status,
@@ -48,6 +50,7 @@ def create_incident(
         adc_driver_id=adc_driver_id,
         severity=severity,
         org_id=org_id,
+        is_test_incident=is_test_incident,
     )
     db.add(incident)
     db.commit()
@@ -74,6 +77,7 @@ def list_incident_queue(
         return []
 
     query = db.query(Incident).filter(Incident.org_id.in_(org_ids))
+    query = query.filter(Incident.is_test_incident.is_(False))
     if case_status:
         query = query.filter(Incident.case_status == case_status)
     if owner_user_id:
@@ -145,6 +149,7 @@ def count_incident_queue(
         return 0
 
     query = db.query(Incident).filter(Incident.org_id.in_(org_ids))
+    query = query.filter(Incident.is_test_incident.is_(False))
     if case_status:
         query = query.filter(Incident.case_status == case_status)
     if owner_user_id:
@@ -185,7 +190,9 @@ def count_incident_alerts(
         }
 
     base = db.query(Incident).filter(
-        Incident.org_id.in_(org_ids), Incident.case_status != "closed"
+        Incident.org_id.in_(org_ids),
+        Incident.case_status != "closed",
+        Incident.is_test_incident.is_(False),
     )
     stalled_cutoff = now_utc - timedelta(hours=72)
     export_aging_cutoff = now_utc - timedelta(hours=48)
@@ -201,6 +208,7 @@ def count_incident_alerts(
         .filter(
             Incident.org_id.in_(org_ids),
             Incident.case_status == "ready_for_export",
+            Incident.is_test_incident.is_(False),
             Incident.ready_for_export_at_utc.is_not(None),
             Incident.ready_for_export_at_utc <= export_aging_cutoff,
         )

--- a/backend/app/onboarding/blockers.py
+++ b/backend/app/onboarding/blockers.py
@@ -169,7 +169,7 @@ def classify_blockers(*, signals: OnboardingSignals) -> list[ClassifiedBlocker]:
                 title="Test run not completed",
                 detail="Complete a successful test incident run before go-live.",
                 severity="critical",
-                blocking_step_key="test_run",
+                blocking_step_key="testIncidentCompleted",
             )
         )
 

--- a/backend/app/onboarding/models.py
+++ b/backend/app/onboarding/models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Literal
+import uuid
 
 ReadinessStatus = Literal[
     "not_started",
@@ -80,9 +81,11 @@ class VehicleQrDeployment:
 @dataclass(slots=True)
 class TestIncidentRun:
     status: IncidentRunStatus
+    run_id: uuid.UUID | None = None
     incident_id: str | None = None
     started_at_utc: datetime | None = None
     completed_at_utc: datetime | None = None
+    step_results: list[dict[str, object]] = field(default_factory=list)
     findings: list[str] = field(default_factory=list)
 
 

--- a/backend/app/onboarding/progress.py
+++ b/backend/app/onboarding/progress.py
@@ -55,7 +55,7 @@ STEP_DEFINITIONS: tuple[StepDefinition, ...] = (
     StepDefinition("integrations", "Integrations", 50),
     StepDefinition("vehicle_qr", "Vehicle QR deployment", 60),
     StepDefinition("driver_protocol", "Driver protocol", 70),
-    StepDefinition("test_run", "Test incident run", 80),
+    StepDefinition("testIncidentCompleted", "Test incident run", 80),
     StepDefinition("export_validation", "Export validation", 90),
 )
 
@@ -100,7 +100,9 @@ def derive_step_statuses(
         "driver_protocol": "completed"
         if signals.protocol_configured
         else "not_started",
-        "test_run": "completed" if signals.test_run_passed else "not_started",
+        "testIncidentCompleted": "completed"
+        if signals.test_run_passed
+        else "not_started",
         "export_validation": "completed"
         if signals.export_validation_passed
         else "not_started",

--- a/backend/app/onboarding/readiness.py
+++ b/backend/app/onboarding/readiness.py
@@ -12,7 +12,7 @@ PILOT_REQUIRED_STEPS = {
     "users_roles",
     "integrations",
     "driver_protocol",
-    "test_run",
+    "testIncidentCompleted",
 }
 
 LAUNCH_REQUIRED_STEPS = {
@@ -23,7 +23,7 @@ LAUNCH_REQUIRED_STEPS = {
     "integrations",
     "vehicle_qr",
     "driver_protocol",
-    "test_run",
+    "testIncidentCompleted",
     "export_validation",
 }
 

--- a/backend/app/onboarding/service.py
+++ b/backend/app/onboarding/service.py
@@ -15,10 +15,12 @@ from app.db.models import (
     Event,
     Export,
     ExternalMapping,
+    Incident,
     IntegrationConnection,
     IntegrationOperation,
     Org,
     OrgOnboardingStepCompletion,
+    OrgTestIncidentRun,
     OrgVehicleRegistry,
     User,
     UserOrg,
@@ -194,6 +196,12 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
         and export_profiles_available
     )
 
+    latest_test_run = (
+        db.query(OrgTestIncidentRun)
+        .filter(OrgTestIncidentRun.org_id == org_id)
+        .order_by(OrgTestIncidentRun.started_at_utc.desc())
+        .first()
+    )
     test_run_event = (
         db.query(Event)
         .filter(
@@ -203,7 +211,9 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
         .order_by(Event.occurred_at_utc.desc())
         .first()
     )
-    test_run_passed = test_run_event is not None
+    test_run_passed = bool(
+        latest_test_run is not None and latest_test_run.status == "completed"
+    )
 
     latest_export = (
         db.query(Export)
@@ -376,9 +386,13 @@ def get_org_onboarding_readiness(
     """Reusable facade for API routes and background jobs."""
     signals = collect_onboarding_signals(db, org_id=org_id)
     overrides = list_step_completion_overrides(db, org_id=org_id)
-    return build_onboarding_readiness(
+    readiness = build_onboarding_readiness(
         org_id=org_id, signals=signals, step_completion_overrides=overrides
     )
+    latest_test_run = get_latest_test_incident_run(db, org_id=org_id)
+    if latest_test_run is not None:
+        readiness.test_incident_run = _to_test_incident_run_model(latest_test_run)
+    return readiness
 
 
 def get_protocol_setup_step(
@@ -446,3 +460,142 @@ def set_step_completion_override(
     db.commit()
     db.refresh(row)
     return row
+
+
+def _to_test_incident_run_model(row: OrgTestIncidentRun) -> TestIncidentRun:
+    return TestIncidentRun(
+        run_id=row.run_id,
+        status=row.status,
+        incident_id=str(row.incident_id) if row.incident_id is not None else None,
+        started_at_utc=row.started_at_utc,
+        completed_at_utc=row.completed_at_utc,
+        step_results=list(row.step_results_json or []),
+        findings=list(row.findings_json or []),
+    )
+
+
+def get_latest_test_incident_run(
+    db: Session, *, org_id: uuid.UUID
+) -> OrgTestIncidentRun | None:
+    return (
+        db.query(OrgTestIncidentRun)
+        .filter(OrgTestIncidentRun.org_id == org_id)
+        .order_by(OrgTestIncidentRun.started_at_utc.desc())
+        .first()
+    )
+
+
+def list_test_incident_runs(
+    db: Session, *, org_id: uuid.UUID
+) -> list[OrgTestIncidentRun]:
+    return (
+        db.query(OrgTestIncidentRun)
+        .filter(OrgTestIncidentRun.org_id == org_id)
+        .order_by(OrgTestIncidentRun.started_at_utc.desc())
+        .all()
+    )
+
+
+def create_test_incident_run(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    actor_user_id: uuid.UUID,
+    incident_id: uuid.UUID | None,
+    findings: list[str] | None = None,
+) -> TestIncidentRun:
+    row = OrgTestIncidentRun(
+        org_id=org_id,
+        incident_id=incident_id,
+        status="in_progress",
+        findings_json=list(findings or []),
+        step_results_json=[],
+        created_by_user_id=actor_user_id,
+        started_at_utc=datetime.now(timezone.utc),
+    )
+    db.add(row)
+    if incident_id is not None:
+        incident = (
+            db.query(Incident)
+            .filter(Incident.incident_id == incident_id, Incident.org_id == org_id)
+            .first()
+        )
+        if incident is not None:
+            incident.is_test_incident = True
+            db.add(incident)
+    db.commit()
+    db.refresh(row)
+    return _to_test_incident_run_model(row)
+
+
+def get_test_incident_run_by_id(
+    db: Session, *, org_id: uuid.UUID, run_id: uuid.UUID
+) -> OrgTestIncidentRun | None:
+    return (
+        db.query(OrgTestIncidentRun)
+        .filter(OrgTestIncidentRun.org_id == org_id, OrgTestIncidentRun.run_id == run_id)
+        .first()
+    )
+
+
+def complete_test_incident_run_step(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    run_id: uuid.UUID,
+    step_key: str,
+    step_status: str,
+    result: dict[str, object],
+    source: str,
+    actor_user_id: uuid.UUID,
+) -> TestIncidentRun:
+    row = get_test_incident_run_by_id(db, org_id=org_id, run_id=run_id)
+    if row is None:
+        raise ValueError("not_found")
+
+    step_results = list(row.step_results_json or [])
+    now_utc = datetime.now(timezone.utc)
+    next_item = {
+        "step_key": step_key,
+        "status": step_status,
+        "result": result,
+        "source": source,
+        "completed_by_user_id": str(actor_user_id),
+        "completed_at_utc": now_utc.isoformat(),
+    }
+    replaced = False
+    for index, existing in enumerate(step_results):
+        if isinstance(existing, dict) and existing.get("step_key") == step_key:
+            step_results[index] = next_item
+            replaced = True
+            break
+    if not replaced:
+        step_results.append(next_item)
+
+    row.step_results_json = step_results
+    row.status = "in_progress" if step_status in {"not_started", "in_progress"} else step_status
+    if row.status == "completed":
+        row.completed_at_utc = now_utc
+        set_step_completion_override(
+            db,
+            org_id=org_id,
+            step_key="testIncidentCompleted",
+            is_completed=True,
+            actor_user_id=actor_user_id,
+            source=source,
+        )
+    elif row.status == "blocked":
+        set_step_completion_override(
+            db,
+            org_id=org_id,
+            step_key="testIncidentCompleted",
+            is_completed=False,
+            actor_user_id=actor_user_id,
+            source=source,
+        )
+        row.completed_at_utc = None
+    row.updated_at_utc = now_utc
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return _to_test_incident_run_model(row)

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -418,6 +418,82 @@ class TestIntegrationDiagnosticsRoutes:
         assert org_settings_step["metadata"]["completion_source"] == "dashboard"
         assert org_settings_step["metadata"]["completed_by_user_id"]
 
+    def test_org_test_runs_crud_and_complete_step(
+        self, client, db_session, test_org, auth_headers
+    ):
+        incident = Incident(org_id=test_org.id, status="open")
+        db_session.add(incident)
+        db_session.commit()
+        db_session.refresh(incident)
+
+        created = client.post(
+            "/org/test-runs",
+            headers=auth_headers,
+            json={"incident_id": str(incident.incident_id), "findings": ["kicked off"]},
+        )
+        assert created.status_code == 201
+        run_id = created.json()["run_id"]
+        assert created.json()["status"] == "in_progress"
+
+        listed = client.get("/org/test-runs", headers=auth_headers)
+        assert listed.status_code == 200
+        assert len(listed.json()["runs"]) == 1
+        assert listed.json()["runs"][0]["run_id"] == run_id
+
+        completed_step = client.post(
+            f"/org/test-runs/{run_id}/complete-step",
+            headers=auth_headers,
+            json={
+                "step_key": "export-check",
+                "status": "completed",
+                "result": {"status": "ok", "artifacts": 1},
+            },
+        )
+        assert completed_step.status_code == 200
+        assert completed_step.json()["status"] == "completed"
+        assert completed_step.json()["step_results"][0]["step_key"] == "export-check"
+
+        detail = client.get(f"/org/test-runs/{run_id}", headers=auth_headers)
+        assert detail.status_code == 200
+        assert detail.json()["run_id"] == run_id
+
+        refreshed = (
+            db_session.query(Incident)
+            .filter_by(incident_id=incident.incident_id)
+            .first()
+        )
+        assert refreshed is not None
+        assert refreshed.is_test_incident is True
+
+    def test_export_check_action_endpoint(
+        self, client, db_session, test_org, auth_headers
+    ):
+        failing = client.post("/org/onboarding/export-check", headers=auth_headers)
+        assert failing.status_code == 409
+        assert failing.json()["detail"]["code"] == "export_validation_not_ready"
+
+        incident = Incident(org_id=test_org.id, status="open")
+        db_session.add(incident)
+        db_session.flush()
+        export = Export(
+            org_id=test_org.id,
+            incident_id=incident.incident_id,
+            export_type="court_defense",
+            status="ready",
+            s3_bucket="bucket",
+            s3_key="key.zip",
+            byte_size=10,
+        )
+        db_session.add(export)
+        db_session.commit()
+
+        success = client.post("/org/onboarding/export-check", headers=auth_headers)
+        assert success.status_code == 200
+        step = next(
+            item for item in success.json()["steps"] if item["key"] == "export_validation"
+        )
+        assert step["status"] == "completed"
+
     def test_users_roles_step_gate_requires_org_admin_and_safety_capable(
         self, client, auth_headers
     ):
@@ -1209,6 +1285,20 @@ class TestListIncidents:
         assert inc["evidence_captured"] == 1
         assert inc["evidence_total"] == 2
         assert "created_at_utc" in inc
+
+    def test_list_incidents_excludes_test_incidents_by_default(
+        self, client, db_session, test_org, auth_headers
+    ):
+        operational = Incident(org_id=test_org.id, status="open", is_test_incident=False)
+        test_run = Incident(org_id=test_org.id, status="open", is_test_incident=True)
+        db_session.add_all([operational, test_run])
+        db_session.commit()
+
+        resp = client.get("/incidents/", headers=auth_headers)
+        assert resp.status_code == 200
+        incident_ids = {item["incident_id"] for item in resp.json()}
+        assert str(operational.incident_id) in incident_ids
+        assert str(test_run.incident_id) not in incident_ids
 
 
 # ── POST /exports ────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Provide an explicit mechanism to run and validate onboarding test incidents, capture structured per-step results, and surface that state in onboarding/admin tools without polluting operational analytics.
- Ensure successful test runs can be tied to readiness gating so onboarding flows can mark `testIncidentCompleted` when appropriate.

### Description
- Added persisted `OrgTestIncidentRun` model and migration to store runs, per-step `step_results_json`, `findings_json`, timestamps and run `status`, and added an `is_test_incident` flag on `Incident` rows.  
- Implemented onboarding service helpers to `create_test_incident_run`, `list_test_incident_runs`, `get_test_incident_run_by_id`, and `complete_test_incident_run_step`, including mapping to typed model `TestIncidentRun` and setting the onboarding step completion override `testIncidentCompleted` when a run completes.  
- Added API schemas and endpoints for test-run lifecycle and export check action: `POST /org/test-runs`, `GET /org/test-runs`, `GET /org/test-runs/{run_id}`, `POST /org/test-runs/{run_id}/complete-step`, and `POST /org/onboarding/export-check`, and response mapping helpers.  
- Excluded incidents flagged with `is_test_incident` from default incident listings, queue metrics and alert counts so test incidents remain visible for admin/onboarding checks but are omitted from operational analytics and queues.  
- Updated onboarding step identity from `test_run` to `testIncidentCompleted` across step derivation, blocker classification, and readiness requirement sets so successful test-run completion is tied to readiness logic.  

### Testing
- Ran lint with `make lint` and static checks which passed.  
- Executed focused unit tests: `pytest backend/tests/test_onboarding_service.py backend/tests/test_api_endpoints.py backend/tests/test_migration_integrity.py backend/tests/test_runtime_contract_snapshot.py -q` and all executed tests passed.  
- Ran full test suite via `make test` which completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deee8da6a88321a8853309af1115d5)