### PR TITLE
Add commercial plan, module, and entitlement service package

### DIFF
--- a/backend/app/commercial/__init__.py
+++ b/backend/app/commercial/__init__.py
@@ -1,0 +1,27 @@
+"""Commercial plan, module, and entitlement service utilities."""
+
+from app.commercial.expansion import EXPANSION_READINESS_STATES, ExpansionReadiness
+from app.commercial.modules import ProductModule, list_modules_by_plan
+from app.commercial.plans import ProductPlan, resolve_plan
+from app.commercial.service import (
+    is_feature_enabled_for_org,
+    list_org_modules,
+    resolve_org_entitlements,
+    resolve_org_plan,
+)
+from app.commercial.trust import DEPLOYMENT_SCOPE_STATES, DeploymentScope
+
+__all__ = [
+    "ProductPlan",
+    "ProductModule",
+    "DeploymentScope",
+    "ExpansionReadiness",
+    "DEPLOYMENT_SCOPE_STATES",
+    "EXPANSION_READINESS_STATES",
+    "resolve_plan",
+    "list_modules_by_plan",
+    "resolve_org_plan",
+    "resolve_org_entitlements",
+    "list_org_modules",
+    "is_feature_enabled_for_org",
+]

--- a/backend/app/commercial/demo.py
+++ b/backend/app/commercial/demo.py
@@ -1,0 +1,8 @@
+"""Demo and sandbox feature definitions."""
+
+from __future__ import annotations
+
+DEMO_FEATURES: tuple[str, ...] = (
+    "demo.workspace",
+    "demo.incident_seed",
+)

--- a/backend/app/commercial/docs.py
+++ b/backend/app/commercial/docs.py
@@ -1,0 +1,8 @@
+"""Documentation center feature definitions."""
+
+from __future__ import annotations
+
+DOCS_FEATURES: tuple[str, ...] = (
+    "docs.playbooks",
+    "docs.api_reference",
+)

--- a/backend/app/commercial/entitlements.py
+++ b/backend/app/commercial/entitlements.py
@@ -1,0 +1,91 @@
+"""Entitlement merge and feature-gate checks."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping
+
+from app.commercial.demo import DEMO_FEATURES
+from app.commercial.docs import DOCS_FEATURES
+from app.commercial.expansion import EXPANSION_FEATURES
+from app.commercial.modules import list_modules_by_plan
+from app.commercial.plans import ProductPlan, resolve_plan
+from app.commercial.reporting import REPORTING_FEATURES
+from app.commercial.trust import TRUST_FEATURES
+
+EntitlementMap = dict[str, bool]
+
+_MODULE_FEATURES: dict[str, tuple[str, ...]] = {
+    "onboarding": ("onboarding.readiness", "onboarding.imports"),
+    "case_ops": ("case_ops.workspace", "case_ops.transitions"),
+    "reporting": REPORTING_FEATURES,
+    "expansion": EXPANSION_FEATURES,
+    "trust": TRUST_FEATURES,
+    "demo": DEMO_FEATURES,
+    "docs": DOCS_FEATURES,
+}
+
+
+def base_entitlements_for_plan(plan: ProductPlan | str | None) -> EntitlementMap:
+    """Build base feature entitlements from enabled modules for a plan."""
+    entitlements: EntitlementMap = {}
+    for module in list_modules_by_plan(plan):
+        for feature_key in _MODULE_FEATURES.get(module.value, ()):  # defensive
+            entitlements[feature_key] = True
+    return entitlements
+
+
+def merge_entitlements(
+    base: Mapping[str, bool],
+    *overlays: Mapping[str, bool] | None,
+) -> EntitlementMap:
+    """Merge base entitlements with optional overlays (last-write-wins)."""
+    merged: EntitlementMap = dict(base)
+    for overlay in overlays:
+        if overlay is None:
+            continue
+        for key, value in overlay.items():
+            merged[str(key)] = bool(value)
+    return merged
+
+
+def resolve_entitlements(
+    *,
+    plan: ProductPlan | str | None,
+    plan_overrides: Mapping[str, bool] | None = None,
+    org_overrides: Mapping[str, bool] | None = None,
+) -> EntitlementMap:
+    """Resolve final entitlement map from plan defaults + overrides."""
+    base = base_entitlements_for_plan(resolve_plan(plan))
+    return merge_entitlements(base, plan_overrides, org_overrides)
+
+
+def is_feature_enabled(
+    org_id: uuid.UUID,
+    feature_key: str,
+    actor_role: str,
+    overrides: Mapping[str, bool] | None,
+    *,
+    plan: ProductPlan | str | None,
+    entitlements: Mapping[str, bool] | None = None,
+    role_allowlist: Mapping[str, set[str]] | None = None,
+) -> bool:
+    """Evaluate whether a feature is enabled for an org/user context.
+
+    ``org_id`` is accepted for telemetry/event parity with calling layers.
+    """
+    _ = org_id
+    effective = (
+        dict(entitlements)
+        if entitlements is not None
+        else resolve_entitlements(plan=plan, org_overrides=overrides)
+    )
+    enabled = bool(effective.get(feature_key, False))
+    if not enabled:
+        return False
+    if role_allowlist is None:
+        return True
+    allowed_roles = role_allowlist.get(feature_key)
+    if not allowed_roles:
+        return True
+    return actor_role in allowed_roles

--- a/backend/app/commercial/expansion.py
+++ b/backend/app/commercial/expansion.py
@@ -1,0 +1,26 @@
+"""Expansion planning state definitions and helpers."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+ExpansionReadiness = Literal[
+    "not_started",
+    "planning",
+    "pilot_ready",
+    "scale_ready",
+    "blocked",
+]
+
+EXPANSION_READINESS_STATES: tuple[ExpansionReadiness, ...] = (
+    "not_started",
+    "planning",
+    "pilot_ready",
+    "scale_ready",
+    "blocked",
+)
+
+EXPANSION_FEATURES: tuple[str, ...] = (
+    "expansion.scorecard",
+    "expansion.rollout",
+)

--- a/backend/app/commercial/modules.py
+++ b/backend/app/commercial/modules.py
@@ -1,0 +1,47 @@
+"""Commercial module catalog and plan-to-module projection."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from app.commercial.plans import ProductPlan, resolve_plan
+
+
+class ProductModule(str, Enum):
+    ONBOARDING = "onboarding"
+    CASE_OPS = "case_ops"
+    REPORTING = "reporting"
+    EXPANSION = "expansion"
+    TRUST = "trust"
+    DEMO = "demo"
+    DOCS = "docs"
+
+
+_PLAN_MODULES: dict[ProductPlan, tuple[ProductModule, ...]] = {
+    ProductPlan.STARTER: (
+        ProductModule.ONBOARDING,
+        ProductModule.CASE_OPS,
+        ProductModule.DOCS,
+    ),
+    ProductPlan.GROWTH: (
+        ProductModule.ONBOARDING,
+        ProductModule.CASE_OPS,
+        ProductModule.REPORTING,
+        ProductModule.DOCS,
+        ProductModule.DEMO,
+    ),
+    ProductPlan.ENTERPRISE: (
+        ProductModule.ONBOARDING,
+        ProductModule.CASE_OPS,
+        ProductModule.REPORTING,
+        ProductModule.EXPANSION,
+        ProductModule.TRUST,
+        ProductModule.DOCS,
+        ProductModule.DEMO,
+    ),
+}
+
+
+def list_modules_by_plan(plan: ProductPlan | str | None) -> list[ProductModule]:
+    """List enabled modules for the given plan."""
+    return list(_PLAN_MODULES[resolve_plan(plan)])

--- a/backend/app/commercial/plans.py
+++ b/backend/app/commercial/plans.py
@@ -1,0 +1,44 @@
+"""Commercial plan primitives and plan resolution helpers."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ProductPlan(str, Enum):
+    """Canonical product plans in ascending commercial capability order."""
+
+    STARTER = "starter"
+    GROWTH = "growth"
+    ENTERPRISE = "enterprise"
+
+
+_PLAN_ORDER: tuple[ProductPlan, ...] = (
+    ProductPlan.STARTER,
+    ProductPlan.GROWTH,
+    ProductPlan.ENTERPRISE,
+)
+
+
+def resolve_plan(
+    plan: ProductPlan | str | None,
+    *,
+    default: ProductPlan = ProductPlan.STARTER,
+) -> ProductPlan:
+    """Resolve user or database plan values to a canonical ``ProductPlan``."""
+    if isinstance(plan, ProductPlan):
+        return plan
+    if isinstance(plan, str):
+        normalized = plan.strip().lower()
+        if normalized:
+            try:
+                return ProductPlan(normalized)
+            except ValueError:
+                pass
+    return default
+
+
+def plan_rank(plan: ProductPlan | str | None) -> int:
+    """Return an integer rank for capability comparisons."""
+    resolved = resolve_plan(plan)
+    return _PLAN_ORDER.index(resolved)

--- a/backend/app/commercial/reporting.py
+++ b/backend/app/commercial/reporting.py
@@ -1,0 +1,9 @@
+"""Reporting feature gates keyed by canonical feature ids."""
+
+from __future__ import annotations
+
+REPORTING_FEATURES: tuple[str, ...] = (
+    "reporting.dashboard",
+    "reporting.audit_trail",
+    "reporting.export_history",
+)

--- a/backend/app/commercial/service.py
+++ b/backend/app/commercial/service.py
@@ -1,0 +1,89 @@
+"""Commercial service facade with dependency-injected data access."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping
+from typing import Protocol
+
+from app.commercial.entitlements import (
+    EntitlementMap,
+    is_feature_enabled,
+    resolve_entitlements,
+)
+from app.commercial.modules import ProductModule, list_modules_by_plan
+from app.commercial.plans import ProductPlan, resolve_plan
+
+
+class PlanRepository(Protocol):
+    def get_plan_for_org(self, org_id: uuid.UUID) -> ProductPlan | str | None: ...
+
+
+class EntitlementRepository(Protocol):
+    def get_overrides_for_org(self, org_id: uuid.UUID) -> Mapping[str, bool]: ...
+
+
+def resolve_org_plan(*, org_id: uuid.UUID, plan_repo: PlanRepository) -> ProductPlan:
+    """Resolve the canonical product plan for an organization."""
+    return resolve_plan(plan_repo.get_plan_for_org(org_id))
+
+
+def resolve_org_entitlements(
+    *,
+    org_id: uuid.UUID,
+    plan_repo: PlanRepository,
+    entitlement_repo: EntitlementRepository | None = None,
+    plan_overrides: Mapping[str, bool] | None = None,
+) -> EntitlementMap:
+    """Resolve entitlements by loading org data via repository interfaces."""
+    plan = resolve_org_plan(org_id=org_id, plan_repo=plan_repo)
+    org_overrides = (
+        entitlement_repo.get_overrides_for_org(org_id)
+        if entitlement_repo is not None
+        else None
+    )
+    return resolve_entitlements(
+        plan=plan,
+        plan_overrides=plan_overrides,
+        org_overrides=org_overrides,
+    )
+
+
+def list_org_modules(*, org_id: uuid.UUID, plan_repo: PlanRepository) -> list[ProductModule]:
+    """Return modules enabled for the organization plan."""
+    return list_modules_by_plan(resolve_org_plan(org_id=org_id, plan_repo=plan_repo))
+
+
+def is_feature_enabled_for_org(
+    *,
+    org_id: uuid.UUID,
+    feature_key: str,
+    actor_role: str,
+    plan_repo: PlanRepository,
+    entitlement_repo: EntitlementRepository | None = None,
+    overrides: Mapping[str, bool] | None = None,
+    role_allowlist: Mapping[str, set[str]] | None = None,
+) -> bool:
+    """Dependency-injected feature gate check.
+
+    If ``overrides`` are provided at call time, they are merged over repository overrides.
+    """
+    plan = resolve_org_plan(org_id=org_id, plan_repo=plan_repo)
+    repo_overrides = (
+        entitlement_repo.get_overrides_for_org(org_id)
+        if entitlement_repo is not None
+        else None
+    )
+    merged_overrides: dict[str, bool] = {}
+    if repo_overrides is not None:
+        merged_overrides.update({str(k): bool(v) for k, v in repo_overrides.items()})
+    if overrides is not None:
+        merged_overrides.update({str(k): bool(v) for k, v in overrides.items()})
+    return is_feature_enabled(
+        org_id=org_id,
+        feature_key=feature_key,
+        actor_role=actor_role,
+        overrides=merged_overrides,
+        plan=plan,
+        role_allowlist=role_allowlist,
+    )

--- a/backend/app/commercial/trust.py
+++ b/backend/app/commercial/trust.py
@@ -1,0 +1,26 @@
+"""Trust and deployment scope state definitions."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+DeploymentScope = Literal[
+    "single_site",
+    "multi_site",
+    "regional",
+    "national",
+    "global",
+]
+
+DEPLOYMENT_SCOPE_STATES: tuple[DeploymentScope, ...] = (
+    "single_site",
+    "multi_site",
+    "regional",
+    "national",
+    "global",
+)
+
+TRUST_FEATURES: tuple[str, ...] = (
+    "trust.sso",
+    "trust.audit_controls",
+)

--- a/backend/tests/test_commercial_service.py
+++ b/backend/tests/test_commercial_service.py
@@ -1,0 +1,101 @@
+import uuid
+
+from app.commercial.entitlements import (
+    merge_entitlements,
+    resolve_entitlements,
+)
+from app.commercial.modules import ProductModule, list_modules_by_plan
+from app.commercial.plans import ProductPlan, resolve_plan
+from app.commercial.service import (
+    is_feature_enabled_for_org,
+    list_org_modules,
+    resolve_org_entitlements,
+)
+
+
+class _StaticPlanRepo:
+    def __init__(self, plan: str):
+        self._plan = plan
+
+    def get_plan_for_org(self, org_id: uuid.UUID) -> str:
+        _ = org_id
+        return self._plan
+
+
+class _StaticEntitlementRepo:
+    def __init__(self, overrides: dict[str, bool]):
+        self._overrides = overrides
+
+    def get_overrides_for_org(self, org_id: uuid.UUID) -> dict[str, bool]:
+        _ = org_id
+        return self._overrides
+
+
+def test_resolve_plan_normalizes_unknown_to_default():
+    assert resolve_plan("enterprise") == ProductPlan.ENTERPRISE
+    assert resolve_plan("unknown-plan") == ProductPlan.STARTER
+
+
+def test_list_modules_by_plan_returns_expected_catalog():
+    starter_modules = list_modules_by_plan(ProductPlan.STARTER)
+    enterprise_modules = list_modules_by_plan(ProductPlan.ENTERPRISE)
+
+    assert ProductModule.REPORTING not in starter_modules
+    assert ProductModule.TRUST in enterprise_modules
+
+
+def test_merge_and_resolve_entitlements_apply_overrides_last_write_wins():
+    merged = merge_entitlements(
+        {"reporting.dashboard": True, "demo.workspace": True},
+        {"demo.workspace": False},
+    )
+    assert merged["demo.workspace"] is False
+
+    resolved = resolve_entitlements(
+        plan=ProductPlan.STARTER,
+        org_overrides={"reporting.dashboard": True},
+    )
+    assert resolved["reporting.dashboard"] is True
+
+
+def test_dependency_injected_service_interfaces():
+    org_id = uuid.uuid4()
+    plan_repo = _StaticPlanRepo("growth")
+    ent_repo = _StaticEntitlementRepo({"reporting.dashboard": True})
+
+    modules = list_org_modules(org_id=org_id, plan_repo=plan_repo)
+    entitlements = resolve_org_entitlements(
+        org_id=org_id,
+        plan_repo=plan_repo,
+        entitlement_repo=ent_repo,
+    )
+
+    assert ProductModule.REPORTING in modules
+    assert entitlements["reporting.dashboard"] is True
+
+
+def test_is_feature_enabled_for_org_with_role_allowlist_and_overrides():
+    org_id = uuid.uuid4()
+    plan_repo = _StaticPlanRepo("enterprise")
+    ent_repo = _StaticEntitlementRepo({"trust.sso": True})
+
+    allowed = is_feature_enabled_for_org(
+        org_id=org_id,
+        feature_key="trust.sso",
+        actor_role="org_admin",
+        plan_repo=plan_repo,
+        entitlement_repo=ent_repo,
+        role_allowlist={"trust.sso": {"org_admin"}},
+    )
+    blocked = is_feature_enabled_for_org(
+        org_id=org_id,
+        feature_key="trust.sso",
+        actor_role="viewer",
+        plan_repo=plan_repo,
+        entitlement_repo=ent_repo,
+        role_allowlist={"trust.sso": {"org_admin"}},
+        overrides={"trust.sso": True},
+    )
+
+    assert allowed is True
+    assert blocked is False


### PR DESCRIPTION
### Motivation
- Provide a single package to model product plans, modules, deployment/expansion states, and feature entitlements for commercial gating and rollout logic.
- Expose pure helpers and dependency-injected service facades so higher-level code can resolve plans, list modules, merge entitlements, and evaluate feature gates without direct DB coupling.

### Description
- Add new package `backend/app/commercial/` containing `plans.py`, `modules.py`, `entitlements.py`, `service.py`, `reporting.py`, `expansion.py`, `demo.py`, `docs.py`, `trust.py`, and `__init__.py` which export the utilities and types.
- Define canonical enums/types: `ProductPlan` and `ProductModule`, and literal state sets for `DeploymentScope` and `ExpansionReadiness`.
- Implement plan utilities `resolve_plan` and `plan_rank`, module projection `list_modules_by_plan`, and small feature catalogs (`REPORTING_FEATURES`, `DEMO_FEATURES`, `DOCS_FEATURES`, `EXPANSION_FEATURES`, `TRUST_FEATURES`).
- Implement entitlement primitives: `base_entitlements_for_plan`, `merge_entitlements`, `resolve_entitlements`, and `is_feature_enabled(org_id, feature_key, actor_role, overrides, ...)` as pure/easily-testable functions.
- Provide dependency-injected service interfaces in `service.py` (`PlanRepository`, `EntitlementRepository` protocols) and helper facades `resolve_org_plan`, `resolve_org_entitlements`, `list_org_modules`, and `is_feature_enabled_for_org`.
- Add unit tests at `backend/tests/test_commercial_service.py` covering plan normalization, module mapping, entitlement merging, DI interfaces, and role allowlist behavior.

### Testing
- Ran unit tests with `cd backend && python -m pytest tests/test_commercial_service.py` which initially errored due to using `StrEnum` on Python 3.10, the enums were adjusted to `str, Enum` and the tests were re-run successfully resulting in `5 passed`.
- Ran linter checks with `cd backend && python -m ruff check app/commercial tests/test_commercial_service.py` which completed with no issues.
- All added tests in `backend/tests/test_commercial_service.py` passed after the enum fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f008e058832192b762a660a71101)