### PR TITLE
Add onboarding validation/setup pages and supporting panels

### DIFF
--- a/frontend/app/onboarding/integration-setup/IntegrationSetupPage.tsx
+++ b/frontend/app/onboarding/integration-setup/IntegrationSetupPage.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import MainLayout from "@/components/MainLayout";
+import IntegrationValidationPanel from "@/components/onboarding/IntegrationValidationPanel";
+import {
+  getIntegrationValidationResults,
+  getOrgOnboardingStatus,
+  toUserErrorMessage,
+  type IntegrationValidationResult,
+  type OrgLaunchReadiness,
+} from "@/lib/api";
+import { getReadinessStepStatus } from "@/lib/onboarding";
+
+export default function IntegrationSetupPage() {
+  const [readiness, setReadiness] = useState<OrgLaunchReadiness | null>(null);
+  const [results, setResults] = useState<IntegrationValidationResult[]>([]);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    Promise.all([getOrgOnboardingStatus(), getIntegrationValidationResults()])
+      .then(([readinessPayload, validationPayload]) => {
+        setReadiness(readinessPayload);
+        setResults(validationPayload);
+        setError("");
+      })
+      .catch((err) => setError(toUserErrorMessage(err, "Failed to load integration setup data")));
+  }, []);
+
+  const status = useMemo(() => getReadinessStepStatus(readiness?.steps ?? [], "integrations"), [readiness]);
+
+  return (
+    <MainLayout title="Integration Setup">
+      <div className="space-y-4">
+        {error ? <p className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p> : null}
+        <IntegrationValidationPanel status={status} results={results} />
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/app/onboarding/integration-setup/page.tsx
+++ b/frontend/app/onboarding/integration-setup/page.tsx
@@ -1,0 +1,5 @@
+import IntegrationSetupPage from "./IntegrationSetupPage";
+
+export default function Page() {
+  return <IntegrationSetupPage />;
+}

--- a/frontend/app/onboarding/mapping-validation/MappingValidationPage.tsx
+++ b/frontend/app/onboarding/mapping-validation/MappingValidationPage.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import MainLayout from "@/components/MainLayout";
+import MappingValidationPanel from "@/components/onboarding/MappingValidationPanel";
+import { getOrgOnboardingStatus, toUserErrorMessage, type OrgLaunchReadiness } from "@/lib/api";
+import { getReadinessBlockersForStep, getReadinessStepStatus } from "@/lib/onboarding";
+
+export default function MappingValidationPage() {
+  const [readiness, setReadiness] = useState<OrgLaunchReadiness | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    getOrgOnboardingStatus()
+      .then((payload) => {
+        setReadiness(payload);
+        setError("");
+      })
+      .catch((err) => setError(toUserErrorMessage(err, "Failed to load mapping validation data")));
+  }, []);
+
+  const status = useMemo(() => getReadinessStepStatus(readiness?.steps ?? [], "mappings"), [readiness]);
+  const blockers = useMemo(
+    () => getReadinessBlockersForStep(readiness?.blockers ?? [], "mappings"),
+    [readiness]
+  );
+
+  return (
+    <MainLayout title="Mapping Validation">
+      <div className="space-y-4">
+        {error ? <p className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p> : null}
+        <MappingValidationPanel status={status} blockers={blockers} />
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/app/onboarding/mapping-validation/page.tsx
+++ b/frontend/app/onboarding/mapping-validation/page.tsx
@@ -1,0 +1,5 @@
+import MappingValidationPage from "./MappingValidationPage";
+
+export default function Page() {
+  return <MappingValidationPage />;
+}

--- a/frontend/app/onboarding/protocol-setup/ProtocolSetupPage.tsx
+++ b/frontend/app/onboarding/protocol-setup/ProtocolSetupPage.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import MainLayout from "@/components/MainLayout";
+import {
+  getOrgOnboardingStatus,
+  getProtocolSetupStepData,
+  toUserErrorMessage,
+  type OrgLaunchReadiness,
+  type ProtocolSetupStepData,
+} from "@/lib/api";
+import { getReadinessStepStatus } from "@/lib/onboarding";
+import { formatStatus, getStatusClasses } from "@/components/onboarding/status";
+import Link from "next/link";
+
+const EMPTY_PROTOCOL: ProtocolSetupStepData = {
+  instruction_set_selected: false,
+  instruction_source: "default",
+  safety_contact_configured: false,
+  safety_manager_phone: null,
+  required_media_prompts_defaulted: false,
+  export_profile_defaulted: false,
+  export_profiles_available: [],
+};
+
+export default function ProtocolSetupPage() {
+  const [readiness, setReadiness] = useState<OrgLaunchReadiness | null>(null);
+  const [data, setData] = useState<ProtocolSetupStepData>(EMPTY_PROTOCOL);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    Promise.all([getOrgOnboardingStatus(), getProtocolSetupStepData()])
+      .then(([readinessPayload, protocolPayload]) => {
+        setReadiness(readinessPayload);
+        setData(protocolPayload);
+        setError("");
+      })
+      .catch((err) => setError(toUserErrorMessage(err, "Failed to load protocol setup data")));
+  }, []);
+
+  const status = useMemo(() => getReadinessStepStatus(readiness?.steps ?? [], "driver_protocol"), [readiness]);
+
+  return (
+    <MainLayout title="Protocol Setup">
+      <div className="space-y-4">
+        {error ? <p className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p> : null}
+        <section className="rounded-lg border border-gray-200 bg-white p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h2 className="text-lg font-semibold text-gray-900">Driver protocol readiness</h2>
+            <span className={`rounded-full px-2 py-1 text-xs font-semibold ${getStatusClasses(status)}`}>{formatStatus(status)}</span>
+          </div>
+          <p className="mt-1 text-sm text-gray-600">Confirm protocol status and complete remediation actions before launch.</p>
+          <div className="mt-3 flex gap-3 text-xs">
+            <Link href="/dashboard?blockers=critical" className="font-semibold text-blue-700 hover:underline">View blockers</Link>
+            <Link href="/admin/driver-protocol" className="font-semibold text-blue-700 hover:underline">Open remediation actions</Link>
+          </div>
+
+          <dl className="mt-4 grid gap-2 text-sm sm:grid-cols-2">
+            <div className="rounded border border-gray-200 p-2">
+              <dt className="text-xs text-gray-500">Instruction set</dt>
+              <dd className="font-semibold text-gray-900">{data.instruction_set_selected ? data.instruction_source : "Not configured"}</dd>
+            </div>
+            <div className="rounded border border-gray-200 p-2">
+              <dt className="text-xs text-gray-500">Safety contact configured</dt>
+              <dd className="font-semibold text-gray-900">{data.safety_contact_configured ? "Yes" : "No"}</dd>
+            </div>
+            <div className="rounded border border-gray-200 p-2">
+              <dt className="text-xs text-gray-500">Safety manager phone</dt>
+              <dd className="font-semibold text-gray-900">{data.safety_manager_phone ?? "Missing"}</dd>
+            </div>
+            <div className="rounded border border-gray-200 p-2">
+              <dt className="text-xs text-gray-500">Export profiles available</dt>
+              <dd className="font-semibold text-gray-900">{data.export_profiles_available.length}</dd>
+            </div>
+          </dl>
+        </section>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/app/onboarding/protocol-setup/page.tsx
+++ b/frontend/app/onboarding/protocol-setup/page.tsx
@@ -1,0 +1,5 @@
+import ProtocolSetupPage from "./ProtocolSetupPage";
+
+export default function Page() {
+  return <ProtocolSetupPage />;
+}

--- a/frontend/app/onboarding/qr-deployment/QrDeploymentPage.tsx
+++ b/frontend/app/onboarding/qr-deployment/QrDeploymentPage.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import MainLayout from "@/components/MainLayout";
+import QrDeploymentTable from "@/components/onboarding/QrDeploymentTable";
+import { getOrgOnboardingQrStats, getOrgOnboardingStatus, toUserErrorMessage, type OrgLaunchReadiness, type VehicleQrStats } from "@/lib/api";
+import { getReadinessStepStatus } from "@/lib/onboarding";
+import { formatStatus, getStatusClasses } from "@/components/onboarding/status";
+import Link from "next/link";
+
+const EMPTY_QR_STATS: VehicleQrStats = {
+  required_vehicle_count: 0,
+  generated_count: 0,
+  distributed_count: 0,
+  confirmed_count: 0,
+  coverage_blockers: [],
+};
+
+export default function QrDeploymentPage() {
+  const [readiness, setReadiness] = useState<OrgLaunchReadiness | null>(null);
+  const [qrStats, setQrStats] = useState<VehicleQrStats>(EMPTY_QR_STATS);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    Promise.all([getOrgOnboardingStatus(), getOrgOnboardingQrStats()])
+      .then(([readinessPayload, qrPayload]) => {
+        setReadiness(readinessPayload);
+        setQrStats(qrPayload);
+        setError("");
+      })
+      .catch((err) => setError(toUserErrorMessage(err, "Failed to load QR deployment data")));
+  }, []);
+
+  const status = useMemo(() => getReadinessStepStatus(readiness?.steps ?? [], "vehicle_qr"), [readiness]);
+
+  return (
+    <MainLayout title="QR Deployment">
+      <div className="space-y-4">
+        {error ? <p className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p> : null}
+        <section className="rounded-lg border border-gray-200 bg-white p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h2 className="text-lg font-semibold text-gray-900">QR deployment coverage</h2>
+            <span className={`rounded-full px-2 py-1 text-xs font-semibold ${getStatusClasses(status)}`}>{formatStatus(status)}</span>
+          </div>
+          <p className="mt-1 text-sm text-gray-600">Track deployment status, blockers, and remediation actions for vehicle QR onboarding.</p>
+          <div className="mt-3 flex gap-3 text-xs">
+            <Link href="/dashboard?blockers=critical" className="font-semibold text-blue-700 hover:underline">View blockers</Link>
+            <Link href="/vehicles" className="font-semibold text-blue-700 hover:underline">Open remediation actions</Link>
+          </div>
+          <div className="mt-4">
+            <QrDeploymentTable stats={qrStats} />
+          </div>
+        </section>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/app/onboarding/qr-deployment/page.tsx
+++ b/frontend/app/onboarding/qr-deployment/page.tsx
@@ -1,0 +1,5 @@
+import QrDeploymentPage from "./QrDeploymentPage";
+
+export default function Page() {
+  return <QrDeploymentPage />;
+}

--- a/frontend/app/onboarding/sample-incident-validation/SampleIncidentValidationPage.tsx
+++ b/frontend/app/onboarding/sample-incident-validation/SampleIncidentValidationPage.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import MainLayout from "@/components/MainLayout";
+import SampleIncidentRunPanel from "@/components/onboarding/SampleIncidentRunPanel";
+import { getOrgOnboardingStatus, toUserErrorMessage, type OrgLaunchReadiness } from "@/lib/api";
+import { getReadinessBlockersForStep, getReadinessStepStatus } from "@/lib/onboarding";
+
+export default function SampleIncidentValidationPage() {
+  const [readiness, setReadiness] = useState<OrgLaunchReadiness | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    getOrgOnboardingStatus()
+      .then((payload) => {
+        setReadiness(payload);
+        setError("");
+      })
+      .catch((err) => setError(toUserErrorMessage(err, "Failed to load sample incident validation data")));
+  }, []);
+
+  const status = useMemo(() => getReadinessStepStatus(readiness?.steps ?? [], "testIncidentCompleted"), [readiness]);
+  const blockers = useMemo(
+    () => getReadinessBlockersForStep(readiness?.blockers ?? [], "testIncidentCompleted"),
+    [readiness]
+  );
+
+  return (
+    <MainLayout title="Sample Incident Validation">
+      <div className="space-y-4">
+        {error ? <p className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p> : null}
+        <SampleIncidentRunPanel status={status} blockers={blockers} />
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/app/onboarding/sample-incident-validation/page.tsx
+++ b/frontend/app/onboarding/sample-incident-validation/page.tsx
@@ -1,0 +1,5 @@
+import SampleIncidentValidationPage from "./SampleIncidentValidationPage";
+
+export default function Page() {
+  return <SampleIncidentValidationPage />;
+}

--- a/frontend/components/onboarding/IntegrationValidationPanel.tsx
+++ b/frontend/components/onboarding/IntegrationValidationPanel.tsx
@@ -1,0 +1,41 @@
+import type { IntegrationValidationResult, OnboardingStepStatus } from "@/lib/api";
+import { formatStatus, getStatusClasses } from "@/components/onboarding/status";
+import Link from "next/link";
+
+type IntegrationValidationPanelProps = {
+  status: OnboardingStepStatus;
+  results: IntegrationValidationResult[];
+};
+
+export default function IntegrationValidationPanel({ status, results }: IntegrationValidationPanelProps) {
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-lg font-semibold text-gray-900">Integration setup validation</h2>
+        <span className={`rounded-full px-2 py-1 text-xs font-semibold ${getStatusClasses(status)}`}>{formatStatus(status)}</span>
+      </div>
+      <p className="mt-1 text-sm text-gray-600">Track validation status and jump directly to blocker and remediation workflows.</p>
+
+      <div className="mt-3 flex gap-3 text-xs">
+        <Link href="/dashboard?blockers=critical" className="font-semibold text-blue-700 hover:underline">View blockers</Link>
+        <Link href="/settings/integrations" className="font-semibold text-blue-700 hover:underline">Open remediation actions</Link>
+      </div>
+
+      <ul className="mt-4 space-y-2">
+        {results.length === 0 ? (
+          <li className="rounded border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700">No integration checks yet.</li>
+        ) : (
+          results.map((result) => (
+            <li key={`${result.integration_id}-${result.timestamp}`} className="rounded border border-gray-200 px-3 py-2 text-sm">
+              <p className="font-semibold text-gray-900">{result.integration_id}</p>
+              <p className="text-xs text-gray-600">
+                Credential: {formatStatus(result.credentialStatus)} · Capability: {formatStatus(result.capabilityStatus)} · Mapping: {formatStatus(result.mappingStatus)}
+              </p>
+              {result.messages.length > 0 ? <p className="mt-1 text-xs text-amber-700">{result.messages.join(" • ")}</p> : null}
+            </li>
+          ))
+        )}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/components/onboarding/MappingIssuesTable.tsx
+++ b/frontend/components/onboarding/MappingIssuesTable.tsx
@@ -1,0 +1,44 @@
+import type { OnboardingBlocker } from "@/lib/api";
+import Link from "next/link";
+
+type MappingIssuesTableProps = {
+  blockers: OnboardingBlocker[];
+};
+
+const REMEDIATION_LINK = "/onboarding/integration-setup";
+
+export default function MappingIssuesTable({ blockers }: MappingIssuesTableProps) {
+  if (blockers.length === 0) {
+    return <p className="rounded border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">No mapping blockers found.</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto rounded border border-gray-200">
+      <table className="min-w-full divide-y divide-gray-200 text-sm">
+        <thead className="bg-gray-50 text-left text-xs uppercase tracking-wide text-gray-600">
+          <tr>
+            <th className="px-3 py-2">Issue</th>
+            <th className="px-3 py-2">Severity</th>
+            <th className="px-3 py-2">Action</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100 bg-white">
+          {blockers.map((blocker) => (
+            <tr key={blocker.code}>
+              <td className="px-3 py-3">
+                <p className="font-semibold text-gray-900">{blocker.title}</p>
+                <p className="text-xs text-gray-600">{blocker.detail}</p>
+              </td>
+              <td className="px-3 py-3 text-xs font-semibold uppercase text-amber-700">{blocker.severity}</td>
+              <td className="px-3 py-3">
+                <Link href={REMEDIATION_LINK} className="text-xs font-semibold text-blue-700 hover:underline">
+                  Open remediation actions
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/components/onboarding/MappingValidationPanel.tsx
+++ b/frontend/components/onboarding/MappingValidationPanel.tsx
@@ -1,0 +1,35 @@
+import type { OnboardingStepStatus, OnboardingBlocker } from "@/lib/api";
+import MappingIssuesTable from "@/components/onboarding/MappingIssuesTable";
+import { formatStatus, getStatusClasses } from "@/components/onboarding/status";
+import Link from "next/link";
+
+type MappingValidationPanelProps = {
+  status: OnboardingStepStatus;
+  blockers: OnboardingBlocker[];
+};
+
+export default function MappingValidationPanel({ status, blockers }: MappingValidationPanelProps) {
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white p-4">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">Mapping validation</h2>
+          <p className="text-sm text-gray-600">Mark and review step status before launch.</p>
+        </div>
+        <span className={`rounded-full px-2 py-1 text-xs font-semibold ${getStatusClasses(status)}`}>{formatStatus(status)}</span>
+      </header>
+
+      <div className="mt-4 space-y-2">
+        <p className="text-sm font-semibold text-gray-800">Blockers and remediation actions</p>
+        <div className="flex gap-3 text-xs">
+          <Link href="/dashboard?blockers=critical" className="font-semibold text-blue-700 hover:underline">View blockers</Link>
+          <Link href="/settings/integrations" className="font-semibold text-blue-700 hover:underline">Open remediation actions</Link>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <MappingIssuesTable blockers={blockers} />
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/onboarding/QrDeploymentTable.tsx
+++ b/frontend/components/onboarding/QrDeploymentTable.tsx
@@ -1,0 +1,40 @@
+import type { VehicleQrStats } from "@/lib/api";
+
+type QrDeploymentTableProps = {
+  stats: VehicleQrStats;
+};
+
+const rows = [
+  { key: "required_vehicle_count", label: "Vehicles required" },
+  { key: "generated_count", label: "QR generated" },
+  { key: "distributed_count", label: "QR distributed" },
+  { key: "confirmed_count", label: "Deployments confirmed" },
+] as const;
+
+export default function QrDeploymentTable({ stats }: QrDeploymentTableProps) {
+  return (
+    <div className="space-y-3">
+      <div className="overflow-x-auto rounded border border-gray-200">
+        <table className="min-w-full divide-y divide-gray-200 text-sm">
+          <tbody className="divide-y divide-gray-100 bg-white">
+            {rows.map((row) => (
+              <tr key={row.key}>
+                <td className="px-3 py-2 font-medium text-gray-900">{row.label}</td>
+                <td className="px-3 py-2 text-right text-gray-700">{stats[row.key]}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {stats.coverage_blockers.length > 0 ? (
+        <ul className="space-y-1 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+          {stats.coverage_blockers.map((blocker) => (
+            <li key={blocker}>• {blocker}</li>
+          ))}
+        </ul>
+      ) : (
+        <p className="rounded border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">No QR coverage blockers detected.</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/onboarding/SampleIncidentRunPanel.tsx
+++ b/frontend/components/onboarding/SampleIncidentRunPanel.tsx
@@ -1,0 +1,40 @@
+import type { OnboardingBlocker, OnboardingStepStatus } from "@/lib/api";
+import { formatStatus, getStatusClasses } from "@/components/onboarding/status";
+import Link from "next/link";
+
+type SampleIncidentRunPanelProps = {
+  status: OnboardingStepStatus;
+  blockers: OnboardingBlocker[];
+};
+
+export default function SampleIncidentRunPanel({ status, blockers }: SampleIncidentRunPanelProps) {
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-lg font-semibold text-gray-900">Sample incident validation</h2>
+        <span className={`rounded-full px-2 py-1 text-xs font-semibold ${getStatusClasses(status)}`}>{formatStatus(status)}</span>
+      </div>
+      <p className="mt-1 text-sm text-gray-600">Run a dry-run incident and resolve blockers before launch sign-off.</p>
+
+      <div className="mt-3 flex gap-3 text-xs">
+        <Link href="/dashboard?blockers=critical" className="font-semibold text-blue-700 hover:underline">View blockers</Link>
+        <Link href="/incidents" className="font-semibold text-blue-700 hover:underline">Open remediation actions</Link>
+      </div>
+
+      <div className="mt-4">
+        {blockers.length === 0 ? (
+          <p className="rounded border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">No sample incident blockers reported.</p>
+        ) : (
+          <ul className="space-y-2">
+            {blockers.map((blocker) => (
+              <li key={blocker.code} className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm">
+                <p className="font-semibold text-amber-900">{blocker.title}</p>
+                <p className="text-amber-800">{blocker.detail}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/onboarding/status.ts
+++ b/frontend/components/onboarding/status.ts
@@ -1,0 +1,12 @@
+import type { OnboardingStepStatus } from "@/lib/api";
+
+export function getStatusClasses(status: OnboardingStepStatus): string {
+  if (status === "completed") return "bg-green-100 text-green-700";
+  if (status === "blocked") return "bg-red-100 text-red-700";
+  if (status === "in_progress") return "bg-amber-100 text-amber-700";
+  return "bg-gray-100 text-gray-700";
+}
+
+export function formatStatus(status: OnboardingStepStatus): string {
+  return status.replaceAll("_", " ");
+}

--- a/frontend/lib/onboarding.ts
+++ b/frontend/lib/onboarding.ts
@@ -1,1 +1,14 @@
+import type { OnboardingReadinessStep, OnboardingStepStatus } from "@/lib/api";
+
 export const ONBOARDING_WIZARD_STORAGE_KEY = "adc.onboarding.currentStep";
+
+export function getReadinessStepStatus(steps: OnboardingReadinessStep[], key: string): OnboardingStepStatus {
+  return steps.find((step) => step.key === key)?.status ?? "not_started";
+}
+
+export function getReadinessBlockersForStep<T extends { blocking_step_key?: string | null }>(
+  blockers: T[],
+  stepKey: string
+): T[] {
+  return blockers.filter((blocker) => blocker.blocking_step_key === stepKey);
+}


### PR DESCRIPTION
### Motivation
- Provide dedicated onboarding sub-pages to review and remediate step-specific readiness signals during launch preparation. 
- Surface per-step blocker lists and remediation links so operators can quickly jump to actions that unblock onboarding progress. 
- Reuse shared status formatting and readiness helpers to keep page logic consistent with existing onboarding flows.

### Description
- Added five client pages under `frontend/app/onboarding/`: `mapping-validation`, `integration-setup`, `qr-deployment`, `protocol-setup`, and `sample-incident-validation`, each wired to onboarding APIs and showing the step status. 
- Implemented new components: `MappingValidationPanel`, `MappingIssuesTable`, `IntegrationValidationPanel`, `QrDeploymentTable`, and `SampleIncidentRunPanel` to render status badges, blockers, and remediation links. 
- Introduced `frontend/components/onboarding/status.ts` for consistent status badge classes and formatting and `frontend/lib/onboarding.ts` helpers `getReadinessStepStatus` and `getReadinessBlockersForStep` for per-step derivation. 
- Replaced raw `<a>` hrefs with Next.js `Link` where appropriate and ensured each page links to blocker filters and remediation destinations (dashboard, integrations, vehicles, driver protocol, incidents).

### Testing
- Ran lint with `cd frontend && npm run lint` and the build-time linting succeeded after updates. 
- Ran type checking with `cd frontend && npm run typecheck` and `tsc --noEmit` completed successfully. 
- Ran frontend tests with `cd frontend && npm test` and all tests passed (`5` tests, `0` failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a8f5113c8321897d83881d58b818)