### PR TITLE
Add Onboarding Progress Dashboard and readiness components

### DIFF
--- a/frontend/app/dashboard/DashboardClient.tsx
+++ b/frontend/app/dashboard/DashboardClient.tsx
@@ -11,10 +11,14 @@ import IncidentFilterBar, {
 import IncidentQueueTable from "@/components/case-ops/IncidentQueueTable";
 import IncidentSummaryCards from "@/components/case-ops/IncidentSummaryCards";
 import OverdueFollowUpList from "@/components/case-ops/OverdueFollowUpList";
+import OnboardingProgressDashboard from "@/components/onboarding/OnboardingProgressDashboard";
 import {
+  getIntegrationValidationResults,
   getIncidentAlerts,
   getIncidentQueue,
   getIncidentSummaryMetrics,
+  getOrgOnboardingQrStats,
+  getOrgOnboardingStatus,
   getMyOpenTasks,
   getOverdueTasks,
   patchIncidentOwner,
@@ -24,6 +28,9 @@ import {
   type CaseOpsQueueItem,
   type CaseOpsSummaryMetrics,
   type CaseTaskWidgetItem,
+  type IntegrationValidationResult,
+  type OrgLaunchReadiness,
+  type VehicleQrStats,
 } from "@/lib/api";
 import { useAuth } from "@/lib/useAuth";
 
@@ -60,6 +67,9 @@ export default function DashboardClient() {
   const [queueError, setQueueError] = useState("");
   const [overviewError, setOverviewError] = useState("");
   const [actionError, setActionError] = useState("");
+  const [onboarding, setOnboarding] = useState<OrgLaunchReadiness | null>(null);
+  const [qrStats, setQrStats] = useState<VehicleQrStats | null>(null);
+  const [integrationValidationResults, setIntegrationValidationResults] = useState<IntegrationValidationResult[]>([]);
 
   useEffect(() => {
     if (!user) return;
@@ -89,12 +99,18 @@ export default function DashboardClient() {
       getIncidentAlerts(),
       getOverdueTasks({ limit: 20 }),
       getMyOpenTasks({ limit: 20 }),
+      getOrgOnboardingStatus(),
+      getOrgOnboardingQrStats(),
+      getIntegrationValidationResults(),
     ])
-      .then(([summary, alertPayload, overdue, mine]) => {
+      .then(([summary, alertPayload, overdue, mine, readiness, qrCoverage, validations]) => {
         setMetrics(summary);
         setAlerts(alertPayload);
         setOverdueTasks(overdue.items);
         setMyOpenTasks(mine.items);
+        setOnboarding(readiness);
+        setQrStats(qrCoverage);
+        setIntegrationValidationResults(validations);
         setOverviewError("");
       })
       .catch((err) =>
@@ -179,6 +195,13 @@ export default function DashboardClient() {
 
         {overviewError ? <p className="text-sm text-red-600">{overviewError}</p> : null}
         {actionError ? <p className="text-sm text-red-600">{actionError}</p> : null}
+
+        <OnboardingProgressDashboard
+          readiness={onboarding}
+          qrStats={qrStats}
+          validationResults={integrationValidationResults}
+          loading={overviewLoading}
+        />
 
         <IncidentSummaryCards metrics={metrics} loading={overviewLoading} />
         <IncidentFilterBar

--- a/frontend/app/dashboard/DashboardClient.tsx
+++ b/frontend/app/dashboard/DashboardClient.tsx
@@ -99,18 +99,33 @@ export default function DashboardClient() {
       getIncidentAlerts(),
       getOverdueTasks({ limit: 20 }),
       getMyOpenTasks({ limit: 20 }),
-      getOrgOnboardingStatus(),
-      getOrgOnboardingQrStats(),
-      getIntegrationValidationResults(),
     ])
-      .then(([summary, alertPayload, overdue, mine, readiness, qrCoverage, validations]) => {
+      .then(async ([summary, alertPayload, overdue, mine]) => {
+        const onboardingResults = await Promise.allSettled([
+          getOrgOnboardingStatus(),
+          getOrgOnboardingQrStats(),
+          getIntegrationValidationResults(),
+        ]);
+
         setMetrics(summary);
         setAlerts(alertPayload);
         setOverdueTasks(overdue.items);
         setMyOpenTasks(mine.items);
-        setOnboarding(readiness);
-        setQrStats(qrCoverage);
-        setIntegrationValidationResults(validations);
+        if (onboardingResults[0].status === "fulfilled") {
+          setOnboarding(onboardingResults[0].value);
+        } else {
+          setOnboarding(null);
+        }
+        if (onboardingResults[1].status === "fulfilled") {
+          setQrStats(onboardingResults[1].value);
+        } else {
+          setQrStats(null);
+        }
+        if (onboardingResults[2].status === "fulfilled") {
+          setIntegrationValidationResults(onboardingResults[2].value);
+        } else {
+          setIntegrationValidationResults([]);
+        }
         setOverviewError("");
       })
       .catch((err) =>

--- a/frontend/app/dashboard/DashboardClient.tsx
+++ b/frontend/app/dashboard/DashboardClient.tsx
@@ -32,6 +32,7 @@ import {
   type OrgLaunchReadiness,
   type VehicleQrStats,
 } from "@/lib/api";
+import { ONBOARDING_WIZARD_STORAGE_KEY } from "@/lib/onboarding";
 import { useAuth } from "@/lib/useAuth";
 
 const DEFAULT_FILTERS: IncidentFilters = {
@@ -72,7 +73,7 @@ export default function DashboardClient() {
   const [integrationValidationResults, setIntegrationValidationResults] = useState<IntegrationValidationResult[]>([]);
   const resumeOnboardingHref = useMemo(() => {
     if (typeof window === "undefined") return "/onboarding";
-    const persistedStep = window.localStorage.getItem("adc.onboarding.currentStep");
+    const persistedStep = window.localStorage.getItem(ONBOARDING_WIZARD_STORAGE_KEY);
     return persistedStep
       ? `/onboarding?step=${encodeURIComponent(persistedStep)}`
       : "/onboarding";

--- a/frontend/app/onboarding/OnboardingWizardClient.tsx
+++ b/frontend/app/onboarding/OnboardingWizardClient.tsx
@@ -4,13 +4,12 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import MainLayout from "@/components/MainLayout";
 import {
-  getOrgOnboardingReadiness,
+  getOrgOnboardingStatus,
   toUserErrorMessage,
   type OrgLaunchReadiness,
   type OnboardingStepStatus,
 } from "@/lib/api";
-
-const WIZARD_STORAGE_KEY = "adc.onboarding.currentStep";
+import { ONBOARDING_WIZARD_STORAGE_KEY } from "@/lib/onboarding";
 
 type WizardStep = {
   key: string;
@@ -108,6 +107,7 @@ const WIZARD_STEPS: WizardStep[] = [
 
 function getStepStatus(steps: OrgLaunchReadiness["steps"], readinessKeys: string[]): OnboardingStepStatus {
   if (readinessKeys.length === 0) {
+    if (steps.length === 0) return "not_started";
     return steps.every((step) => step.status === "completed") ? "completed" : "in_progress";
   }
 
@@ -134,12 +134,12 @@ export default function OnboardingWizardClient() {
     if (typeof window === "undefined") return WIZARD_STEPS[0].key;
     const fromQuery = new URLSearchParams(window.location.search).get("step") ?? "";
     if (WIZARD_STEPS.some((step) => step.key === fromQuery)) return fromQuery;
-    const stored = window.localStorage.getItem(WIZARD_STORAGE_KEY) ?? "";
+    const stored = window.localStorage.getItem(ONBOARDING_WIZARD_STORAGE_KEY) ?? "";
     return WIZARD_STEPS.some((step) => step.key === stored) ? stored : WIZARD_STEPS[0].key;
   });
 
   useEffect(() => {
-    getOrgOnboardingReadiness()
+    getOrgOnboardingStatus()
       .then((payload) => {
         setReadiness(payload);
         setError("");
@@ -150,7 +150,7 @@ export default function OnboardingWizardClient() {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    window.localStorage.setItem(WIZARD_STORAGE_KEY, activeStepKey);
+    window.localStorage.setItem(ONBOARDING_WIZARD_STORAGE_KEY, activeStepKey);
     router.replace(`/onboarding?step=${encodeURIComponent(activeStepKey)}`);
   }, [activeStepKey, router]);
 

--- a/frontend/components/onboarding/BlockersPanel.tsx
+++ b/frontend/components/onboarding/BlockersPanel.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+
+type Blocker = {
+  code: string;
+  title: string;
+  detail: string;
+  severity: "critical" | "warning" | "info";
+};
+
+type BlockersPanelProps = {
+  blockers: Blocker[];
+  reviewHref: string;
+};
+
+const SEVERITY_STYLES: Record<Blocker["severity"], string> = {
+  critical: "border-red-300 bg-red-50 text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200",
+  warning: "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-700 dark:bg-amber-900/30 dark:text-amber-200",
+  info: "border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-900/30 dark:text-blue-200",
+};
+
+export default function BlockersPanel({ blockers, reviewHref }: BlockersPanelProps) {
+  return (
+    <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Blockers</h3>
+        <Link href={reviewHref} className="text-xs font-medium text-blue-600 hover:underline">
+          Review blockers
+        </Link>
+      </div>
+
+      {blockers.length === 0 ? (
+        <p className="text-xs text-emerald-700 dark:text-emerald-300">No blockers detected.</p>
+      ) : (
+        <ul className="space-y-2">
+          {blockers.slice(0, 4).map((blocker) => (
+            <li key={blocker.code} className={`rounded-md border p-2 text-xs ${SEVERITY_STYLES[blocker.severity]}`}>
+              <p className="font-semibold">{blocker.title}</p>
+              <p className="mt-1">{blocker.detail}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/components/onboarding/LaunchReadinessBanner.tsx
+++ b/frontend/components/onboarding/LaunchReadinessBanner.tsx
@@ -1,12 +1,13 @@
 import Link from "next/link";
 
 type LaunchReadinessBannerProps = {
-  status: "not_started" | "blocked" | "pilot_ready" | "launch_ready";
+  status: "not_started" | "in_progress" | "blocked" | "pilot_ready" | "launch_ready";
   recommendation: string;
 };
 
 const STATUS_LABELS: Record<LaunchReadinessBannerProps["status"], string> = {
   not_started: "Not started",
+  in_progress: "In progress",
   blocked: "Blocked",
   pilot_ready: "Pilot ready",
   launch_ready: "Launch ready",
@@ -14,6 +15,7 @@ const STATUS_LABELS: Record<LaunchReadinessBannerProps["status"], string> = {
 
 const STATUS_STYLES: Record<LaunchReadinessBannerProps["status"], string> = {
   not_started: "border-slate-300 bg-slate-50 text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200",
+  in_progress: "border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-900/30 dark:text-blue-200",
   blocked: "border-red-300 bg-red-50 text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200",
   pilot_ready: "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-700 dark:bg-amber-900/30 dark:text-amber-200",
   launch_ready: "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-200",

--- a/frontend/components/onboarding/LaunchReadinessBanner.tsx
+++ b/frontend/components/onboarding/LaunchReadinessBanner.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+
+type LaunchReadinessBannerProps = {
+  status: "not_started" | "blocked" | "pilot_ready" | "launch_ready";
+  recommendation: string;
+};
+
+const STATUS_LABELS: Record<LaunchReadinessBannerProps["status"], string> = {
+  not_started: "Not started",
+  blocked: "Blocked",
+  pilot_ready: "Pilot ready",
+  launch_ready: "Launch ready",
+};
+
+const STATUS_STYLES: Record<LaunchReadinessBannerProps["status"], string> = {
+  not_started: "border-slate-300 bg-slate-50 text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200",
+  blocked: "border-red-300 bg-red-50 text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200",
+  pilot_ready: "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-700 dark:bg-amber-900/30 dark:text-amber-200",
+  launch_ready: "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-200",
+};
+
+export default function LaunchReadinessBanner({ status, recommendation }: LaunchReadinessBannerProps) {
+  return (
+    <section className={`rounded-lg border p-4 ${STATUS_STYLES[status]}`}>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-wide">Overall status</p>
+          <h3 className="text-lg font-semibold">{STATUS_LABELS[status]}</h3>
+        </div>
+        <span className="rounded-full border border-current px-3 py-1 text-xs font-semibold">
+          Recommendation: {recommendation}
+        </span>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-3 text-xs font-medium">
+        <Link href="/admin/driver-protocol" className="underline underline-offset-2">Continue setup</Link>
+        <Link href="/dashboard" className="underline underline-offset-2">Rerun validation</Link>
+        <Link href="/settings/integrations" className="underline underline-offset-2">Import data</Link>
+        <Link href="/settings/integrations" className="underline underline-offset-2">Invite users</Link>
+        <Link href="/incidents" className="underline underline-offset-2">Open test incident flow</Link>
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/onboarding/OnboardingProgressDashboard.tsx
+++ b/frontend/components/onboarding/OnboardingProgressDashboard.tsx
@@ -1,0 +1,155 @@
+import { useMemo } from "react";
+import Link from "next/link";
+import BlockersPanel from "./BlockersPanel";
+import LaunchReadinessBanner from "./LaunchReadinessBanner";
+import OnboardingStepCard from "./OnboardingStepCard";
+import ReadinessProgressBar from "./ReadinessProgressBar";
+import type {
+  IntegrationValidationResult,
+  OrgLaunchReadiness,
+  VehicleQrStats,
+} from "@/lib/api";
+
+type OnboardingProgressDashboardProps = {
+  readiness: OrgLaunchReadiness | null;
+  qrStats: VehicleQrStats | null;
+  validationResults: IntegrationValidationResult[];
+  loading: boolean;
+};
+
+function getStepStatus(score: number): "completed" | "in_progress" | "not_started" {
+  if (score >= 1) return "completed";
+  if (score > 0) return "in_progress";
+  return "not_started";
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return "—";
+  return new Date(value).toLocaleString();
+}
+
+function toBadgeRecommendation(readiness: OrgLaunchReadiness | null): string {
+  if (!readiness) return "Awaiting onboarding snapshot";
+  if (readiness.status === "launch_ready") return "Ready to launch";
+  if (readiness.blockers.some((item) => item.severity === "critical")) return "Resolve critical blockers";
+  if (readiness.percent_complete >= 70) return "Run final validation";
+  return "Complete setup steps";
+}
+
+export default function OnboardingProgressDashboard({
+  readiness,
+  qrStats,
+  validationResults,
+  loading,
+}: OnboardingProgressDashboardProps) {
+  const blockers = useMemo(
+    () => (readiness?.blockers ?? []).map((item) => ({ ...item, severity: item.severity === "error" ? "critical" : item.severity })),
+    [readiness]
+  );
+
+  const importSummary = useMemo(() => {
+    const jobs = readiness?.import_jobs ?? [];
+    return {
+      total: jobs.length,
+      succeeded: jobs.filter((job) => job.status === "succeeded").length,
+      failed: jobs.filter((job) => job.status === "failed").length,
+    };
+  }, [readiness]);
+
+  const integrationHealth = useMemo(() => {
+    if (validationResults.length === 0) return { passed: 0, total: 0 };
+    return {
+      passed: validationResults.filter(
+        (item) =>
+          item.credentialStatus === "completed" &&
+          item.capabilityStatus === "completed" &&
+          item.mappingStatus === "completed"
+      ).length,
+      total: validationResults.length,
+    };
+  }, [validationResults]);
+
+  const latestValidationTime = readiness?.latest_export_validation?.validated_at_utc;
+
+  const setupScore = readiness
+    ? readiness.steps.length === 0
+      ? 0
+      : readiness.steps.filter((step) => step.status === "completed").length / readiness.steps.length
+    : 0;
+
+  return (
+    <section className="space-y-4 rounded-xl border border-blue-100 bg-blue-50/40 p-4 dark:border-blue-900/40 dark:bg-blue-900/10">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Onboarding Progress Dashboard</h2>
+          <p className="text-sm text-gray-600 dark:text-gray-300">Track readiness, blockers, validation signals, and launch recommendations.</p>
+        </div>
+        {loading ? <span className="text-xs text-gray-500">Refreshing…</span> : null}
+      </div>
+
+      <LaunchReadinessBanner
+        status={readiness?.status ?? "not_started"}
+        recommendation={toBadgeRecommendation(readiness)}
+      />
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <div className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800 lg:col-span-2">
+          <ReadinessProgressBar
+            label="Overall launch readiness"
+            percent={readiness?.percent_complete ?? 0}
+          />
+          <div className="mt-4 grid gap-3 sm:grid-cols-3">
+            <OnboardingStepCard
+              title="Setup"
+              description="Finish protocol configuration and defaults"
+              status={getStepStatus(setupScore)}
+              href="/admin/driver-protocol"
+              ctaLabel="Continue setup"
+            />
+            <OnboardingStepCard
+              title="Validation"
+              description={`Latest export validation: ${formatDate(latestValidationTime)}`}
+              status={readiness?.latest_export_validation?.status ?? "not_started"}
+              href="/dashboard"
+              ctaLabel="Rerun validation"
+            />
+            <OnboardingStepCard
+              title="Imports"
+              description={`${importSummary.succeeded}/${importSummary.total} jobs succeeded${importSummary.failed ? ` · ${importSummary.failed} failed` : ""}`}
+              status={importSummary.total === 0 ? "not_started" : importSummary.failed > 0 ? "in_progress" : "completed"}
+              href="/settings/integrations"
+              ctaLabel="Import data"
+            />
+          </div>
+
+          <div className="mt-4 grid gap-3 text-xs text-gray-700 dark:text-gray-200 sm:grid-cols-3">
+            <div className="rounded-md border bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900">
+              <p className="text-[11px] uppercase text-gray-500">Integration health</p>
+              <p className="mt-1 text-base font-semibold">{integrationHealth.passed}/{integrationHealth.total}</p>
+              <p className="text-[11px] text-gray-500">validations passing</p>
+            </div>
+            <div className="rounded-md border bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900">
+              <p className="text-[11px] uppercase text-gray-500">QR coverage</p>
+              <p className="mt-1 text-base font-semibold">
+                {qrStats?.distributed_count ?? 0}/{qrStats?.required_vehicle_count ?? 0}
+              </p>
+              <p className="text-[11px] text-gray-500">distributed vehicles</p>
+            </div>
+            <div className="rounded-md border bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900">
+              <p className="text-[11px] uppercase text-gray-500">Recent validations</p>
+              <p className="mt-1 text-base font-semibold">{validationResults.length}</p>
+              <p className="text-[11px] text-gray-500">latest integration checks</p>
+            </div>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-3 text-xs font-medium text-blue-700 dark:text-blue-300">
+            <Link href="/settings/integrations" className="hover:underline">Invite users</Link>
+            <Link href="/incidents" className="hover:underline">Open test incident flow</Link>
+          </div>
+        </div>
+
+        <BlockersPanel blockers={blockers} reviewHref="/dashboard?blockers=critical" />
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/onboarding/OnboardingStepCard.tsx
+++ b/frontend/components/onboarding/OnboardingStepCard.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+
+export type OnboardingStepCardProps = {
+  title: string;
+  description: string;
+  status: "completed" | "in_progress" | "not_started";
+  href: string;
+  ctaLabel: string;
+};
+
+const STATUS_STYLES: Record<OnboardingStepCardProps["status"], string> = {
+  completed: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300",
+  in_progress: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300",
+  not_started: "bg-slate-100 text-slate-700 dark:bg-slate-700/50 dark:text-slate-200",
+};
+
+const STATUS_LABELS: Record<OnboardingStepCardProps["status"], string> = {
+  completed: "Completed",
+  in_progress: "In progress",
+  not_started: "Not started",
+};
+
+export default function OnboardingStepCard({
+  title,
+  description,
+  status,
+  href,
+  ctaLabel,
+}: OnboardingStepCardProps) {
+  return (
+    <article className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">{title}</h3>
+        <span className={`rounded-full px-2 py-1 text-[11px] font-semibold ${STATUS_STYLES[status]}`}>
+          {STATUS_LABELS[status]}
+        </span>
+      </div>
+      <p className="mt-2 text-xs text-gray-600 dark:text-gray-300">{description}</p>
+      <Link
+        href={href}
+        className="mt-3 inline-flex text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
+      >
+        {ctaLabel}
+      </Link>
+    </article>
+  );
+}

--- a/frontend/components/onboarding/OnboardingStepCard.tsx
+++ b/frontend/components/onboarding/OnboardingStepCard.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export type OnboardingStepCardProps = {
   title: string;
   description: string;
-  status: "completed" | "in_progress" | "not_started";
+  status: "completed" | "in_progress" | "not_started" | "blocked";
   href: string;
   ctaLabel: string;
 };
@@ -11,12 +11,14 @@ export type OnboardingStepCardProps = {
 const STATUS_STYLES: Record<OnboardingStepCardProps["status"], string> = {
   completed: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300",
   in_progress: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300",
+  blocked: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
   not_started: "bg-slate-100 text-slate-700 dark:bg-slate-700/50 dark:text-slate-200",
 };
 
 const STATUS_LABELS: Record<OnboardingStepCardProps["status"], string> = {
   completed: "Completed",
   in_progress: "In progress",
+  blocked: "Blocked",
   not_started: "Not started",
 };
 

--- a/frontend/components/onboarding/ReadinessProgressBar.tsx
+++ b/frontend/components/onboarding/ReadinessProgressBar.tsx
@@ -1,0 +1,24 @@
+type ReadinessProgressBarProps = {
+  percent: number;
+  label: string;
+};
+
+export default function ReadinessProgressBar({ percent, label }: ReadinessProgressBarProps) {
+  const boundedPercent = Math.max(0, Math.min(100, percent));
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between">
+        <p className="text-xs font-medium text-gray-600 dark:text-gray-300">{label}</p>
+        <p className="text-xs font-semibold text-gray-900 dark:text-gray-100">{boundedPercent}%</p>
+      </div>
+      <div className="h-2.5 rounded-full bg-gray-200 dark:bg-gray-700">
+        <div
+          className="h-2.5 rounded-full bg-blue-600 transition-all"
+          style={{ width: `${boundedPercent}%` }}
+          aria-label={`${boundedPercent}% complete`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -610,7 +610,7 @@ export function getIntegrationValidationResults() {
   return request<Array<IntegrationValidationResultLegacyResponse | IntegrationValidationResultCurrentResponse>>(
     "/org/integrations/validation-results"
   ).then((rows) =>
-    rows.map((row, index) => {
+    rows.map((row) => {
       const status = (row as IntegrationValidationResultCurrentResponse).credentialStatus
         ?? (row as IntegrationValidationResultLegacyResponse).status
         ?? "not_started";
@@ -619,11 +619,22 @@ export function getIntegrationValidationResults() {
         ?? ((row as IntegrationValidationResultLegacyResponse).detail
           ? [(row as IntegrationValidationResultLegacyResponse).detail as string]
           : []);
+      const fallbackIdSource = [
+        (row as IntegrationValidationResultCurrentResponse).timestamp
+          ?? (row as IntegrationValidationResultLegacyResponse).checked_at_utc
+          ?? "",
+        status,
+        ...mappedMessages,
+      ]
+        .join("|")
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "");
       return {
         integration_id:
           (row as IntegrationValidationResultCurrentResponse).integration_id
           ?? (row as IntegrationValidationResultLegacyResponse).integration_key
-          ?? `integration-${index}`,
+          ?? `integration-${fallbackIdSource || "unknown"}`,
         credentialStatus: (row as IntegrationValidationResultCurrentResponse).credentialStatus ?? status,
         capabilityStatus: (row as IntegrationValidationResultCurrentResponse).capabilityStatus ?? status,
         mappingStatus: (row as IntegrationValidationResultCurrentResponse).mappingStatus ?? status,
@@ -635,9 +646,6 @@ export function getIntegrationValidationResults() {
       };
     })
   );
-}
-export function getOrgOnboardingReadiness() {
-  return request<OrgLaunchReadiness>("/org/onboarding/status");
 }
 /* ── Admin vehicles ─────────────────────────────────────────────── */
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -507,6 +507,83 @@ export function getProtocolSetupStepData() {
   return request<ProtocolSetupStepData>("/org/onboarding/protocol-setup-step");
 }
 
+export type OnboardingStepStatus = "not_started" | "in_progress" | "completed";
+export type OnboardingReadinessStatus = "not_started" | "blocked" | "pilot_ready" | "launch_ready";
+
+export interface OnboardingReadinessStep {
+  key: string;
+  label: string;
+  status: OnboardingStepStatus;
+  order: number;
+  completed_at_utc?: string | null;
+  updated_at_utc?: string | null;
+}
+
+export interface OnboardingBlocker {
+  code: string;
+  title: string;
+  detail: string;
+  severity: "critical" | "warning" | "info" | "error";
+  blocking_step_key?: string | null;
+}
+
+export interface OnboardingImportJob {
+  import_job_id: string;
+  provider: string;
+  status: "queued" | "running" | "succeeded" | "failed";
+  records_total: number;
+  records_succeeded: number;
+  records_failed: number;
+  completed_at_utc?: string | null;
+}
+
+export interface ExportValidationRun {
+  validation_run_id?: string | null;
+  status: OnboardingStepStatus;
+  validated_at_utc?: string | null;
+  checks: Record<string, boolean>;
+}
+
+export interface OrgLaunchReadiness {
+  org_id: string;
+  status: OnboardingReadinessStatus;
+  percent_complete: number;
+  steps: OnboardingReadinessStep[];
+  blockers: OnboardingBlocker[];
+  import_jobs: OnboardingImportJob[];
+  latest_export_validation?: ExportValidationRun | null;
+  snapshot_created_at_utc?: string | null;
+}
+
+export interface VehicleQrStats {
+  required_vehicle_count: number;
+  generated_count: number;
+  distributed_count: number;
+  confirmed_count: number;
+  coverage_blockers: string[];
+}
+
+export interface IntegrationValidationResult {
+  integration_id: string;
+  credentialStatus: OnboardingStepStatus;
+  capabilityStatus: OnboardingStepStatus;
+  mappingStatus: OnboardingStepStatus;
+  messages: string[];
+  timestamp: string;
+}
+
+export function getOrgOnboardingStatus() {
+  return request<OrgLaunchReadiness>("/org/onboarding/status");
+}
+
+export function getOrgOnboardingQrStats() {
+  return request<VehicleQrStats>("/org/onboarding/qr-stats");
+}
+
+export function getIntegrationValidationResults() {
+  return request<IntegrationValidationResult[]>("/org/integrations/validation-results");
+}
+
 /* ── Admin vehicles ─────────────────────────────────────────────── */
 
 export interface AdminVehicle {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -572,6 +572,23 @@ export interface IntegrationValidationResult {
   timestamp: string;
 }
 
+type IntegrationValidationResultLegacyResponse = {
+  integration_key?: string;
+  status?: OnboardingStepStatus;
+  checked_at_utc?: string;
+  detail?: string;
+  errors?: string[];
+};
+
+type IntegrationValidationResultCurrentResponse = {
+  integration_id?: string;
+  credentialStatus?: OnboardingStepStatus;
+  capabilityStatus?: OnboardingStepStatus;
+  mappingStatus?: OnboardingStepStatus;
+  messages?: string[];
+  timestamp?: string;
+};
+
 export function getOrgOnboardingStatus() {
   return request<OrgLaunchReadiness>("/org/onboarding/status");
 }
@@ -581,7 +598,34 @@ export function getOrgOnboardingQrStats() {
 }
 
 export function getIntegrationValidationResults() {
-  return request<IntegrationValidationResult[]>("/org/integrations/validation-results");
+  return request<Array<IntegrationValidationResultLegacyResponse | IntegrationValidationResultCurrentResponse>>(
+    "/org/integrations/validation-results"
+  ).then((rows) =>
+    rows.map((row, index) => {
+      const status = (row as IntegrationValidationResultCurrentResponse).credentialStatus
+        ?? (row as IntegrationValidationResultLegacyResponse).status
+        ?? "not_started";
+      const mappedMessages = (row as IntegrationValidationResultCurrentResponse).messages
+        ?? (row as IntegrationValidationResultLegacyResponse).errors
+        ?? ((row as IntegrationValidationResultLegacyResponse).detail
+          ? [(row as IntegrationValidationResultLegacyResponse).detail as string]
+          : []);
+      return {
+        integration_id:
+          (row as IntegrationValidationResultCurrentResponse).integration_id
+          ?? (row as IntegrationValidationResultLegacyResponse).integration_key
+          ?? `integration-${index}`,
+        credentialStatus: (row as IntegrationValidationResultCurrentResponse).credentialStatus ?? status,
+        capabilityStatus: (row as IntegrationValidationResultCurrentResponse).capabilityStatus ?? status,
+        mappingStatus: (row as IntegrationValidationResultCurrentResponse).mappingStatus ?? status,
+        messages: mappedMessages,
+        timestamp:
+          (row as IntegrationValidationResultCurrentResponse).timestamp
+          ?? (row as IntegrationValidationResultLegacyResponse).checked_at_utc
+          ?? new Date(0).toISOString(),
+      };
+    })
+  );
 }
 
 /* ── Admin vehicles ─────────────────────────────────────────────── */

--- a/frontend/lib/onboarding.ts
+++ b/frontend/lib/onboarding.ts
@@ -1,0 +1,1 @@
+export const ONBOARDING_WIZARD_STORAGE_KEY = "adc.onboarding.currentStep";


### PR DESCRIPTION
### Motivation
- Surface org launch readiness and make it actionable in the Command Center by showing overall percent, blockers, recent validations, import stats, integration health, QR coverage, and a recommendation badge with CTAs.
- Provide reusable UI primitives so other pages can reference onboarding readiness signals and CTA flows like continue setup, rerun validation, import data, invite users, open test incident flow, and review blockers.

### Description
- Added a new dashboard UI composed of `OnboardingProgressDashboard`, `OnboardingStepCard`, `ReadinessProgressBar`, `BlockersPanel`, and `LaunchReadinessBanner` under `frontend/components/onboarding` to present readiness, blockers, validations, import summaries, QR coverage, and CTA links.
- Wired the onboarding dashboard into the Command Center by importing and mounting `OnboardingProgressDashboard` in `frontend/app/dashboard/DashboardClient.tsx` and fetching onboarding-related payloads during overview load.
- Extended the frontend API client `frontend/lib/api.ts` with onboarding types and client functions: `getOrgOnboardingStatus`, `getOrgOnboardingQrStats`, and `getIntegrationValidationResults`, plus related TypeScript interfaces for readiness, blockers, import jobs, and validations.
- Improved integration-health calculation in `OnboardingProgressDashboard` to consider credential, capability and mapping statuses as passing only when all are `completed`.

### Testing
- Ran lint with `cd frontend && npm run lint` and it completed successfully.
- Ran TypeScript typecheck with `cd frontend && npm run typecheck` and it completed successfully.
- Ran frontend unit tests with `cd frontend && npm test` and all tests passed (5/5).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e242971e50832182f3a70d3f10a104)