### PR TITLE
Add vehicle/driver CSV import preview, validation UI and job polling

### DIFF
--- a/frontend/app/admin/vehicles/page.tsx
+++ b/frontend/app/admin/vehicles/page.tsx
@@ -1,21 +1,85 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import QRCode from "qrcode";
 import Image from "next/image";
 import AdminLayout from "@/components/AdminLayout";
+import CategorizedIssueList from "@/components/imports/CategorizedIssueList";
+import DriverImportPreviewTable from "@/components/imports/DriverImportPreviewTable";
+import VehicleImportPreviewTable from "@/components/imports/VehicleImportPreviewTable";
 import {
+  createDriverImportJob,
+  createVehicleImportJob,
+  getDriverImportJob,
+  getVehicleImportJob,
   getVehicleQrPayload,
   listAdminVehicles,
   rotateVehicleQr,
   type AdminVehicle,
+  type DriverImportJobResponse,
+  type ImportJobStatus,
+  type VehicleImportJobResponse,
 } from "@/lib/api";
+import {
+  autoMapHeaders,
+  buildDriverPreview,
+  buildRowObjects,
+  buildVehiclePreview,
+  parseCsv,
+  type DriverPreviewRow,
+  type ImportIssue,
+  type VehiclePreviewRow,
+} from "@/lib/csvImport";
 
 type QrModalState = {
   vehicle: AdminVehicle;
   payload: string;
   imageUrl: string;
 };
+
+const VEHICLE_ALIASES = {
+  unit_number: ["unitNumber", "unit_number", "unit", "trucknumber", "vehicleunit"],
+  vin: ["vin", "vehiclevin"],
+  provider_vehicle_id: ["providerVehicleId", "provider_vehicle_id", "externalid", "providerid"],
+  is_active: ["isActive", "active", "status"],
+};
+
+const DRIVER_ALIASES = {
+  first_name: ["firstName", "first_name", "first"],
+  last_name: ["lastName", "last_name", "last"],
+  phone: ["phone", "mobile", "mobilephone", "phone_e164"],
+  provider_driver_id: ["providerDriverId", "provider_driver_id", "externaldriverid"],
+  is_active: ["isActive", "active", "status"],
+};
+
+function ImportJobProgress({ status, total, processed }: { status: ImportJobStatus; total: number; processed: number }) {
+  const pct = total > 0 ? Math.round((processed / total) * 100) : status === "running" ? 10 : 0;
+  return (
+    <div className="space-y-1">
+      <p className="text-xs text-gray-600">Status: <span className="font-semibold">{status}</span></p>
+      <div className="h-2 rounded bg-gray-200">
+        <div className="h-2 rounded bg-blue-600" style={{ width: `${Math.min(100, pct)}%` }} />
+      </div>
+      <p className="text-xs text-gray-500">{processed}/{total || "?"} processed</p>
+    </div>
+  );
+}
+
+function ImportSummary({ title, items }: { title: string; items: Array<{ label: string; value: number }> }) {
+  return (
+    <div className="rounded-md border border-gray-200 bg-white p-3">
+      <p className="text-sm font-semibold text-gray-800">{title}</p>
+      <dl className="mt-2 grid grid-cols-2 gap-2 text-xs">
+        {items.map((item) => (
+          <div key={item.label}>
+            <dt className="text-gray-500">{item.label}</dt>
+            <dd className="font-semibold text-gray-800">{item.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
 
 export default function AdminVehiclesPage() {
   const [vehicles, setVehicles] = useState<AdminVehicle[]>([]);
@@ -24,6 +88,21 @@ export default function AdminVehiclesPage() {
   const [qrModal, setQrModal] = useState<QrModalState | null>(null);
   const [busyVehicleId, setBusyVehicleId] = useState<string | null>(null);
 
+  const [vehicleCsv, setVehicleCsv] = useState("");
+  const [driverCsv, setDriverCsv] = useState("");
+  const [vehicleMapping, setVehicleMapping] = useState<Record<string, string>>({});
+  const [driverMapping, setDriverMapping] = useState<Record<string, string>>({});
+  const [vehiclePreview, setVehiclePreview] = useState<VehiclePreviewRow[]>([]);
+  const [driverPreview, setDriverPreview] = useState<DriverPreviewRow[]>([]);
+  const [vehicleIssues, setVehicleIssues] = useState<ImportIssue[]>([]);
+  const [driverIssues, setDriverIssues] = useState<ImportIssue[]>([]);
+  const [vehicleConfirm, setVehicleConfirm] = useState(false);
+  const [driverConfirm, setDriverConfirm] = useState(false);
+  const [vehicleSubmitting, setVehicleSubmitting] = useState(false);
+  const [driverSubmitting, setDriverSubmitting] = useState(false);
+  const [vehicleJob, setVehicleJob] = useState<VehicleImportJobResponse | null>(null);
+  const [driverJob, setDriverJob] = useState<DriverImportJobResponse | null>(null);
+
   useEffect(() => {
     listAdminVehicles()
       .then(setVehicles)
@@ -31,25 +110,97 @@ export default function AdminVehiclesPage() {
       .finally(() => setLoading(false));
   }, []);
 
+  useEffect(() => {
+    if (!vehicleCsv.trim()) return;
+    const parsed = parseCsv(vehicleCsv);
+    const mapping = autoMapHeaders(parsed.headers, VEHICLE_ALIASES);
+    setVehicleMapping(mapping);
+    const rowObjects = buildRowObjects(parsed.headers, parsed.rows);
+    const preview = buildVehiclePreview(rowObjects, mapping);
+    setVehiclePreview(preview.previewRows);
+    setVehicleIssues(preview.issues);
+  }, [vehicleCsv]);
+
+  useEffect(() => {
+    if (!driverCsv.trim()) return;
+    const parsed = parseCsv(driverCsv);
+    const mapping = autoMapHeaders(parsed.headers, DRIVER_ALIASES);
+    setDriverMapping(mapping);
+    const rowObjects = buildRowObjects(parsed.headers, parsed.rows);
+    const preview = buildDriverPreview(rowObjects, mapping);
+    setDriverPreview(preview.previewRows);
+    setDriverIssues(preview.issues);
+  }, [driverCsv]);
+
+  useEffect(() => {
+    if (!vehicleJob || (vehicleJob.status !== "pending" && vehicleJob.status !== "running")) return;
+    const timer = window.setInterval(async () => {
+      const detail = await getVehicleImportJob(vehicleJob.job_id);
+      setVehicleJob(detail);
+      if (detail.status !== "pending" && detail.status !== "running") {
+        window.clearInterval(timer);
+      }
+    }, 2500);
+    return () => window.clearInterval(timer);
+  }, [vehicleJob]);
+
+  useEffect(() => {
+    if (!driverJob || (driverJob.status !== "pending" && driverJob.status !== "running")) return;
+    const timer = window.setInterval(async () => {
+      const detail = await getDriverImportJob(driverJob.job_id);
+      setDriverJob(detail);
+      if (detail.status !== "pending" && detail.status !== "running") {
+        window.clearInterval(timer);
+      }
+    }, 2500);
+    return () => window.clearInterval(timer);
+  }, [driverJob]);
+
+  const vehicleErrorCount = useMemo(() => vehicleIssues.filter((i) => i.severity === "error").length, [vehicleIssues]);
+  const driverErrorCount = useMemo(() => driverIssues.filter((i) => i.severity === "error").length, [driverIssues]);
+
   const handleGenerateQr = async (vehicle: AdminVehicle) => {
     setError("");
     setBusyVehicleId(vehicle.adc_vehicle_id);
     try {
       await rotateVehicleQr(vehicle.adc_vehicle_id);
       const payload = await getVehicleQrPayload(vehicle.adc_vehicle_id);
-      const imageUrl = await QRCode.toDataURL(payload.deep_link, {
-        margin: 1,
-        width: 240,
-      });
-      setQrModal({
-        vehicle,
-        payload: payload.deep_link,
-        imageUrl,
-      });
+      const imageUrl = await QRCode.toDataURL(payload.deep_link, { margin: 1, width: 240 });
+      setQrModal({ vehicle, payload: payload.deep_link, imageUrl });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to generate QR");
     } finally {
       setBusyVehicleId(null);
+    }
+  };
+
+  const submitVehicleImport = async () => {
+    setVehicleSubmitting(true);
+    try {
+      const created = await createVehicleImportJob({
+        provider: "csv_upload",
+        csv_content: vehicleCsv,
+        header_mapping: vehicleMapping,
+        inactive_unit_numbers: [],
+      });
+      setVehicleJob(await getVehicleImportJob(created.job_id));
+    } finally {
+      setVehicleSubmitting(false);
+    }
+  };
+
+  const submitDriverImport = async () => {
+    setDriverSubmitting(true);
+    try {
+      const created = await createDriverImportJob({
+        provider: "csv_upload",
+        csv_content: driverCsv,
+        header_mapping: driverMapping,
+        inactive_mobile_phones: [],
+      });
+      setDriverJob(await getDriverImportJob(created.job_id));
+    } finally {
+      setDriverSubmitting(false);
     }
   };
 
@@ -58,51 +209,96 @@ export default function AdminVehiclesPage() {
       {loading && <p className="text-gray-500">Loading…</p>}
       {error && <p className="mb-4 text-sm text-red-600">{error}</p>}
 
+      <section className="mb-8 space-y-4 rounded-lg border border-gray-200 bg-white p-4">
+        <h2 className="text-base font-semibold text-gray-900">Vehicle CSV import</h2>
+        <textarea value={vehicleCsv} onChange={(e) => setVehicleCsv(e.target.value)} rows={5} className="w-full rounded-md border p-2 text-sm" placeholder="Paste vehicle CSV content here" />
+        {vehiclePreview.length > 0 && <VehicleImportPreviewTable rows={vehiclePreview} />}
+        <CategorizedIssueList issues={vehicleIssues} />
+        <label className="flex items-center gap-2 text-sm">
+          <input type="checkbox" checked={vehicleConfirm} onChange={(e) => setVehicleConfirm(e.target.checked)} />
+          I reviewed mapping + validation and want to apply this vehicle import.
+        </label>
+        <button disabled={!vehicleConfirm || vehicleErrorCount > 0 || vehicleSubmitting || !vehicleCsv.trim()} onClick={submitVehicleImport} className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50">
+          {vehicleSubmitting ? "Submitting…" : "Apply vehicle import"}
+        </button>
+        {vehicleJob && (
+          <div className="space-y-3 rounded-md border border-gray-200 bg-gray-50 p-3">
+            <ImportJobProgress status={vehicleJob.status} total={vehicleJob.records_total} processed={vehicleJob.records_processed} />
+            {(vehicleJob.status === "succeeded" || vehicleJob.status === "failed") && (
+              <ImportSummary
+                title="Final summary"
+                items={[
+                  { label: "Imported", value: vehicleJob.records_imported },
+                  { label: "Updated", value: vehicleJob.records_updated },
+                  { label: "Skipped", value: vehicleJob.records_skipped },
+                  { label: "Errors", value: vehicleJob.records_errored },
+                  { label: "Missing QR", value: vehicleJob.summary.missing_qr_count },
+                  { label: "Missing mapping", value: vehicleJob.summary.missing_provider_mapping_count },
+                ]}
+              />
+            )}
+          </div>
+        )}
+      </section>
+
+      <section className="mb-8 space-y-4 rounded-lg border border-gray-200 bg-white p-4">
+        <h2 className="text-base font-semibold text-gray-900">Driver CSV import</h2>
+        <textarea value={driverCsv} onChange={(e) => setDriverCsv(e.target.value)} rows={5} className="w-full rounded-md border p-2 text-sm" placeholder="Paste driver CSV content here" />
+        {driverPreview.length > 0 && <DriverImportPreviewTable rows={driverPreview} />}
+        <CategorizedIssueList issues={driverIssues} />
+        <label className="flex items-center gap-2 text-sm">
+          <input type="checkbox" checked={driverConfirm} onChange={(e) => setDriverConfirm(e.target.checked)} />
+          I reviewed mapping + validation and want to apply this driver import.
+        </label>
+        <button disabled={!driverConfirm || driverErrorCount > 0 || driverSubmitting || !driverCsv.trim()} onClick={submitDriverImport} className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50">
+          {driverSubmitting ? "Submitting…" : "Apply driver import"}
+        </button>
+        {driverJob && (
+          <div className="space-y-3 rounded-md border border-gray-200 bg-gray-50 p-3">
+            <ImportJobProgress status={driverJob.status} total={driverJob.records_total} processed={driverJob.records_processed} />
+            {(driverJob.status === "succeeded" || driverJob.status === "failed") && (
+              <ImportSummary
+                title="Final summary"
+                items={[
+                  { label: "Imported", value: driverJob.records_imported },
+                  { label: "Updated", value: driverJob.records_updated },
+                  { label: "Skipped", value: driverJob.records_skipped },
+                  { label: "Errors", value: driverJob.records_errored },
+                  { label: "Needs review", value: driverJob.summary.needs_review_count },
+                  { label: "Invalid phone", value: driverJob.summary.invalid_phone_count },
+                ]}
+              />
+            )}
+          </div>
+        )}
+      </section>
+
       {!loading && (
         <div className="overflow-hidden rounded-lg border bg-white shadow dark:border-gray-700 dark:bg-gray-800">
           <table className="w-full text-left text-sm">
             <thead className="bg-gray-100 dark:bg-gray-700">
               <tr>
-                <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
-                  Vehicle
-                </th>
-                <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
-                  Actions
-                </th>
+                <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">Vehicle</th>
+                <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">Actions</th>
               </tr>
             </thead>
             <tbody className="divide-y dark:divide-gray-700">
               {vehicles.map((vehicle) => (
                 <tr key={vehicle.adc_vehicle_id}>
                   <td className="px-4 py-3">
-                    <p className="font-medium text-gray-800 dark:text-gray-100">
-                      {vehicle.display_label}
-                    </p>
-                    <p className="text-xs text-gray-500">
-                      {vehicle.adc_vehicle_id}
-                    </p>
+                    <p className="font-medium text-gray-800 dark:text-gray-100">{vehicle.display_label}</p>
+                    <p className="text-xs text-gray-500">{vehicle.adc_vehicle_id}</p>
                   </td>
                   <td className="px-4 py-3">
-                    <button
-                      onClick={() => handleGenerateQr(vehicle)}
-                      disabled={busyVehicleId === vehicle.adc_vehicle_id}
-                      className="rounded-md bg-blue-600 px-3 py-2 text-xs font-semibold text-white hover:bg-blue-700 disabled:opacity-60"
-                    >
-                      {busyVehicleId === vehicle.adc_vehicle_id
-                        ? "Generating…"
-                        : "Generate/Rotate QR"}
+                    <button onClick={() => handleGenerateQr(vehicle)} disabled={busyVehicleId === vehicle.adc_vehicle_id} className="rounded-md bg-blue-600 px-3 py-2 text-xs font-semibold text-white hover:bg-blue-700 disabled:opacity-60">
+                      {busyVehicleId === vehicle.adc_vehicle_id ? "Generating…" : "Generate/Rotate QR"}
                     </button>
                   </td>
                 </tr>
               ))}
               {vehicles.length === 0 && (
                 <tr>
-                  <td
-                    colSpan={2}
-                    className="px-4 py-6 text-center text-sm text-gray-500"
-                  >
-                    No vehicles configured.
-                  </td>
+                  <td colSpan={2} className="px-4 py-6 text-center text-sm text-gray-500">No vehicles configured.</td>
                 </tr>
               )}
             </tbody>
@@ -115,32 +311,14 @@ export default function AdminVehiclesPage() {
           <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-lg dark:bg-gray-800">
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h2 className="text-base font-semibold text-gray-800 dark:text-gray-100">
-                  QR for {qrModal.vehicle.display_label}
-                </h2>
-                <p className="text-xs text-gray-500">
-                  {qrModal.vehicle.adc_vehicle_id}
-                </p>
+                <h2 className="text-base font-semibold text-gray-800 dark:text-gray-100">QR for {qrModal.vehicle.display_label}</h2>
+                <p className="text-xs text-gray-500">{qrModal.vehicle.adc_vehicle_id}</p>
               </div>
-              <button
-                onClick={() => setQrModal(null)}
-                className="text-sm text-gray-500 hover:text-gray-700"
-              >
-                Close
-              </button>
+              <button onClick={() => setQrModal(null)} className="text-sm text-gray-500 hover:text-gray-700">Close</button>
             </div>
             <div className="mt-4 flex flex-col items-center gap-4">
-              <Image
-                src={qrModal.imageUrl}
-                alt={`QR for ${qrModal.vehicle.adc_vehicle_id}`}
-                width={240}
-                height={240}
-                unoptimized
-                className="h-60 w-60"
-              />
-              <p className="break-all text-xs text-gray-500">
-                {qrModal.payload}
-              </p>
+              <Image src={qrModal.imageUrl} alt={`QR for ${qrModal.vehicle.adc_vehicle_id}`} width={240} height={240} unoptimized className="h-60 w-60" />
+              <p className="break-all text-xs text-gray-500">{qrModal.payload}</p>
             </div>
           </div>
         </div>

--- a/frontend/components/imports/CategorizedIssueList.tsx
+++ b/frontend/components/imports/CategorizedIssueList.tsx
@@ -1,0 +1,45 @@
+import type { ImportIssue } from "@/lib/csvImport";
+
+type CategorizedIssueListProps = {
+  issues: ImportIssue[];
+};
+
+export default function CategorizedIssueList({ issues }: CategorizedIssueListProps) {
+  const grouped = issues.reduce<Record<string, ImportIssue[]>>((acc, issue) => {
+    const key = `${issue.severity}:${issue.category}`;
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(issue);
+    return acc;
+  }, {});
+
+  if (issues.length === 0) {
+    return <p className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">No validation issues found in preview rows.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {Object.entries(grouped).map(([key, values]) => {
+        const [severity, category] = key.split(":");
+        const isError = severity === "error";
+        return (
+          <div
+            key={key}
+            className={`rounded-md border px-3 py-2 ${
+              isError
+                ? "border-red-200 bg-red-50 text-red-700"
+                : "border-amber-200 bg-amber-50 text-amber-800"
+            }`}
+          >
+            <p className="text-sm font-semibold">{isError ? "Errors" : "Warnings"}: {category}</p>
+            <ul className="mt-1 list-disc pl-5 text-sm">
+              {values.slice(0, 8).map((issue, idx) => (
+                <li key={`${issue.message}-${idx}`}>{issue.message}</li>
+              ))}
+            </ul>
+            {values.length > 8 && <p className="mt-1 text-xs">+{values.length - 8} more in this category.</p>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/components/imports/DriverImportPreviewTable.tsx
+++ b/frontend/components/imports/DriverImportPreviewTable.tsx
@@ -1,0 +1,37 @@
+import type { DriverPreviewRow } from "@/lib/csvImport";
+
+type DriverImportPreviewTableProps = {
+  rows: DriverPreviewRow[];
+};
+
+export default function DriverImportPreviewTable({ rows }: DriverImportPreviewTableProps) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-gray-200">
+      <table className="w-full text-left text-sm">
+        <thead className="bg-gray-50 text-gray-700">
+          <tr>
+            <th className="px-3 py-2 font-medium">First Name</th>
+            <th className="px-3 py-2 font-medium">Last Name</th>
+            <th className="px-3 py-2 font-medium">Phone</th>
+            <th className="px-3 py-2 font-medium">Provider Driver ID</th>
+            <th className="px-3 py-2 font-medium">Active</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100 bg-white">
+          {rows.slice(0, 12).map((row, idx) => (
+            <tr key={`${row.phone}-${idx}`}>
+              <td className="px-3 py-2">{row.firstName || <span className="text-red-600">Missing</span>}</td>
+              <td className="px-3 py-2">{row.lastName || <span className="text-red-600">Missing</span>}</td>
+              <td className="px-3 py-2">{row.phone || <span className="text-red-600">Missing</span>}</td>
+              <td className="px-3 py-2">{row.providerDriverId || <span className="text-gray-400">—</span>}</td>
+              <td className="px-3 py-2">{row.isActive}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {rows.length > 12 && (
+        <p className="border-t bg-gray-50 px-3 py-2 text-xs text-gray-500">Showing first 12 of {rows.length} rows.</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/imports/VehicleImportPreviewTable.tsx
+++ b/frontend/components/imports/VehicleImportPreviewTable.tsx
@@ -1,0 +1,35 @@
+import type { VehiclePreviewRow } from "@/lib/csvImport";
+
+type VehicleImportPreviewTableProps = {
+  rows: VehiclePreviewRow[];
+};
+
+export default function VehicleImportPreviewTable({ rows }: VehicleImportPreviewTableProps) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-gray-200">
+      <table className="w-full text-left text-sm">
+        <thead className="bg-gray-50 text-gray-700">
+          <tr>
+            <th className="px-3 py-2 font-medium">Unit Number</th>
+            <th className="px-3 py-2 font-medium">VIN</th>
+            <th className="px-3 py-2 font-medium">Provider Vehicle ID</th>
+            <th className="px-3 py-2 font-medium">Active</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100 bg-white">
+          {rows.slice(0, 12).map((row, idx) => (
+            <tr key={`${row.unitNumber}-${idx}`}>
+              <td className="px-3 py-2">{row.unitNumber || <span className="text-red-600">Missing</span>}</td>
+              <td className="px-3 py-2">{row.vin || <span className="text-amber-700">Missing</span>}</td>
+              <td className="px-3 py-2">{row.providerVehicleId || <span className="text-gray-400">—</span>}</td>
+              <td className="px-3 py-2">{row.isActive}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {rows.length > 12 && (
+        <p className="border-t bg-gray-50 px-3 py-2 text-xs text-gray-500">Showing first 12 of {rows.length} rows.</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -677,6 +677,80 @@ export interface CaseOpsQueueItem {
   blockers: CaseOpsQueueBlockerCounts;
 }
 
+
+
+export type ImportJobStatus = "pending" | "running" | "succeeded" | "failed";
+
+export interface VehicleImportJobSummary {
+  missing_qr_count: number;
+  missing_provider_mapping_count: number;
+  duplicate_like_count: number;
+  inactive_count: number;
+}
+
+export interface VehicleImportJobOutcome {
+  imported: string[];
+  updated: string[];
+  skipped: string[];
+  errored: string[];
+}
+
+export interface VehicleImportJobResponse {
+  job_id: string;
+  provider: string;
+  status: ImportJobStatus;
+  started_at_utc?: string | null;
+  completed_at_utc?: string | null;
+  records_total: number;
+  records_processed: number;
+  records_imported: number;
+  records_updated: number;
+  records_skipped: number;
+  records_errored: number;
+  warnings: string[];
+  outcomes: VehicleImportJobOutcome;
+  summary: VehicleImportJobSummary;
+  error_message?: string | null;
+}
+
+export interface DriverImportJobSummary {
+  invalid_phone_count: number;
+  duplicate_warning_count: number;
+  missing_assignment_count: number;
+  missing_external_mapping_count: number;
+  needs_review_count: number;
+  inactive_count: number;
+}
+
+export interface DriverImportJobOutcome {
+  imported: string[];
+  updated: string[];
+  skipped: string[];
+  errored: string[];
+  invalid_phone: string[];
+  duplicate_warning: string[];
+  missing_assignment_or_mapping: string[];
+  needs_review: string[];
+}
+
+export interface DriverImportJobResponse {
+  job_id: string;
+  provider: string;
+  status: ImportJobStatus;
+  started_at_utc?: string | null;
+  completed_at_utc?: string | null;
+  records_total: number;
+  records_processed: number;
+  records_imported: number;
+  records_updated: number;
+  records_skipped: number;
+  records_errored: number;
+  warnings: string[];
+  outcomes: DriverImportJobOutcome;
+  summary: DriverImportJobSummary;
+  error_message?: string | null;
+}
+
 export interface CaseOpsQueueResponse {
   items: CaseOpsQueueItem[];
   total: number;
@@ -729,6 +803,39 @@ export function rotateVehicleQr(vehicleId: string) {
 
 export function getVehicleQrPayload(vehicleId: string) {
   return request<{ deep_link: string }>(`/admin/vehicles/${vehicleId}/qr`);
+}
+
+
+export function createVehicleImportJob(data: {
+  provider: string;
+  csv_content: string;
+  header_mapping: Record<string, string>;
+  inactive_unit_numbers: string[];
+}) {
+  return request<{ job_id: string; status: ImportJobStatus }>("/org/vehicles/import", {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export function getVehicleImportJob(jobId: string) {
+  return request<VehicleImportJobResponse>(`/org/vehicles/import-jobs/${jobId}`);
+}
+
+export function createDriverImportJob(data: {
+  provider: string;
+  csv_content: string;
+  header_mapping: Record<string, string>;
+  inactive_mobile_phones: string[];
+}) {
+  return request<{ job_id: string; status: ImportJobStatus }>("/org/drivers/import", {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export function getDriverImportJob(jobId: string) {
+  return request<DriverImportJobResponse>(`/org/drivers/import-jobs/${jobId}`);
 }
 
 export function getIncidentQueue(params?: {

--- a/frontend/lib/csvImport.ts
+++ b/frontend/lib/csvImport.ts
@@ -1,0 +1,195 @@
+export type ImportIssueSeverity = "error" | "warning";
+
+export interface ImportIssue {
+  severity: ImportIssueSeverity;
+  category: string;
+  message: string;
+  rowIndex?: number;
+}
+
+export interface ParsedCsv {
+  headers: string[];
+  rows: string[][];
+}
+
+export function parseCsv(content: string): ParsedCsv {
+  const rows: string[][] = [];
+  let currentRow: string[] = [];
+  let currentCell = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < content.length; i += 1) {
+    const char = content[i];
+    const next = content[i + 1];
+
+    if (char === '"') {
+      if (inQuotes && next === '"') {
+        currentCell += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (!inQuotes && char === ",") {
+      currentRow.push(currentCell.trim());
+      currentCell = "";
+      continue;
+    }
+
+    if (!inQuotes && (char === "\n" || char === "\r")) {
+      if (char === "\r" && next === "\n") i += 1;
+      currentRow.push(currentCell.trim());
+      if (currentRow.some((cell) => cell.length > 0)) {
+        rows.push(currentRow);
+      }
+      currentRow = [];
+      currentCell = "";
+      continue;
+    }
+
+    currentCell += char;
+  }
+
+  if (currentCell.length > 0 || currentRow.length > 0) {
+    currentRow.push(currentCell.trim());
+    if (currentRow.some((cell) => cell.length > 0)) {
+      rows.push(currentRow);
+    }
+  }
+
+  if (rows.length === 0) return { headers: [], rows: [] };
+  const [headers, ...dataRows] = rows;
+  return { headers, rows: dataRows };
+}
+
+export function normalizeHeader(header: string): string {
+  return header.trim().toLowerCase().replace(/[^a-z0-9_]/g, "");
+}
+
+export function autoMapHeaders(
+  headers: string[],
+  aliases: Record<string, string[]>
+): Record<string, string> {
+  const normalizedToOriginal = new Map(headers.map((h) => [normalizeHeader(h), h]));
+  const mapping: Record<string, string> = {};
+
+  Object.entries(aliases).forEach(([canonical, values]) => {
+    for (const value of values) {
+      const found = normalizedToOriginal.get(normalizeHeader(value));
+      if (found) {
+        mapping[canonical] = found;
+        break;
+      }
+    }
+  });
+
+  return mapping;
+}
+
+function cell(row: Record<string, string>, key?: string): string {
+  if (!key) return "";
+  return (row[key] ?? "").trim();
+}
+
+export function buildRowObjects(headers: string[], rows: string[][]): Record<string, string>[] {
+  return rows.map((raw) => {
+    const out: Record<string, string> = {};
+    headers.forEach((header, i) => {
+      out[header] = raw[i] ?? "";
+    });
+    return out;
+  });
+}
+
+export interface VehiclePreviewRow {
+  unitNumber: string;
+  vin: string;
+  providerVehicleId: string;
+  isActive: string;
+}
+
+export interface DriverPreviewRow {
+  firstName: string;
+  lastName: string;
+  phone: string;
+  providerDriverId: string;
+  isActive: string;
+}
+
+export function buildVehiclePreview(
+  rows: Record<string, string>[],
+  mapping: Record<string, string>
+): { previewRows: VehiclePreviewRow[]; issues: ImportIssue[] } {
+  const issues: ImportIssue[] = [];
+  const seen = new Set<string>();
+
+  const previewRows = rows.map((row, index) => {
+    const unit = cell(row, mapping.unit_number);
+    const vin = cell(row, mapping.vin);
+    const providerVehicleId = cell(row, mapping.provider_vehicle_id);
+    const isActive = cell(row, mapping.is_active) || "true";
+
+    if (!unit) {
+      issues.push({ severity: "error", category: "Required fields", message: `Row ${index + 2}: unit number is required`, rowIndex: index });
+    }
+    const key = unit.toLowerCase();
+    if (unit && seen.has(key)) {
+      issues.push({ severity: "error", category: "Duplicate values", message: `Row ${index + 2}: duplicate unit number '${unit}'`, rowIndex: index });
+    }
+    if (unit) seen.add(key);
+
+    if (!vin) {
+      issues.push({ severity: "warning", category: "Data completeness", message: `Row ${index + 2}: VIN is missing`, rowIndex: index });
+    }
+
+    return { unitNumber: unit, vin, providerVehicleId, isActive };
+  });
+
+  if (!mapping.unit_number) {
+    issues.unshift({ severity: "error", category: "Column mapping", message: "No column mapped to unit number." });
+  }
+
+  return { previewRows, issues };
+}
+
+const PHONE_RE = /^\+?[1-9]\d{7,14}$/;
+
+export function buildDriverPreview(
+  rows: Record<string, string>[],
+  mapping: Record<string, string>
+): { previewRows: DriverPreviewRow[]; issues: ImportIssue[] } {
+  const issues: ImportIssue[] = [];
+  const seenPhones = new Set<string>();
+
+  const previewRows = rows.map((row, index) => {
+    const firstName = cell(row, mapping.first_name);
+    const lastName = cell(row, mapping.last_name);
+    const phone = cell(row, mapping.phone);
+    const providerDriverId = cell(row, mapping.provider_driver_id);
+    const isActive = cell(row, mapping.is_active) || "true";
+
+    if (!firstName || !lastName || !phone) {
+      issues.push({ severity: "error", category: "Required fields", message: `Row ${index + 2}: first name, last name, and phone are required`, rowIndex: index });
+    }
+
+    if (phone && !PHONE_RE.test(phone.replace(/[\s()-]/g, ""))) {
+      issues.push({ severity: "warning", category: "Phone formatting", message: `Row ${index + 2}: phone may not be in E.164 format`, rowIndex: index });
+    }
+
+    const key = phone.toLowerCase();
+    if (phone && seenPhones.has(key)) {
+      issues.push({ severity: "error", category: "Duplicate values", message: `Row ${index + 2}: duplicate phone '${phone}'`, rowIndex: index });
+    }
+    if (phone) seenPhones.add(key);
+
+    return { firstName, lastName, phone, providerDriverId, isActive };
+  });
+
+  if (!mapping.phone) {
+    issues.unshift({ severity: "error", category: "Column mapping", message: "No column mapped to phone." });
+  }
+
+  return { previewRows, issues };
+}


### PR DESCRIPTION
### Motivation
- Provide admins a safe CSV import flow for vehicles and drivers with client-side preview, validation and a confirmation gate before applying changes.
- Surface categorized errors/warnings and a concise final summary so import results are easy to review and remediate.
- Support async import processing by creating jobs and polling for progress and final outcomes so the UI stays responsive.

### Description
- Added client-side CSV parsing, header auto-mapping, preview builders and validation rules in `frontend/lib/csvImport.ts` (vehicle + driver preview shapes, issue model, helpers like `parseCsv`, `autoMapHeaders`, `buildVehiclePreview`, `buildDriverPreview`).
- Implemented preview tables `VehicleImportPreviewTable` and `DriverImportPreviewTable` under `frontend/components/imports/` that show the first rows and missing-field indicators.
- Implemented `CategorizedIssueList` to group and display errors/warnings by severity and category with truncation for long lists.
- Extended the admin vehicles page (`frontend/app/admin/vehicles/page.tsx`) to include CSV paste areas, auto-mapping, previews, categorized issue display, apply-confirmation checkbox, import submission (`createVehicleImportJob`/`createDriverImportJob`), import job polling and final summary cards.
- Added API client types and functions to `frontend/lib/api.ts` for import job creation and querying (`createVehicleImportJob`, `getVehicleImportJob`, `createDriverImportJob`, `getDriverImportJob`) and typed import job response models.

### Testing
- Ran lint: `cd frontend && npm run lint` — succeeded.
- Ran TypeScript typecheck: `cd frontend && npm run typecheck` — succeeded.
- Ran frontend unit tests: `cd frontend && npm test` — all tests passed (5/5).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a5efcfd083219533be3e78c324e8)