### PR TITLE
Add onboarding metrics, alert conditions, and reporting hooks

### DIFF
--- a/backend/app/api/routes_onboarding.py
+++ b/backend/app/api/routes_onboarding.py
@@ -66,6 +66,9 @@ def _to_readiness_response(readiness) -> OrgLaunchReadinessResponse:
             "latest_export_validation": asdict(readiness.latest_export_validation)
             if readiness.latest_export_validation is not None
             else None,
+            "metrics": asdict(readiness.metrics) if readiness.metrics is not None else None,
+            "alert_conditions": [asdict(item) for item in readiness.alert_conditions],
+            "reporting_hooks": readiness.reporting_hooks,
             "snapshot_created_at_utc": readiness.snapshot_created_at_utc,
         }
     )

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -801,6 +801,29 @@ class ExportValidationRunResponse(BaseModel):
     details: dict[str, str] = Field(default_factory=dict)
 
 
+class OnboardingMetricsSnapshotResponse(BaseModel):
+    onboarding_started_at_utc: Optional[datetime] = None
+    latest_activity_at_utc: Optional[datetime] = None
+    time_to_pilot_ready_hours: Optional[float] = None
+    time_to_launch_ready_hours: Optional[float] = None
+    import_success_rate: float = Field(default=0.0, ge=0.0, le=1.0)
+    driver_import_success_rate: float = Field(default=0.0, ge=0.0, le=1.0)
+    qr_coverage_rate: float = Field(default=0.0, ge=0.0, le=1.0)
+    valid_driver_phone_ratio: float = Field(default=0.0, ge=0.0, le=1.0)
+    integration_validation_pass_rate: float = Field(default=0.0, ge=0.0, le=1.0)
+    sample_incident_completion_rate: float = Field(default=0.0, ge=0.0, le=1.0)
+    export_validation_rate: float = Field(default=0.0, ge=0.0, le=1.0)
+    common_blockers: list[ShortText] = Field(default_factory=list)
+
+
+class OnboardingAlertConditionResponse(BaseModel):
+    code: ShortText
+    title: ShortText
+    severity: ValidationSeverity = "warning"
+    triggered: bool = False
+    detail: str
+
+
 class TestIncidentRunCreateRequest(BaseModel):
     incident_id: Optional[uuid.UUID] = None
     findings: list[str] = Field(default_factory=list, max_length=100)
@@ -831,6 +854,9 @@ class OrgLaunchReadinessResponse(BaseModel):
     vehicle_qr_deployment: Optional[VehicleQrDeploymentResponse] = None
     test_incident_run: Optional[TestIncidentRunResponse] = None
     latest_export_validation: Optional[ExportValidationRunResponse] = None
+    metrics: Optional[OnboardingMetricsSnapshotResponse] = None
+    alert_conditions: list[OnboardingAlertConditionResponse] = Field(default_factory=list)
+    reporting_hooks: dict[str, Any] = Field(default_factory=dict)
     snapshot_created_at_utc: Optional[datetime] = None
 
 

--- a/backend/app/onboarding/models.py
+++ b/backend/app/onboarding/models.py
@@ -103,6 +103,31 @@ class ExportValidationRun:
 
 
 @dataclass(slots=True)
+class OnboardingMetricsSnapshot:
+    onboarding_started_at_utc: datetime | None = None
+    latest_activity_at_utc: datetime | None = None
+    time_to_pilot_ready_hours: float | None = None
+    time_to_launch_ready_hours: float | None = None
+    import_success_rate: float = 0.0
+    driver_import_success_rate: float = 0.0
+    qr_coverage_rate: float = 0.0
+    valid_driver_phone_ratio: float = 0.0
+    integration_validation_pass_rate: float = 0.0
+    sample_incident_completion_rate: float = 0.0
+    export_validation_rate: float = 0.0
+    common_blockers: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class OnboardingAlertCondition:
+    code: str
+    title: str
+    severity: ValidationSeverity
+    triggered: bool
+    detail: str
+
+
+@dataclass(slots=True)
 class ProtocolSetupStep:
     instruction_set_selected: bool
     instruction_source: str
@@ -127,4 +152,7 @@ class OrgLaunchReadiness:
     vehicle_qr_deployment: VehicleQrDeployment | None = None
     test_incident_run: TestIncidentRun | None = None
     latest_export_validation: ExportValidationRun | None = None
+    metrics: OnboardingMetricsSnapshot | None = None
+    alert_conditions: list[OnboardingAlertCondition] = field(default_factory=list)
+    reporting_hooks: dict[str, object] = field(default_factory=dict)
     snapshot_created_at_utc: datetime | None = None

--- a/backend/app/onboarding/progress.py
+++ b/backend/app/onboarding/progress.py
@@ -37,6 +37,16 @@ class OnboardingSignals:
     test_run_passed: bool = False
     export_validation_passed: bool = False
     successful_export_validation_count: int = 0
+    total_export_validation_count: int = 0
+    total_test_run_count: int = 0
+    completed_test_run_count: int = 0
+    integration_validation_pass_count: int = 0
+    integration_validation_total_count: int = 0
+    valid_driver_phone_count: int = 0
+    total_driver_count: int = 0
+    onboarding_started_at_utc: datetime | None = None
+    latest_activity_at_utc: datetime | None = None
+    repeated_integration_failures: int = 0
     has_started_activity: bool = False
 
 

--- a/backend/app/onboarding/service.py
+++ b/backend/app/onboarding/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from collections import Counter
 from datetime import datetime, timezone
 
 from sqlalchemy import func
@@ -15,6 +16,7 @@ from app.db.models import (
     Event,
     Export,
     ExternalMapping,
+    Driver,
     Incident,
     IntegrationConnection,
     IntegrationOperation,
@@ -31,6 +33,8 @@ from app.onboarding.blockers import blocked_step_keys, classify_blockers
 from app.onboarding.models import (
     ImportJob,
     IntegrationValidationResult,
+    OnboardingAlertCondition,
+    OnboardingMetricsSnapshot,
     OrgLaunchReadiness,
     ExportValidationRun,
     ProtocolSetupStep,
@@ -217,13 +221,13 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
         latest_test_run is not None and latest_test_run.status == "completed"
     )
 
-    successful_export_validation_count = (
-        db.query(OrgExportValidationRun.validation_run_id)
-        .filter(
-            OrgExportValidationRun.org_id == org_id,
-            OrgExportValidationRun.status == "passed",
-        )
-        .count()
+    export_validation_rows = (
+        db.query(OrgExportValidationRun)
+        .filter(OrgExportValidationRun.org_id == org_id)
+        .all()
+    )
+    successful_export_validation_count = sum(
+        1 for row in export_validation_rows if row.status == "passed"
     )
     latest_export = (
         db.query(Export)
@@ -232,6 +236,69 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
         .first()
     )
     export_validation_passed = successful_export_validation_count > 0
+    total_export_validation_count = len(export_validation_rows)
+    test_run_rows = db.query(OrgTestIncidentRun).filter(OrgTestIncidentRun.org_id == org_id).all()
+    completed_test_run_count = sum(1 for row in test_run_rows if row.status == "completed")
+    integration_validation_rows = (
+        db.query(IntegrationValidationResult)
+        .filter(IntegrationValidationResult.org_id == org_id)
+        .all()
+    )
+    integration_validation_pass_count = sum(
+        1
+        for row in integration_validation_rows
+        if row.credential_status == "completed"
+        and row.capability_status == "completed"
+        and row.mapping_status == "completed"
+    )
+    valid_driver_phone_count = (
+        db.query(func.count(Driver.driver_id))
+        .filter(
+            Driver.org_id == org_id,
+            Driver.is_active.is_(True),
+            Driver.phone_e164.is_not(None),
+            Driver.phone_e164.like("+%"),
+            func.length(Driver.phone_e164) >= 11,
+        )
+        .scalar()
+        or 0
+    )
+    total_driver_count = (
+        db.query(func.count(Driver.driver_id))
+        .filter(Driver.org_id == org_id, Driver.is_active.is_(True))
+        .scalar()
+        or 0
+    )
+    onboarding_activity_timestamps = [
+        row.requested_at_utc
+        for row in import_operations
+        if row.requested_at_utc is not None
+    ]
+    onboarding_activity_timestamps.extend(
+        [row.created_at_utc for row in driver_import_jobs if row.created_at_utc is not None]
+    )
+    onboarding_activity_timestamps.extend(
+        [row.started_at_utc for row in test_run_rows if row.started_at_utc is not None]
+    )
+    onboarding_activity_timestamps.extend(
+        [
+            row.validated_at_utc
+            for row in export_validation_rows
+            if row.validated_at_utc is not None
+        ]
+    )
+    now_utc = datetime.now(timezone.utc)
+    integration_failure_window_start = now_utc.timestamp() - (24 * 3600)
+    repeated_integration_failures = (
+        db.query(IntegrationOperation.operation_id)
+        .filter(
+            IntegrationOperation.org_id == org_id,
+            IntegrationOperation.status == "failed",
+            IntegrationOperation.requested_at_utc
+            >= datetime.fromtimestamp(integration_failure_window_start, tz=timezone.utc),
+        )
+        .count()
+    )
 
     has_started_activity = any(
         [
@@ -272,8 +339,130 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
         test_run_passed=test_run_passed,
         export_validation_passed=export_validation_passed,
         successful_export_validation_count=successful_export_validation_count,
+        total_export_validation_count=total_export_validation_count,
+        total_test_run_count=len(test_run_rows),
+        completed_test_run_count=completed_test_run_count,
+        integration_validation_pass_count=integration_validation_pass_count,
+        integration_validation_total_count=len(integration_validation_rows),
+        valid_driver_phone_count=valid_driver_phone_count,
+        total_driver_count=total_driver_count,
+        onboarding_started_at_utc=min(onboarding_activity_timestamps)
+        if onboarding_activity_timestamps
+        else None,
+        latest_activity_at_utc=max(onboarding_activity_timestamps)
+        if onboarding_activity_timestamps
+        else None,
+        repeated_integration_failures=repeated_integration_failures,
         has_started_activity=has_started_activity,
     )
+
+
+def _safe_ratio(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round(numerator / denominator, 4)
+
+
+def _build_onboarding_metrics(
+    *, signals: OnboardingSignals, status: str, common_blockers: list[str]
+) -> OnboardingMetricsSnapshot:
+    now_utc = datetime.now(timezone.utc)
+    started_at = signals.onboarding_started_at_utc
+    elapsed_hours = (
+        round((now_utc - started_at).total_seconds() / 3600, 2)
+        if started_at is not None
+        else None
+    )
+    pilot_or_better = status in {"pilot_ready", "launch_ready"}
+    launch_ready = status == "launch_ready"
+    return OnboardingMetricsSnapshot(
+        onboarding_started_at_utc=started_at,
+        latest_activity_at_utc=signals.latest_activity_at_utc,
+        time_to_pilot_ready_hours=elapsed_hours if pilot_or_better else None,
+        time_to_launch_ready_hours=elapsed_hours if launch_ready else None,
+        import_success_rate=_safe_ratio(
+            signals.successful_import_count,
+            signals.successful_import_count + signals.failed_import_count,
+        ),
+        driver_import_success_rate=_safe_ratio(
+            signals.successful_driver_import_count,
+            signals.successful_driver_import_count + signals.failed_driver_import_count,
+        ),
+        qr_coverage_rate=_safe_ratio(signals.qr_codes_distributed, signals.vehicles_total),
+        valid_driver_phone_ratio=_safe_ratio(
+            signals.valid_driver_phone_count, signals.total_driver_count
+        ),
+        integration_validation_pass_rate=_safe_ratio(
+            signals.integration_validation_pass_count,
+            signals.integration_validation_total_count,
+        ),
+        sample_incident_completion_rate=_safe_ratio(
+            signals.completed_test_run_count, signals.total_test_run_count
+        ),
+        export_validation_rate=_safe_ratio(
+            signals.successful_export_validation_count,
+            signals.total_export_validation_count,
+        ),
+        common_blockers=common_blockers,
+    )
+
+
+def _build_alert_conditions(
+    *, signals: OnboardingSignals, status: str, critical_blocker_count: int
+) -> list[OnboardingAlertCondition]:
+    now_utc = datetime.now(timezone.utc)
+    latest_activity = signals.latest_activity_at_utc
+    stalled_onboarding = bool(
+        signals.has_started_activity
+        and latest_activity is not None
+        and (now_utc - latest_activity).total_seconds() >= 7 * 24 * 3600
+    )
+    repeated_integration_failures = signals.repeated_integration_failures >= 3
+    unresolved_critical_blockers = critical_blocker_count > 0
+    low_qr_coverage = bool(
+        signals.vehicles_total > 0 and _safe_ratio(signals.qr_codes_distributed, signals.vehicles_total) < 0.8
+    )
+    no_test_incident_near_launch = bool(
+        status in {"pilot_ready", "launch_ready"}
+        and (signals.completed_test_run_count == 0 or not signals.test_run_passed)
+    )
+    return [
+        OnboardingAlertCondition(
+            code="stalled_onboarding",
+            title="Onboarding stalled",
+            severity="warning",
+            triggered=stalled_onboarding,
+            detail="No onboarding activity detected in the last 7 days after onboarding started.",
+        ),
+        OnboardingAlertCondition(
+            code="repeated_integration_failures",
+            title="Repeated integration failures",
+            severity="error",
+            triggered=repeated_integration_failures,
+            detail="Three or more integration operations have recently failed and require remediation.",
+        ),
+        OnboardingAlertCondition(
+            code="unresolved_critical_blockers",
+            title="Unresolved critical blockers",
+            severity="error",
+            triggered=unresolved_critical_blockers,
+            detail="Critical blockers are still open and are preventing launch readiness.",
+        ),
+        OnboardingAlertCondition(
+            code="low_pilot_qr_coverage",
+            title="Low pilot QR coverage",
+            severity="warning",
+            triggered=low_qr_coverage,
+            detail="Distributed QR coverage is below 80% of required active vehicles.",
+        ),
+        OnboardingAlertCondition(
+            code="no_successful_test_incident_near_launch",
+            title="No successful test incident near launch",
+            severity="error",
+            triggered=no_test_incident_near_launch,
+            detail="No completed test incident run is available while readiness is targeting launch.",
+        ),
+    ]
 
 
 def build_onboarding_readiness(
@@ -313,6 +502,9 @@ def build_onboarding_readiness(
             }
     percent_complete = completion_percent(steps)
     status = derive_readiness_status(steps=steps, percent_complete=percent_complete)
+    blocker_counts = Counter(item.code for item in classified)
+    common_blockers = [code for code, _ in blocker_counts.most_common(5)]
+    critical_blocker_count = sum(1 for item in classified if item.severity == "critical")
 
     import_jobs = [
         ImportJob(
@@ -391,6 +583,27 @@ def build_onboarding_readiness(
         integration_validations=integration_validations,
         vehicle_qr_deployment=qr_deployment,
         test_incident_run=test_incident_run,
+        metrics=_build_onboarding_metrics(
+            signals=signals, status=status, common_blockers=common_blockers
+        ),
+        alert_conditions=_build_alert_conditions(
+            signals=signals,
+            status=status,
+            critical_blocker_count=critical_blocker_count,
+        ),
+        reporting_hooks={
+            "internal_dashboard": {
+                "metrics_path": "/org/onboarding/status#metrics",
+                "alerts_path": "/org/onboarding/status#alert_conditions",
+                "snapshot_created_at_utc": datetime.now(timezone.utc).isoformat(),
+            },
+            "reporting": {
+                "org_id": str(org_id),
+                "status": status,
+                "percent_complete": percent_complete,
+                "common_blockers": common_blockers,
+            },
+        },
         snapshot_created_at_utc=datetime.now(timezone.utc),
     )
 

--- a/backend/app/onboarding/service.py
+++ b/backend/app/onboarding/service.py
@@ -17,6 +17,7 @@ from app.db.models import (
     Export,
     ExternalMapping,
     Driver,
+    IntegrationValidationResult as IntegrationValidationResultRow,
     Incident,
     IntegrationConnection,
     IntegrationOperation,
@@ -240,8 +241,8 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
     test_run_rows = db.query(OrgTestIncidentRun).filter(OrgTestIncidentRun.org_id == org_id).all()
     completed_test_run_count = sum(1 for row in test_run_rows if row.status == "completed")
     integration_validation_rows = (
-        db.query(IntegrationValidationResult)
-        .filter(IntegrationValidationResult.org_id == org_id)
+        db.query(IntegrationValidationResultRow)
+        .filter(IntegrationValidationResultRow.org_id == org_id)
         .all()
     )
     integration_validation_pass_count = sum(
@@ -363,11 +364,19 @@ def _safe_ratio(numerator: int, denominator: int) -> float:
     return round(numerator / denominator, 4)
 
 
+def _as_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
 def _build_onboarding_metrics(
     *, signals: OnboardingSignals, status: str, common_blockers: list[str]
 ) -> OnboardingMetricsSnapshot:
     now_utc = datetime.now(timezone.utc)
-    started_at = signals.onboarding_started_at_utc
+    started_at = _as_utc(signals.onboarding_started_at_utc)
     elapsed_hours = (
         round((now_utc - started_at).total_seconds() / 3600, 2)
         if started_at is not None
@@ -377,7 +386,7 @@ def _build_onboarding_metrics(
     launch_ready = status == "launch_ready"
     return OnboardingMetricsSnapshot(
         onboarding_started_at_utc=started_at,
-        latest_activity_at_utc=signals.latest_activity_at_utc,
+        latest_activity_at_utc=_as_utc(signals.latest_activity_at_utc),
         time_to_pilot_ready_hours=elapsed_hours if pilot_or_better else None,
         time_to_launch_ready_hours=elapsed_hours if launch_ready else None,
         import_success_rate=_safe_ratio(
@@ -411,7 +420,7 @@ def _build_alert_conditions(
     *, signals: OnboardingSignals, status: str, critical_blocker_count: int
 ) -> list[OnboardingAlertCondition]:
     now_utc = datetime.now(timezone.utc)
-    latest_activity = signals.latest_activity_at_utc
+    latest_activity = _as_utc(signals.latest_activity_at_utc)
     stalled_onboarding = bool(
         signals.has_started_activity
         and latest_activity is not None

--- a/backend/tests/test_onboarding_service.py
+++ b/backend/tests/test_onboarding_service.py
@@ -104,6 +104,14 @@ def test_build_onboarding_readiness_uses_blocked_status_when_critical_exists():
     assert "org_settings" in blocked
     assert "integrations" in blocked
     assert len(snapshot.blockers) >= 1
+    assert snapshot.metrics is not None
+    assert snapshot.metrics.import_success_rate == 0.0
+    assert "org_settings_incomplete" in snapshot.metrics.common_blockers
+    assert any(
+        item.code == "unresolved_critical_blockers" and item.triggered
+        for item in snapshot.alert_conditions
+    )
+    assert "internal_dashboard" in snapshot.reporting_hooks
 
 
 def test_driver_import_step_completion_signal():
@@ -177,3 +185,48 @@ def test_export_validation_override_does_not_bypass_successful_test_export_requi
     by_key = {step.key: step for step in snapshot.steps}
     assert by_key["export_validation"].status == "not_started"
     assert snapshot.status != "launch_ready"
+
+
+def test_build_onboarding_readiness_metrics_and_alerts_for_ready_state():
+    snapshot = build_onboarding_readiness(
+        org_id=uuid.uuid4(),
+        signals=OnboardingSignals(
+            org_settings_configured=True,
+            org_admin_count=1,
+            safety_capable_user_count=1,
+            active_user_count=2,
+            successful_import_count=9,
+            failed_import_count=1,
+            successful_driver_import_count=8,
+            failed_driver_import_count=2,
+            mapping_count=4,
+            active_integration_count=2,
+            total_integration_count=2,
+            vehicles_total=10,
+            qr_codes_generated=10,
+            qr_codes_distributed=9,
+            qr_codes_confirmed=8,
+            protocol_configured=True,
+            test_run_passed=True,
+            total_test_run_count=5,
+            completed_test_run_count=4,
+            export_validation_passed=True,
+            successful_export_validation_count=3,
+            total_export_validation_count=4,
+            integration_validation_pass_count=6,
+            integration_validation_total_count=8,
+            valid_driver_phone_count=12,
+            total_driver_count=15,
+        ),
+    )
+    assert snapshot.metrics is not None
+    assert snapshot.metrics.import_success_rate == 0.9
+    assert snapshot.metrics.qr_coverage_rate == 0.9
+    assert snapshot.metrics.valid_driver_phone_ratio == 0.8
+    assert snapshot.metrics.integration_validation_pass_rate == 0.75
+    assert snapshot.metrics.sample_incident_completion_rate == 0.8
+    assert snapshot.metrics.export_validation_rate == 0.75
+    assert any(
+        item.code == "no_successful_test_incident_near_launch" and not item.triggered
+        for item in snapshot.alert_conditions
+    )

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -553,6 +553,29 @@ export interface ExportValidationRun {
   checks: Record<string, boolean>;
 }
 
+export interface OnboardingMetricsSnapshot {
+  onboarding_started_at_utc?: string | null;
+  latest_activity_at_utc?: string | null;
+  time_to_pilot_ready_hours?: number | null;
+  time_to_launch_ready_hours?: number | null;
+  import_success_rate: number;
+  driver_import_success_rate: number;
+  qr_coverage_rate: number;
+  valid_driver_phone_ratio: number;
+  integration_validation_pass_rate: number;
+  sample_incident_completion_rate: number;
+  export_validation_rate: number;
+  common_blockers: string[];
+}
+
+export interface OnboardingAlertCondition {
+  code: string;
+  title: string;
+  severity: "critical" | "warning" | "info" | "error";
+  triggered: boolean;
+  detail: string;
+}
+
 export interface OrgLaunchReadiness {
   org_id: string;
   status: OnboardingReadinessStatus;
@@ -561,6 +584,9 @@ export interface OrgLaunchReadiness {
   blockers: OnboardingBlocker[];
   import_jobs: OnboardingImportJob[];
   latest_export_validation?: ExportValidationRun | null;
+  metrics?: OnboardingMetricsSnapshot | null;
+  alert_conditions?: OnboardingAlertCondition[];
+  reporting_hooks?: Record<string, unknown>;
   snapshot_created_at_utc?: string | null;
 }
 


### PR DESCRIPTION
### Motivation
- Provide operational KPIs for onboarding (time-to-pilot/launch, import success rates, QR coverage, valid-driver-phone ratio, integration validation pass rate, sample incident completion rate, export validation rate, and common blockers) to better track rollout progress. 
- Surface actionable alert conditions for stalled onboarding, repeated integration failures, unresolved critical blockers, low pilot QR coverage, and missing successful test incidents near launch. 
- Expose internal dashboard and reporting hooks so consumers (internal dashboards or reporting pipelines) can read metric snapshots and alerts from the readiness snapshot.

### Description
- Added typed models `OnboardingMetricsSnapshot` and `OnboardingAlertCondition` and extended `OrgLaunchReadiness` with `metrics`, `alert_conditions`, and `reporting_hooks` (backend: `backend/app/onboarding/models.py`).
- Extended normalized signals in `OnboardingSignals` (backend: `backend/app/onboarding/progress.py`) to carry totals for export/test runs, integration validation counts, valid driver phone counts, onboarding activity timestamps, and repeated integration-failure counts.
- Collected new inputs in `collect_onboarding_signals` and computed KPIs and alerts in the service layer via `_build_onboarding_metrics` and `_build_alert_conditions`; added helper `_safe_ratio` and common-blocker aggregation (backend: `backend/app/onboarding/service.py`).
- Exposed metrics/alerts/reporting hooks through the `/org/onboarding/status` response by serializing the new fields (backend: `backend/app/api/routes_onboarding.py` and `backend/app/api/schemas.py`).
- Updated frontend API typings to include `metrics`, `alert_conditions`, and `reporting_hooks` (frontend: `frontend/lib/api.ts`).
- Added/updated unit tests to validate metrics, alert evaluation, and presence of reporting hook payloads (backend: `backend/tests/test_onboarding_service.py`).

### Testing
- Ran code style check `cd backend && ruff check app/onboarding/service.py app/onboarding/models.py app/onboarding/progress.py app/api/routes_onboarding.py app/api/schemas.py tests/test_onboarding_service.py` and it completed with no issues.
- Ran backend unit tests `cd backend && pytest tests/test_onboarding_service.py -q` and they passed (`7 passed`).
- Ran frontend lint `cd frontend && npm run lint` and it completed successfully.
- Ran frontend tests `cd frontend && npm test` and they passed (`5 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2b2d0babc83218f613912c75929fd)