### PR TITLE
Add standardized audit schema & emitter; instrument onboarding/integrations; add internal audit query API

### DIFF
--- a/backend/app/api/routes_admin.py
+++ b/backend/app/api/routes_admin.py
@@ -30,7 +30,7 @@ from app.api.schemas import (
     QrPayloadResponse,
     RotateQrResponse,
 )
-from app.audit.emitter import emit_audit_event
+from app.audit.emitter import emit_audit_event, emit_standard_audit_event
 from app.core.config import settings
 from app.core.deps import get_current_user
 from app.case_ops.service import build_dashboard_snapshot
@@ -490,15 +490,17 @@ def rotate_qr(
         },
     )
     db.add(event)
-    emit_audit_event(
+    emit_standard_audit_event(
         db,
         org_id=org_id,
         actor_type="user",
         actor_id=str(admin.id),
         action="admin.vehicle_qr.rotate",
         event_type="credential_updated",
+        entity_type="vehicle",
+        entity_id=vehicle_id,
         outcome="success",
-        metadata={"adc_vehicle_id": vehicle_id, "token_sha256": token_hash},
+        metadata={"token_sha256": token_hash},
     )
     db.commit()
 

--- a/backend/app/api/routes_integrations.py
+++ b/backend/app/api/routes_integrations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import asdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import hashlib
 import secrets
 import tempfile
@@ -21,7 +21,9 @@ from fastapi import (
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
+from app.audit.emitter import emit_standard_audit_event
 from app.api.schemas import (
+    AuditSearchResponseItem,
     DriverImportJobCreateRequest,
     DriverImportJobCreateResponse,
     DriverImportJobResponse,
@@ -81,6 +83,7 @@ from app.db.models import (
     Driver,
     DriverVehicleAssignment,
     ExternalMapping,
+    AuditEvent,
     OrgVehicleRegistry,
     VehicleImportJob,
     VehicleQrToken,
@@ -125,6 +128,7 @@ from app.onboarding.service import (
 from app.security.permissions import (
     CANONICAL_ROLES,
     Capability,
+    Role,
     has_capability,
     normalize_role,
 )
@@ -146,6 +150,32 @@ _PILOT_REQUIRED_DOMAINS = {"telematics", "messaging"}
 
 def _first_org_id(context) -> uuid.UUID:
     return context.org_ids[0]
+
+
+def _emit_org_audit(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    actor: User,
+    action: str,
+    entity_type: str,
+    entity_id: str | None = None,
+    outcome: str = "success",
+    metadata: dict | None = None,
+    event_type: str | None = None,
+) -> None:
+    emit_standard_audit_event(
+        db,
+        org_id=org_id,
+        actor_type="user",
+        actor_id=str(actor.id),
+        action=action,
+        event_type=event_type,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        outcome=outcome,
+        metadata=metadata or {},
+    )
 
 
 def _to_readiness_response(readiness) -> OrgLaunchReadinessResponse:
@@ -513,6 +543,25 @@ def _run_vehicle_import_background(
             item.strip().lower() for item in inactive_unit_numbers if item.strip()
         },
     )
+    completed = db.query(VehicleImportJob).filter(VehicleImportJob.job_id == job_id).first()
+    emit_standard_audit_event(
+        db,
+        org_id=org_id,
+        actor_type="system",
+        actor_id="vehicle_import_worker",
+        action="onboarding.vehicle_import.apply",
+        event_type="onboarding_vehicle_import_applied",
+        entity_type="vehicle_import_job",
+        entity_id=str(job_id),
+        outcome="success" if completed and completed.status == "completed" else "failure",
+        metadata={
+            "job_status": completed.status if completed else None,
+            "records_processed": completed.records_processed if completed else None,
+            "records_imported": completed.records_imported if completed else None,
+            "records_updated": completed.records_updated if completed else None,
+            "records_errored": completed.records_errored if completed else None,
+        },
+    )
 
 
 def _get_required_vehicle(
@@ -639,6 +688,25 @@ def _run_driver_import_background(
         header_mapping=header_mapping,
         inactive_phones=inactive_phones,
     )
+    completed = db.query(DriverImportJob).filter(DriverImportJob.job_id == job_id).first()
+    emit_standard_audit_event(
+        db,
+        org_id=org_id,
+        actor_type="system",
+        actor_id="driver_import_worker",
+        action="onboarding.driver_import.apply",
+        event_type="onboarding_driver_import_applied",
+        entity_type="driver_import_job",
+        entity_id=str(job_id),
+        outcome="success" if completed and completed.status == "completed" else "failure",
+        metadata={
+            "job_status": completed.status if completed else None,
+            "records_processed": completed.records_processed if completed else None,
+            "records_imported": completed.records_imported if completed else None,
+            "records_updated": completed.records_updated if completed else None,
+            "records_errored": completed.records_errored if completed else None,
+        },
+    )
 
 
 def _to_driver_import_job_response(job: DriverImportJob) -> DriverImportJobResponse:
@@ -702,6 +770,16 @@ def patch_org_settings(
         org.contacts_json = [item for item in updates["contacts"] or []]
     if "implementation_contact" in updates:
         org.implementation_contact_json = updates["implementation_contact"] or {}
+    _emit_org_audit(
+        db,
+        org_id=org.id,
+        actor=current_user,
+        action="org.settings.update",
+        event_type="org_settings_updated",
+        entity_type="org_settings",
+        entity_id=str(org.id),
+        metadata={"updated_fields": sorted(updates.keys())},
+    )
     db.add(org)
     db.commit()
     db.refresh(org)
@@ -740,6 +818,16 @@ def create_org_test_run(
         actor_user_id=current_user.id,
         incident_id=payload.incident_id,
         findings=payload.findings,
+    )
+    _emit_org_audit(
+        db,
+        org_id=_first_org_id(context),
+        actor=current_user,
+        action="onboarding.test_run.create",
+        event_type="onboarding_test_run_created",
+        entity_type="test_run",
+        entity_id=str(run.run_id),
+        metadata={"incident_id": str(payload.incident_id) if payload.incident_id else None},
     )
     return TestIncidentRunResponse.model_validate(asdict(run))
 
@@ -793,6 +881,16 @@ def complete_org_test_run_step(
         if str(exc) == "not_found":
             raise HTTPException(status_code=404, detail="Test run not found") from exc
         raise
+    _emit_org_audit(
+        db,
+        org_id=_first_org_id(context),
+        actor=current_user,
+        action="onboarding.test_run.complete_step",
+        event_type="onboarding_test_run_step_completed",
+        entity_type="test_run",
+        entity_id=str(run_id),
+        metadata={"step_key": payload.step_key, "step_status": payload.status},
+    )
     return TestIncidentRunResponse.model_validate(asdict(run))
 
 
@@ -910,6 +1008,20 @@ def run_org_onboarding_export_check(
         actor_user_id=current_user.id,
         source="export_check_action",
     )
+    _emit_org_audit(
+        db,
+        org_id=org_id,
+        actor=current_user,
+        action="onboarding.export_validation.run",
+        event_type="onboarding_export_validation_run",
+        entity_type="export_validation",
+        entity_id=str(export_row.export_id),
+        metadata={
+            "status": status,
+            "checks": checks,
+            "incident_id": str(latest_incident.incident_id),
+        },
+    )
     refreshed = get_org_onboarding_readiness(db, org_id=org_id)
     return _to_readiness_response(refreshed)
 
@@ -987,6 +1099,16 @@ def mark_org_onboarding_step(
         actor_user_id=current_user.id,
         source=payload.source,
     )
+    _emit_org_audit(
+        db,
+        org_id=org_id,
+        actor=current_user,
+        action="onboarding.step.override",
+        event_type="onboarding_readiness_override_updated",
+        entity_type="onboarding_step",
+        entity_id=payload.step_key,
+        metadata={"completed": payload.completed, "source": payload.source},
+    )
     readiness = get_org_onboarding_readiness(db, org_id=org_id)
     return _to_readiness_response(readiness)
 
@@ -1005,6 +1127,16 @@ def create_org_vehicle_import_job(
     context = build_user_auth_context(db, current_user)
     org_id = _first_org_id(context)
     job = create_vehicle_import_job(db, org_id=org_id, provider=payload.provider)
+    _emit_org_audit(
+        db,
+        org_id=org_id,
+        actor=current_user,
+        action="onboarding.vehicle_import.create",
+        event_type="onboarding_vehicle_import_created",
+        entity_type="vehicle_import_job",
+        entity_id=str(job.job_id),
+        metadata={"provider": payload.provider},
+    )
     background_tasks.add_task(
         _run_vehicle_import_background,
         db,
@@ -1082,6 +1214,16 @@ def generate_vehicle_qr(
         vehicle_id=vehicle.unit_number,
         payload={"token_sha256": token_hash},
     )
+    _emit_org_audit(
+        db,
+        org_id=org_id,
+        actor=current_user,
+        action="onboarding.vehicle_qr.generate",
+        event_type="onboarding_vehicle_qr_generated",
+        entity_type="vehicle",
+        entity_id=vehicle.unit_number,
+        metadata={"token_sha256": token_hash},
+    )
     db.commit()
     return VehicleQrGenerateResponse(
         vehicle_id=vehicle.unit_number,
@@ -1150,6 +1292,15 @@ def bulk_generate_vehicle_qr(
                 deployment_status="generated",
             )
         )
+    _emit_org_audit(
+        db,
+        org_id=org_id,
+        actor=current_user,
+        action="onboarding.vehicle_qr.bulk_generate",
+        event_type="onboarding_vehicle_qr_generated",
+        entity_type="vehicle_qr_batch",
+        metadata={"generated_count": len(generated), "skipped_count": len(skipped)},
+    )
     db.commit()
     return VehicleQrBulkGenerateResponse(
         generated_count=len(generated),
@@ -1196,6 +1347,16 @@ def rotate_vehicle_qr(
         action=SystemEventType.VEHICLE_QR_ROTATED.value,
         vehicle_id=vehicle.unit_number,
         payload={"token_sha256": hashlib.sha256(token.qr_token.encode()).hexdigest()},
+    )
+    _emit_org_audit(
+        db,
+        org_id=org_id,
+        actor=current_user,
+        action="onboarding.vehicle_qr.rotate",
+        event_type="onboarding_vehicle_qr_rotated",
+        entity_type="vehicle",
+        entity_id=vehicle.unit_number,
+        metadata={"token_sha256": hashlib.sha256(token.qr_token.encode()).hexdigest()},
     )
     db.commit()
     return VehicleQrGenerateResponse(
@@ -1274,6 +1435,16 @@ def create_org_driver_import_job(
     context = build_user_auth_context(db, current_user)
     org_id = _first_org_id(context)
     job = create_driver_import_job(db, org_id=org_id, provider=payload.provider)
+    _emit_org_audit(
+        db,
+        org_id=org_id,
+        actor=current_user,
+        action="onboarding.driver_import.create",
+        event_type="onboarding_driver_import_created",
+        entity_type="driver_import_job",
+        entity_id=str(job.job_id),
+        metadata={"provider": payload.provider},
+    )
     background_tasks.add_task(
         _run_driver_import_background,
         db,
@@ -1376,6 +1547,16 @@ def invite_org_user(
     db.add(invite)
     db.commit()
     db.refresh(invite)
+    _emit_org_audit(
+        db,
+        org_id=org_id,
+        actor=current_user,
+        action="org.users.invite",
+        event_type="org_user_invite_created",
+        entity_type="org_user_invite",
+        entity_id=str(invite.invite_id),
+        metadata={"email": invite.email, "role": invite.role, "status": invite.status},
+    )
     role_counts = _role_counts_for_org(db, org_id=org_id)
     return OrgInviteUserResponse(
         invite=OrgUserInviteSummary(
@@ -1409,9 +1590,20 @@ def patch_org_user_role(
     )
     if row is None:
         raise HTTPException(status_code=404, detail="User not found")
+    previous_role = row.role
     row.role = normalize_role(payload.role).value
     db.add(row)
     db.commit()
+    _emit_org_audit(
+        db,
+        org_id=org_id,
+        actor=current_user,
+        action="org.users.role.patch",
+        event_type="org_user_role_changed",
+        entity_type="user",
+        entity_id=str(row.id),
+        metadata={"previous_role": previous_role, "new_role": row.role},
+    )
     return list_org_users(db=db, current_user=current_user)
 
 
@@ -1438,6 +1630,16 @@ def resend_org_user_invite(
     db.add(row)
     db.commit()
     db.refresh(row)
+    _emit_org_audit(
+        db,
+        org_id=org_id,
+        actor=current_user,
+        action="org.users.invite.resend",
+        event_type="org_user_invite_resent",
+        entity_type="org_user_invite",
+        entity_id=str(row.invite_id),
+        metadata={"email": row.email, "role": row.role},
+    )
     role_counts = _role_counts_for_org(db, org_id=org_id)
     return OrgInviteUserResponse(
         invite=OrgUserInviteSummary(
@@ -1476,6 +1678,16 @@ def deactivate_org_user_invite(
     db.add(row)
     db.commit()
     db.refresh(row)
+    _emit_org_audit(
+        db,
+        org_id=org_id,
+        actor=current_user,
+        action="org.users.invite.deactivate",
+        event_type="org_user_invite_deactivated",
+        entity_type="org_user_invite",
+        entity_id=str(row.invite_id),
+        metadata={"email": row.email, "role": row.role},
+    )
     role_counts = _role_counts_for_org(db, org_id=org_id)
     return OrgInviteUserResponse(
         invite=OrgUserInviteSummary(
@@ -1553,9 +1765,25 @@ def upsert_org_integration(
     row.status = payload.status
     row.credentials_ref = payload.credentials_ref
     row.config_json = payload.config_json
+    credential_changed = bool(payload.credentials_ref)
     db.add(row)
     db.commit()
     db.refresh(row)
+    _emit_org_audit(
+        db,
+        org_id=org_id,
+        actor=current_user,
+        action="integration.connection.upsert",
+        event_type="integration_credentials_updated" if credential_changed else "integration_connection_updated",
+        entity_type="integration_connection",
+        entity_id=str(row.connection_id),
+        metadata={
+            "provider": row.provider,
+            "domain": row.domain,
+            "status": row.status,
+            "credentials_ref_set": bool(row.credentials_ref),
+        },
+    )
 
     return IntegrationConnectionHealthResponse(
         integration_id=row.connection_id,
@@ -1596,6 +1824,71 @@ def list_org_integration_validation_results(
             timestamp=row.validated_at_utc,
         )
         for row in rows
+    ]
+
+
+@router.get(
+    "/internal/audit/events",
+    response_model=list[AuditSearchResponseItem],
+)
+def list_internal_audit_events(
+    org_id: uuid.UUID | None = None,
+    action: str | None = None,
+    event_type: str | None = None,
+    outcome: str | None = None,
+    actor_id: str | None = None,
+    entity_type: str | None = None,
+    entity_id: str | None = None,
+    lookback_hours: int = 168,
+    limit: int = 250,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    if normalize_role(context.user.role) != Role.SYSTEM_ADMIN:
+        raise HTTPException(status_code=403, detail="System admin access required")
+
+    lookback_cutoff = datetime.now(timezone.utc) - timedelta(hours=max(1, lookback_hours))
+    query = db.query(AuditEvent).filter(AuditEvent.occurred_at_utc >= lookback_cutoff)
+    if org_id is not None:
+        query = query.filter(AuditEvent.org_id == org_id)
+    if action:
+        query = query.filter(AuditEvent.action.ilike(f"%{action}%"))
+    if event_type:
+        query = query.filter(AuditEvent.event_type.ilike(f"%{event_type}%"))
+    if outcome:
+        query = query.filter(AuditEvent.outcome == outcome)
+    if actor_id:
+        query = query.filter(AuditEvent.actor_id.ilike(f"%{actor_id}%"))
+    rows = query.order_by(AuditEvent.occurred_at_utc.desc()).limit(max(1, min(limit, 1000))).all()
+
+    filtered_rows = rows
+    if entity_type or entity_id:
+        filtered_rows = []
+        for row in rows:
+            metadata = row.metadata_json or {}
+            entity = metadata.get("entity", {}) if isinstance(metadata, dict) else {}
+            if entity_type and entity.get("type") != entity_type:
+                continue
+            if entity_id and entity.get("id") != entity_id:
+                continue
+            filtered_rows.append(row)
+
+    return [
+        AuditSearchResponseItem(
+            audit_event_id=row.id,
+            org_id=row.org_id,
+            incident_id=row.incident_id,
+            export_id=row.export_id,
+            actor_type=row.actor_type,
+            actor_id=row.actor_id,
+            action=row.action,
+            event_type=row.event_type,
+            outcome=row.outcome,
+            occurred_at_utc=row.occurred_at_utc,
+            metadata=row.metadata_json or {},
+        )
+        for row in filtered_rows
     ]
 
 
@@ -1673,6 +1966,24 @@ def validate_org_integration(
     )
     db.add(validation)
     db.commit()
+    _emit_org_audit(
+        db,
+        org_id=row.org_id,
+        actor=current_user,
+        action="integration.connection.validate",
+        event_type="integration_validation_completed",
+        entity_type="integration_connection",
+        entity_id=str(row.connection_id),
+        outcome="success" if valid else "failure",
+        metadata={
+            "provider": row.provider,
+            "domain": row.domain,
+            "credential_status": credential_status,
+            "capability_status": capability_status,
+            "mapping_status": mapping_status,
+            "messages": messages,
+        },
+    )
 
     return IntegrationConnectionValidateResponse(
         integration_id=row.connection_id,
@@ -1710,12 +2021,27 @@ def patch_org_integration(
         raise HTTPException(status_code=404, detail="Integration not found")
 
     updates = payload.model_dump(exclude_unset=True)
+    previous_credentials_ref = row.credentials_ref
     for field in ("status", "credentials_ref", "config_json"):
         if field in updates:
             setattr(row, field, updates[field])
     db.add(row)
     db.commit()
     db.refresh(row)
+    _emit_org_audit(
+        db,
+        org_id=row.org_id,
+        actor=current_user,
+        action="integration.connection.patch",
+        event_type=(
+            "integration_credentials_updated"
+            if "credentials_ref" in updates and updates.get("credentials_ref") != previous_credentials_ref
+            else "integration_connection_updated"
+        ),
+        entity_type="integration_connection",
+        entity_id=str(row.connection_id),
+        metadata={"updated_fields": sorted(updates.keys()), "status": row.status},
+    )
 
     return IntegrationConnectionHealthResponse(
         integration_id=row.connection_id,
@@ -1756,6 +2082,16 @@ def disable_org_integration(
     db.add(row)
     db.commit()
     db.refresh(row)
+    _emit_org_audit(
+        db,
+        org_id=row.org_id,
+        actor=current_user,
+        action="integration.connection.disable",
+        event_type="integration_connection_updated",
+        entity_type="integration_connection",
+        entity_id=str(row.connection_id),
+        metadata={"status": row.status},
+    )
 
     return IntegrationConnectionHealthResponse(
         integration_id=row.connection_id,

--- a/backend/app/api/routes_onboarding.py
+++ b/backend/app/api/routes_onboarding.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
+from app.audit.emitter import emit_standard_audit_event
 from app.api.error_responses import raise_api_error
 from app.api.schemas import (
     ApiErrorResponse,
@@ -175,6 +176,18 @@ def mark_org_onboarding_step(
         is_completed=payload.completed,
         actor_user_id=current_user.id,
         source=payload.source,
+    )
+    emit_standard_audit_event(
+        db,
+        org_id=org_id,
+        actor_type="user",
+        actor_id=str(current_user.id),
+        action="onboarding.step.override",
+        event_type="onboarding_readiness_override_updated",
+        entity_type="onboarding_step",
+        entity_id=payload.step_key,
+        outcome="success",
+        metadata={"completed": payload.completed, "source": payload.source},
     )
     readiness = get_org_onboarding_readiness(db, org_id=org_id)
     return _to_readiness_response(readiness)

--- a/backend/app/api/routes_test_runs.py
+++ b/backend/app/api/routes_test_runs.py
@@ -8,6 +8,7 @@ import uuid
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
+from app.audit.emitter import emit_standard_audit_event
 from app.api.error_responses import raise_api_error
 from app.api.schemas import (
     ApiErrorResponse,
@@ -78,6 +79,18 @@ def create_org_test_run(
         actor_user_id=current_user.id,
         incident_id=payload.incident_id,
         findings=payload.findings,
+    )
+    emit_standard_audit_event(
+        db,
+        org_id=_first_org_id(context),
+        actor_type="user",
+        actor_id=str(current_user.id),
+        action="onboarding.test_run.create",
+        event_type="onboarding_test_run_created",
+        entity_type="test_run",
+        entity_id=str(run.run_id),
+        outcome="success",
+        metadata={"incident_id": str(payload.incident_id) if payload.incident_id else None},
     )
     return TestIncidentRunResponse.model_validate(asdict(run))
 
@@ -150,4 +163,16 @@ def complete_org_test_run_step(
         if str(exc) == "not_found":
             raise_api_error(status_code=404, message="Test run not found.", code="RESOURCE_NOT_FOUND")
         raise
+    emit_standard_audit_event(
+        db,
+        org_id=_first_org_id(context),
+        actor_type="user",
+        actor_id=str(current_user.id),
+        action="onboarding.test_run.complete_step",
+        event_type="onboarding_test_run_step_completed",
+        entity_type="test_run",
+        entity_id=str(run_id),
+        outcome="success",
+        metadata={"step_key": payload.step_key, "step_status": payload.status},
+    )
     return TestIncidentRunResponse.model_validate(asdict(run))

--- a/backend/app/audit/emitter.py
+++ b/backend/app/audit/emitter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -81,3 +82,39 @@ def emit_audit_event(
                 "metadata": metadata or {},
             }),
         )
+
+
+def emit_standard_audit_event(
+    db: Session,
+    *,
+    org_id: uuid.UUID | None,
+    actor_type: str,
+    actor_id: str,
+    action: str,
+    entity_type: str,
+    entity_id: str | None = None,
+    outcome: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    event_type: str | None = None,
+    occurred_at_utc: datetime | None = None,
+) -> None:
+    """Emit an audit event with standardized actor/org/entity/action metadata."""
+    timestamp = occurred_at_utc or datetime.now(timezone.utc)
+    emit_audit_event(
+        db,
+        org_id=org_id,
+        actor_type=actor_type,
+        actor_id=actor_id,
+        action=action,
+        event_type=event_type or action,
+        outcome=outcome,
+        metadata={
+            "schema_version": "audit.v1",
+            "actor": {"type": actor_type, "id": actor_id},
+            "org": {"id": str(org_id) if org_id else None},
+            "entity": {"type": entity_type, "id": entity_id},
+            "action": action,
+            "timestamp": timestamp.isoformat(),
+            **(metadata or {}),
+        },
+    )

--- a/backend/app/audit/queries.py
+++ b/backend/app/audit/queries.py
@@ -67,6 +67,37 @@ def list_audit_events(
     return query.order_by(AuditEvent.occurred_at_utc.desc()).limit(limit).all()
 
 
+def list_audit_events_for_admin(
+    db: Session,
+    *,
+    org_id: uuid.UUID | None = None,
+    actor_id: str | None = None,
+    event_type: str | None = None,
+    action: str | None = None,
+    outcome: str | None = None,
+    occurred_after_utc: datetime | None = None,
+    occurred_before_utc: datetime | None = None,
+    limit: int = 500,
+) -> list[AuditEvent]:
+    """List audit events for privileged users across orgs (optionally scoped)."""
+    query = db.query(AuditEvent)
+    if org_id is not None:
+        query = query.filter(AuditEvent.org_id == org_id)
+    if actor_id is not None:
+        query = query.filter(AuditEvent.actor_id == actor_id)
+    if event_type is not None:
+        query = query.filter(AuditEvent.event_type == event_type)
+    if action is not None:
+        query = query.filter(AuditEvent.action == action)
+    if outcome is not None:
+        query = query.filter(AuditEvent.outcome == outcome)
+    if occurred_after_utc is not None:
+        query = query.filter(AuditEvent.occurred_at_utc >= occurred_after_utc)
+    if occurred_before_utc is not None:
+        query = query.filter(AuditEvent.occurred_at_utc <= occurred_before_utc)
+    return query.order_by(AuditEvent.occurred_at_utc.desc()).limit(limit).all()
+
+
 def update_audit_event_retention(
     db: Session,
     *,

--- a/backend/app/audit/service.py
+++ b/backend/app/audit/service.py
@@ -11,6 +11,7 @@ from app.audit.models import AuditEventCreate, AuditEventRetentionUpdate
 from app.audit.queries import (
     insert_audit_event,
     list_audit_events,
+    list_audit_events_for_admin,
     update_audit_event_retention,
 )
 from app.db.models import AuditEvent
@@ -62,4 +63,30 @@ def set_retention(
             retention_expires_at_utc=retention_expires_at_utc,
             retention_purged_at_utc=retention_purged_at_utc,
         ),
+    )
+
+
+def get_events_for_admin(
+    db: Session,
+    *,
+    org_id: uuid.UUID | None = None,
+    actor_id: str | None = None,
+    event_type: str | None = None,
+    action: str | None = None,
+    outcome: str | None = None,
+    occurred_after_utc: datetime | None = None,
+    occurred_before_utc: datetime | None = None,
+    limit: int = 500,
+) -> list[AuditEvent]:
+    """Read audit events across org scope for privileged/internal users."""
+    return list_audit_events_for_admin(
+        db,
+        org_id=org_id,
+        actor_id=actor_id,
+        event_type=event_type,
+        action=action,
+        outcome=outcome,
+        occurred_after_utc=occurred_after_utc,
+        occurred_before_utc=occurred_before_utc,
+        limit=limit,
     )

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -400,6 +400,15 @@ class TestIntegrationDiagnosticsRoutes:
         assert payload["contacts"][0]["email"] == "safety@test.org"
         assert payload["implementation_contact"]["email"] == "impl@test.org"
         assert payload["logo_url"] == "https://cdn.example.com/logo.png"
+        audit = (
+            db_session.query(AuditEvent)
+            .filter(AuditEvent.event_type == "org_settings_updated")
+            .order_by(AuditEvent.occurred_at_utc.desc())
+            .first()
+        )
+        assert audit is not None
+        assert audit.action == "org.settings.update"
+        assert audit.metadata_json["entity"]["type"] == "org_settings"
 
     def test_onboarding_status_and_mark_step(self, client, auth_headers):
         status_before = client.get("/org/onboarding/status", headers=auth_headers)
@@ -464,6 +473,16 @@ class TestIntegrationDiagnosticsRoutes:
         )
         assert refreshed is not None
         assert refreshed.is_test_incident is True
+        audit_types = {
+            row.event_type
+            for row in db_session.query(AuditEvent).filter(
+                AuditEvent.event_type.in_(
+                    ["onboarding_test_run_created", "onboarding_test_run_step_completed"]
+                )
+            )
+        }
+        assert "onboarding_test_run_created" in audit_types
+        assert "onboarding_test_run_step_completed" in audit_types
 
     def test_export_check_action_endpoint(
         self, client, db_session, test_org, auth_headers
@@ -480,6 +499,14 @@ class TestIntegrationDiagnosticsRoutes:
         assert latest["checks"]["branding_correct"] is True
         assert latest["checks"]["warnings_behavior_ok"] is True
         assert latest["checks"]["file_download_success"] is True
+        audit = (
+            db_session.query(AuditEvent)
+            .filter(AuditEvent.event_type == "onboarding_export_validation_run")
+            .order_by(AuditEvent.occurred_at_utc.desc())
+            .first()
+        )
+        assert audit is not None
+        assert audit.metadata_json["checks"]["required_sections_present"] is True
 
     def test_export_validation_cannot_be_marked_complete_manually(
         self, client, auth_headers
@@ -715,6 +742,25 @@ class TestIntegrationDiagnosticsRoutes:
             if item["user_id"] == str(test_user.id)
         )
         assert updated_user["role"] == "org_admin"
+        emitted = {
+            row.event_type
+            for row in db_session.query(AuditEvent).filter(
+                AuditEvent.event_type.in_(
+                    [
+                        "org_user_invite_created",
+                        "org_user_invite_resent",
+                        "org_user_invite_deactivated",
+                        "org_user_role_changed",
+                    ]
+                )
+            )
+        }
+        assert emitted == {
+            "org_user_invite_created",
+            "org_user_invite_resent",
+            "org_user_invite_deactivated",
+            "org_user_role_changed",
+        }
 
     def test_org_user_admin_permissions_enforced(self, client, auth_headers):
         invite_resp = client.post(
@@ -886,6 +932,60 @@ class TestIntegrationDiagnosticsRoutes:
 
         stored = db_session.query(IntegrationValidationResult).all()
         assert len(stored) == 1
+        audit = (
+            db_session.query(AuditEvent)
+            .filter(AuditEvent.event_type == "integration_validation_completed")
+            .order_by(AuditEvent.occurred_at_utc.desc())
+            .first()
+        )
+        assert audit is not None
+        assert audit.metadata_json["entity"]["type"] == "integration_connection"
+
+    def test_internal_audit_events_for_system_admin(
+        self, client, db_session, test_org, test_user
+    ):
+        org_admin = User(
+            email="org-admin-audit@example.com",
+            password_hash=hash_password("password123"),
+            role="org_admin",
+        )
+        db_session.add(org_admin)
+        db_session.commit()
+        db_session.refresh(org_admin)
+        db_session.add(UserOrg(user_id=org_admin.id, org_id=test_org.id))
+        db_session.commit()
+        org_admin_headers = {
+            "Authorization": f"Bearer {create_access_token({'sub': str(org_admin.id), 'role': 'org_admin'})}"
+        }
+        client.patch(
+            "/org/settings",
+            headers=org_admin_headers,
+            json={"display_name": "Audit Filter Org"},
+        )
+
+        denied = client.get("/internal/audit/events", headers=org_admin_headers)
+        assert denied.status_code == 403
+
+        system_admin = User(
+            email="system-admin-audit@example.com",
+            password_hash=hash_password("password123"),
+            role="system_admin",
+        )
+        db_session.add(system_admin)
+        db_session.commit()
+        db_session.refresh(system_admin)
+        db_session.add(UserOrg(user_id=system_admin.id, org_id=test_org.id))
+        db_session.commit()
+        system_admin_headers = {
+            "Authorization": f"Bearer {create_access_token({'sub': str(system_admin.id), 'role': 'system_admin'})}"
+        }
+        allowed = client.get(
+            f"/internal/audit/events?org_id={test_org.id}&entity_type=org_settings",
+            headers=system_admin_headers,
+        )
+        assert allowed.status_code == 200
+        assert len(allowed.json()) >= 1
+        assert allowed.json()[0]["metadata"]["entity"]["type"] == "org_settings"
 
     @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_get_incident_returns_created_at(


### PR DESCRIPTION
### Motivation
- Standardize audit payloads so events emitted across onboarding, integrations, QR/credential workflows and user/org operations carry a consistent actor/org/entity/action/timestamp schema.
- Emit audit events for org settings updates, invites/role changes, vehicle/driver import create + apply outcomes, QR generation/rotation, integration credential changes and validations, test run lifecycle, export validation runs, and onboarding readiness overrides so these activities are observable and queryable.
- Provide an internal query surface for system/internal admins to search audit events across orgs and filter by entity metadata for troubleshooting and compliance.

### Description
- Added `emit_standard_audit_event` in `app.audit.emitter` which produces an additive, versioned metadata payload (`schema_version: "audit.v1"`) containing `actor`, `org`, `entity`, `action`, and ISO `timestamp` and delegates to the existing append logic.
- Added admin-scoped audit query helpers `list_audit_events_for_admin` and `get_events_for_admin` to `app.audit.queries` / `app.audit.service` for cross-org retrieval and optional filters.
- Instrumented onboarding and integration routes to emit standardized audit events (examples: `org.settings.update`, `org.users.invite` / `resend` / `deactivate`, `org.users.role.patch`, `onboarding.vehicle_import.create` + apply results, `onboarding.driver_import.create` + apply results, `onboarding.vehicle_qr.generate` / `bulk_generate` / `rotate`, `integration.connection.*` upsert/patch/validate, `onboarding.test_run.create` / `complete_step`, `onboarding.export_validation.run`, `onboarding.step.override`).
- Added a new internal endpoint `GET /internal/audit/events` (in `routes_integrations`) that is restricted to `system_admin` and supports filters for `org_id`, `action`, `event_type`, `outcome`, `actor_id`, and entity `type`/`id` (returns `AuditSearchResponseItem`).
- Expanded tests to assert emitted audit rows and internal query behavior and added calls where appropriate in the onboarding/test-run routes.

### Testing
- Ran style/lint checks with `ruff check` on modified backend files and they passed.
- Ran targeted API tests with `pytest` for onboarding/integration/audit-related scenarios (the integration diagnostics test class): the targeted suite completed successfully (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2aace95e48321be03042bff07c6b6)