### PR TITLE
Add org content, entitlement, and readiness persistence schema/repo support

### DIFF
--- a/backend/app/db/migrations/versions/0025_add_org_content_and_readiness_tables.py
+++ b/backend/app/db/migrations/versions/0025_add_org_content_and_readiness_tables.py
@@ -1,0 +1,303 @@
+"""add org content, entitlement, and readiness tables
+
+Revision ID: 0025_add_org_content_and_readiness_tables
+Revises: 0024_add_org_export_validation_runs
+Create Date: 2026-04-19 00:00:00.000000
+"""
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+import uuid
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0025"
+down_revision: Union[str, None] = "0024"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "org_plan_entitlements",
+        sa.Column("entitlement_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("plan_code", sa.Text(), nullable=False, server_default="starter"),
+        sa.Column("billing_status", sa.Text(), nullable=False, server_default="active"),
+        sa.Column("core_incident_protocol", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("entitlements_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("effective_from_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("effective_to_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("created_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("entitlement_id"),
+    )
+    op.create_index("ix_org_plan_entitlements_org_id", "org_plan_entitlements", ["org_id"], unique=False)
+    op.create_index(
+        "ix_org_plan_entitlements_org_current",
+        "org_plan_entitlements",
+        ["org_id", "effective_to_utc"],
+        unique=False,
+    )
+
+    bind = op.get_bind()
+    org_ids = [row[0] for row in bind.execute(sa.text("SELECT id FROM orgs")).fetchall()]
+    if org_ids:
+        op.bulk_insert(
+            sa.table(
+                "org_plan_entitlements",
+                sa.column("entitlement_id", postgresql.UUID(as_uuid=True)),
+                sa.column("org_id", postgresql.UUID(as_uuid=True)),
+                sa.column("plan_code", sa.Text()),
+                sa.column("billing_status", sa.Text()),
+                sa.column("core_incident_protocol", sa.Boolean()),
+                sa.column("entitlements_json", postgresql.JSONB(astext_type=sa.Text())),
+            ),
+            [
+                {
+                    "entitlement_id": uuid.uuid4(),
+                    "org_id": org_id,
+                    "plan_code": "starter",
+                    "billing_status": "active",
+                    "core_incident_protocol": True,
+                    "entitlements_json": {},
+                }
+                for org_id in org_ids
+            ],
+        )
+
+    op.create_table(
+        "demo_scenarios",
+        sa.Column("scenario_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("scenario_key", sa.Text(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("seeded_by", sa.Text(), nullable=True),
+        sa.Column("seed_batch_id", sa.Text(), nullable=True),
+        sa.Column("seed_metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("created_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("scenario_id"),
+    )
+    op.create_index("ix_demo_scenarios_org_id", "demo_scenarios", ["org_id"], unique=False)
+    op.create_index("ix_demo_scenarios_org_key", "demo_scenarios", ["org_id", "scenario_key"], unique=True)
+    op.create_index("ix_demo_scenarios_org_active", "demo_scenarios", ["org_id", "is_active"], unique=False)
+
+    op.create_table(
+        "help_categories",
+        sa.Column("category_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("slug", sa.Text(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("is_published", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("published_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("unpublished_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("created_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("category_id"),
+    )
+    op.create_index("ix_help_categories_org_id", "help_categories", ["org_id"], unique=False)
+    op.create_index("ix_help_categories_is_published", "help_categories", ["is_published"], unique=False)
+    op.create_index("ix_help_categories_org_slug", "help_categories", ["org_id", "slug"], unique=True)
+    op.create_index(
+        "ix_help_categories_org_published",
+        "help_categories",
+        ["org_id", "is_published", "sort_order"],
+        unique=False,
+    )
+
+    op.create_table(
+        "help_articles",
+        sa.Column("article_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("category_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("slug", sa.Text(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("body_markdown", sa.Text(), nullable=False),
+        sa.Column("metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("is_published", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("published_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("unpublished_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("created_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("updated_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["category_id"], ["help_categories.category_id"]),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.ForeignKeyConstraint(["updated_by_user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("article_id"),
+    )
+    op.create_index("ix_help_articles_org_id", "help_articles", ["org_id"], unique=False)
+    op.create_index("ix_help_articles_category_id", "help_articles", ["category_id"], unique=False)
+    op.create_index("ix_help_articles_is_published", "help_articles", ["is_published"], unique=False)
+    op.create_index("ix_help_articles_published_at_utc", "help_articles", ["published_at_utc"], unique=False)
+    op.create_index("ix_help_articles_org_slug", "help_articles", ["org_id", "slug"], unique=True)
+    op.create_index(
+        "ix_help_articles_org_published_category",
+        "help_articles",
+        ["org_id", "is_published", "category_id", "published_at_utc"],
+        unique=False,
+    )
+
+    op.create_table(
+        "trust_sections",
+        sa.Column("section_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("slug", sa.Text(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("body_markdown", sa.Text(), nullable=False),
+        sa.Column("metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("is_published", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("published_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("unpublished_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("created_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("section_id"),
+    )
+    op.create_index("ix_trust_sections_org_id", "trust_sections", ["org_id"], unique=False)
+    op.create_index("ix_trust_sections_is_published", "trust_sections", ["is_published"], unique=False)
+    op.create_index("ix_trust_sections_published_at_utc", "trust_sections", ["published_at_utc"], unique=False)
+    op.create_index("ix_trust_sections_org_slug", "trust_sections", ["org_id", "slug"], unique=True)
+    op.create_index(
+        "ix_trust_sections_org_published_sort",
+        "trust_sections",
+        ["org_id", "is_published", "sort_order", "published_at_utc"],
+        unique=False,
+    )
+
+    op.create_table(
+        "deployment_scope_snapshots",
+        sa.Column("snapshot_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("scope_version", sa.Text(), nullable=False),
+        sa.Column("scope_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("captured_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("captured_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["captured_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("snapshot_id"),
+    )
+    op.create_index("ix_deployment_scope_snapshots_org_id", "deployment_scope_snapshots", ["org_id"], unique=False)
+    op.create_index(
+        "ix_deployment_scope_snapshots_org_captured",
+        "deployment_scope_snapshots",
+        ["org_id", "captured_at_utc"],
+        unique=False,
+    )
+
+    op.create_table(
+        "help_article_views",
+        sa.Column("view_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("article_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("viewer_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("source", sa.Text(), nullable=True),
+        sa.Column("metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("viewed_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["article_id"], ["help_articles.article_id"]),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.ForeignKeyConstraint(["viewer_user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("view_id"),
+    )
+    op.create_index("ix_help_article_views_org_id", "help_article_views", ["org_id"], unique=False)
+    op.create_index("ix_help_article_views_article_id", "help_article_views", ["article_id"], unique=False)
+    op.create_index("ix_help_article_views_viewer_user_id", "help_article_views", ["viewer_user_id"], unique=False)
+    op.create_index("ix_help_article_views_viewed_at_utc", "help_article_views", ["viewed_at_utc"], unique=False)
+    op.create_index(
+        "ix_help_article_views_org_article_viewed",
+        "help_article_views",
+        ["org_id", "article_id", "viewed_at_utc"],
+        unique=False,
+    )
+
+    op.create_table(
+        "expansion_readiness_snapshots",
+        sa.Column("snapshot_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("scope_key", sa.Text(), nullable=False),
+        sa.Column("readiness_score", sa.Integer(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False, server_default="unknown"),
+        sa.Column("summary_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("computed_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("expires_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("created_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at_utc", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("snapshot_id"),
+    )
+    op.create_index("ix_expansion_readiness_snapshots_org_id", "expansion_readiness_snapshots", ["org_id"], unique=False)
+    op.create_index(
+        "ix_expansion_readiness_snapshots_org_scope",
+        "expansion_readiness_snapshots",
+        ["org_id", "scope_key"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_expansion_readiness_snapshots_org_computed",
+        "expansion_readiness_snapshots",
+        ["org_id", "computed_at_utc"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_expansion_readiness_snapshots_org_computed", table_name="expansion_readiness_snapshots")
+    op.drop_index("ix_expansion_readiness_snapshots_org_scope", table_name="expansion_readiness_snapshots")
+    op.drop_index("ix_expansion_readiness_snapshots_org_id", table_name="expansion_readiness_snapshots")
+    op.drop_table("expansion_readiness_snapshots")
+
+    op.drop_index("ix_help_article_views_org_article_viewed", table_name="help_article_views")
+    op.drop_index("ix_help_article_views_viewed_at_utc", table_name="help_article_views")
+    op.drop_index("ix_help_article_views_viewer_user_id", table_name="help_article_views")
+    op.drop_index("ix_help_article_views_article_id", table_name="help_article_views")
+    op.drop_index("ix_help_article_views_org_id", table_name="help_article_views")
+    op.drop_table("help_article_views")
+
+    op.drop_index("ix_deployment_scope_snapshots_org_captured", table_name="deployment_scope_snapshots")
+    op.drop_index("ix_deployment_scope_snapshots_org_id", table_name="deployment_scope_snapshots")
+    op.drop_table("deployment_scope_snapshots")
+
+    op.drop_index("ix_trust_sections_org_published_sort", table_name="trust_sections")
+    op.drop_index("ix_trust_sections_org_slug", table_name="trust_sections")
+    op.drop_index("ix_trust_sections_published_at_utc", table_name="trust_sections")
+    op.drop_index("ix_trust_sections_is_published", table_name="trust_sections")
+    op.drop_index("ix_trust_sections_org_id", table_name="trust_sections")
+    op.drop_table("trust_sections")
+
+    op.drop_index("ix_help_articles_org_published_category", table_name="help_articles")
+    op.drop_index("ix_help_articles_org_slug", table_name="help_articles")
+    op.drop_index("ix_help_articles_published_at_utc", table_name="help_articles")
+    op.drop_index("ix_help_articles_is_published", table_name="help_articles")
+    op.drop_index("ix_help_articles_category_id", table_name="help_articles")
+    op.drop_index("ix_help_articles_org_id", table_name="help_articles")
+    op.drop_table("help_articles")
+
+    op.drop_index("ix_help_categories_org_published", table_name="help_categories")
+    op.drop_index("ix_help_categories_org_slug", table_name="help_categories")
+    op.drop_index("ix_help_categories_is_published", table_name="help_categories")
+    op.drop_index("ix_help_categories_org_id", table_name="help_categories")
+    op.drop_table("help_categories")
+
+    op.drop_index("ix_demo_scenarios_org_active", table_name="demo_scenarios")
+    op.drop_index("ix_demo_scenarios_org_key", table_name="demo_scenarios")
+    op.drop_index("ix_demo_scenarios_org_id", table_name="demo_scenarios")
+    op.drop_table("demo_scenarios")
+
+    op.drop_index("ix_org_plan_entitlements_org_current", table_name="org_plan_entitlements")
+    op.drop_index("ix_org_plan_entitlements_org_id", table_name="org_plan_entitlements")
+    op.drop_table("org_plan_entitlements")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1527,6 +1527,314 @@ class OrgExportValidationRun(Base):
     )
 
 
+class OrgPlanEntitlement(Base):
+    """Organization plan and entitlement state."""
+
+    __tablename__ = "org_plan_entitlements"
+
+    entitlement_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    plan_code = Column(Text, nullable=False, default="starter", server_default="starter")
+    billing_status = Column(
+        Text, nullable=False, default="active", server_default="active"
+    )
+    core_incident_protocol = Column(
+        Boolean, nullable=False, default=True, server_default=text("true")
+    )
+    entitlements_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    effective_from_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    effective_to_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_org_plan_entitlements_org_current", "org_id", "effective_to_utc"),
+    )
+
+
+class DemoScenario(Base):
+    """Curated demo scenarios, optionally seeded for an organization."""
+
+    __tablename__ = "demo_scenarios"
+
+    scenario_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    scenario_key = Column(Text, nullable=False)
+    name = Column(Text, nullable=False)
+    description = Column(Text, nullable=True)
+    is_active = Column(Boolean, nullable=False, default=True, server_default=text("true"))
+    seeded_by = Column(Text, nullable=True)
+    seed_batch_id = Column(Text, nullable=True)
+    seed_metadata_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_demo_scenarios_org_key", "org_id", "scenario_key", unique=True),
+        Index("ix_demo_scenarios_org_active", "org_id", "is_active"),
+    )
+
+
+class HelpCategory(Base):
+    """Knowledge base category metadata."""
+
+    __tablename__ = "help_categories"
+
+    category_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    slug = Column(Text, nullable=False)
+    title = Column(Text, nullable=False)
+    description = Column(Text, nullable=True)
+    sort_order = Column(Integer, nullable=False, default=0, server_default=text("0"))
+    metadata_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    is_published = Column(
+        Boolean, nullable=False, default=False, server_default=text("false"), index=True
+    )
+    published_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    unpublished_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_help_categories_org_slug", "org_id", "slug", unique=True),
+        Index("ix_help_categories_org_published", "org_id", "is_published", "sort_order"),
+    )
+
+
+class HelpArticle(Base):
+    """Help center article content and publication metadata."""
+
+    __tablename__ = "help_articles"
+
+    article_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    category_id = Column(
+        UUID(as_uuid=True), ForeignKey("help_categories.category_id"), nullable=True, index=True
+    )
+    slug = Column(Text, nullable=False)
+    title = Column(Text, nullable=False)
+    summary = Column(Text, nullable=True)
+    body_markdown = Column(Text, nullable=False)
+    metadata_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    is_published = Column(
+        Boolean, nullable=False, default=False, server_default=text("false"), index=True
+    )
+    published_at_utc = Column(TIMESTAMP(timezone=True), nullable=True, index=True)
+    unpublished_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    created_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
+    updated_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_help_articles_org_slug", "org_id", "slug", unique=True),
+        Index(
+            "ix_help_articles_org_published_category",
+            "org_id",
+            "is_published",
+            "category_id",
+            "published_at_utc",
+        ),
+    )
+
+
+class TrustSection(Base):
+    """Trust center section content and publication metadata."""
+
+    __tablename__ = "trust_sections"
+
+    section_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    slug = Column(Text, nullable=False)
+    title = Column(Text, nullable=False)
+    body_markdown = Column(Text, nullable=False)
+    metadata_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    sort_order = Column(Integer, nullable=False, default=0, server_default=text("0"))
+    is_published = Column(
+        Boolean, nullable=False, default=False, server_default=text("false"), index=True
+    )
+    published_at_utc = Column(TIMESTAMP(timezone=True), nullable=True, index=True)
+    unpublished_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_trust_sections_org_slug", "org_id", "slug", unique=True),
+        Index(
+            "ix_trust_sections_org_published_sort",
+            "org_id",
+            "is_published",
+            "sort_order",
+            "published_at_utc",
+        ),
+    )
+
+
+class DeploymentScopeSnapshot(Base):
+    """Point-in-time deployment scope snapshot for an organization."""
+
+    __tablename__ = "deployment_scope_snapshots"
+
+    snapshot_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    scope_version = Column(Text, nullable=False)
+    scope_json = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
+    captured_by_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
+    captured_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_deployment_scope_snapshots_org_captured",
+            "org_id",
+            "captured_at_utc",
+        ),
+    )
+
+
+class HelpArticleView(Base):
+    """Per-view telemetry events for help article usage."""
+
+    __tablename__ = "help_article_views"
+
+    view_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    article_id = Column(
+        UUID(as_uuid=True), ForeignKey("help_articles.article_id"), nullable=False, index=True
+    )
+    viewer_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True, index=True
+    )
+    source = Column(Text, nullable=True)
+    metadata_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    viewed_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now(), index=True
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_help_article_views_org_article_viewed",
+            "org_id",
+            "article_id",
+            "viewed_at_utc",
+        ),
+    )
+
+
+class ExpansionReadinessSnapshot(Base):
+    """Optional cached expansion readiness summary per org and scope."""
+
+    __tablename__ = "expansion_readiness_snapshots"
+
+    snapshot_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False, index=True
+    )
+    scope_key = Column(Text, nullable=False)
+    readiness_score = Column(Integer, nullable=True)
+    status = Column(Text, nullable=False, default="unknown", server_default="unknown")
+    summary_json = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    computed_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    expires_at_utc = Column(TIMESTAMP(timezone=True), nullable=True)
+    created_at_utc = Column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at_utc = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_expansion_readiness_snapshots_org_scope",
+            "org_id",
+            "scope_key",
+            unique=True,
+        ),
+        Index(
+            "ix_expansion_readiness_snapshots_org_computed",
+            "org_id",
+            "computed_at_utc",
+        ),
+    )
+
+
 # ── Driver protocol models ────────────────────────────────────────────
 
 

--- a/backend/app/db/repo/org_content.py
+++ b/backend/app/db/repo/org_content.py
@@ -1,0 +1,285 @@
+"""Repository helpers for org entitlements, content, and readiness snapshots."""
+
+import uuid as _uuid
+
+from sqlalchemy.orm import Session
+
+from app.db.models import (
+    DemoScenario,
+    DeploymentScopeSnapshot,
+    ExpansionReadinessSnapshot,
+    HelpArticle,
+    HelpArticleView,
+    HelpCategory,
+    OrgPlanEntitlement,
+    TrustSection,
+)
+
+
+def get_org_plan_entitlement(db: Session, org_id: _uuid.UUID) -> OrgPlanEntitlement | None:
+    """Return the most recent active entitlement row for an org."""
+    return (
+        db.query(OrgPlanEntitlement)
+        .filter(
+            OrgPlanEntitlement.org_id == org_id,
+            OrgPlanEntitlement.effective_to_utc.is_(None),
+        )
+        .order_by(OrgPlanEntitlement.effective_from_utc.desc())
+        .first()
+    )
+
+
+def upsert_org_plan_entitlement(
+    db: Session,
+    org_id: _uuid.UUID,
+    *,
+    plan_code: str,
+    billing_status: str = "active",
+    core_incident_protocol: bool = True,
+    entitlements_json: dict | None = None,
+) -> OrgPlanEntitlement:
+    """Create or update active org entitlement state."""
+    row = get_org_plan_entitlement(db, org_id)
+    if row is None:
+        row = OrgPlanEntitlement(org_id=org_id)
+        db.add(row)
+
+    row.plan_code = plan_code
+    row.billing_status = billing_status
+    row.core_incident_protocol = core_incident_protocol
+    row.entitlements_json = entitlements_json or {}
+
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def create_demo_scenario(
+    db: Session,
+    org_id: _uuid.UUID,
+    *,
+    scenario_key: str,
+    name: str,
+    description: str | None = None,
+    seeded_by: str | None = None,
+    seed_batch_id: str | None = None,
+    seed_metadata_json: dict | None = None,
+) -> DemoScenario:
+    """Create an org-scoped demo scenario."""
+    row = DemoScenario(
+        org_id=org_id,
+        scenario_key=scenario_key,
+        name=name,
+        description=description,
+        seeded_by=seeded_by,
+        seed_batch_id=seed_batch_id,
+        seed_metadata_json=seed_metadata_json or {},
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def list_demo_scenarios(db: Session, org_id: _uuid.UUID, *, active_only: bool = True) -> list[DemoScenario]:
+    """List demo scenarios for an org."""
+    query = db.query(DemoScenario).filter(DemoScenario.org_id == org_id)
+    if active_only:
+        query = query.filter(DemoScenario.is_active.is_(True))
+    return query.order_by(DemoScenario.created_at_utc.desc()).all()
+
+
+def create_help_category(
+    db: Session,
+    org_id: _uuid.UUID,
+    *,
+    slug: str,
+    title: str,
+    description: str | None = None,
+    metadata_json: dict | None = None,
+    sort_order: int = 0,
+) -> HelpCategory:
+    """Create a help category."""
+    row = HelpCategory(
+        org_id=org_id,
+        slug=slug,
+        title=title,
+        description=description,
+        metadata_json=metadata_json or {},
+        sort_order=sort_order,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def create_help_article(
+    db: Session,
+    org_id: _uuid.UUID,
+    *,
+    slug: str,
+    title: str,
+    body_markdown: str,
+    category_id: _uuid.UUID | None = None,
+    summary: str | None = None,
+    metadata_json: dict | None = None,
+    created_by_user_id: _uuid.UUID | None = None,
+) -> HelpArticle:
+    """Create a help article."""
+    row = HelpArticle(
+        org_id=org_id,
+        category_id=category_id,
+        slug=slug,
+        title=title,
+        summary=summary,
+        body_markdown=body_markdown,
+        metadata_json=metadata_json or {},
+        created_by_user_id=created_by_user_id,
+        updated_by_user_id=created_by_user_id,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def list_help_articles(
+    db: Session,
+    org_id: _uuid.UUID,
+    *,
+    published_only: bool = True,
+    category_id: _uuid.UUID | None = None,
+) -> list[HelpArticle]:
+    """List help articles for an org."""
+    query = db.query(HelpArticle).filter(HelpArticle.org_id == org_id)
+    if published_only:
+        query = query.filter(HelpArticle.is_published.is_(True))
+    if category_id:
+        query = query.filter(HelpArticle.category_id == category_id)
+    return query.order_by(HelpArticle.published_at_utc.desc().nullslast()).all()
+
+
+def create_trust_section(
+    db: Session,
+    org_id: _uuid.UUID,
+    *,
+    slug: str,
+    title: str,
+    body_markdown: str,
+    metadata_json: dict | None = None,
+    sort_order: int = 0,
+) -> TrustSection:
+    """Create a trust section."""
+    row = TrustSection(
+        org_id=org_id,
+        slug=slug,
+        title=title,
+        body_markdown=body_markdown,
+        metadata_json=metadata_json or {},
+        sort_order=sort_order,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def list_trust_sections(
+    db: Session,
+    org_id: _uuid.UUID,
+    *,
+    published_only: bool = True,
+) -> list[TrustSection]:
+    """List trust center sections."""
+    query = db.query(TrustSection).filter(TrustSection.org_id == org_id)
+    if published_only:
+        query = query.filter(TrustSection.is_published.is_(True))
+    return query.order_by(TrustSection.sort_order.asc(), TrustSection.created_at_utc.asc()).all()
+
+
+def create_deployment_scope_snapshot(
+    db: Session,
+    org_id: _uuid.UUID,
+    *,
+    scope_version: str,
+    scope_json: dict,
+    captured_by_user_id: _uuid.UUID | None = None,
+) -> DeploymentScopeSnapshot:
+    """Persist a deployment scope snapshot."""
+    row = DeploymentScopeSnapshot(
+        org_id=org_id,
+        scope_version=scope_version,
+        scope_json=scope_json,
+        captured_by_user_id=captured_by_user_id,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def get_latest_deployment_scope_snapshot(
+    db: Session, org_id: _uuid.UUID
+) -> DeploymentScopeSnapshot | None:
+    """Return the latest deployment scope snapshot for an org."""
+    return (
+        db.query(DeploymentScopeSnapshot)
+        .filter(DeploymentScopeSnapshot.org_id == org_id)
+        .order_by(DeploymentScopeSnapshot.captured_at_utc.desc())
+        .first()
+    )
+
+
+def record_help_article_view(
+    db: Session,
+    org_id: _uuid.UUID,
+    article_id: _uuid.UUID,
+    *,
+    viewer_user_id: _uuid.UUID | None = None,
+    source: str | None = None,
+    metadata_json: dict | None = None,
+) -> HelpArticleView:
+    """Record a help article view event."""
+    row = HelpArticleView(
+        org_id=org_id,
+        article_id=article_id,
+        viewer_user_id=viewer_user_id,
+        source=source,
+        metadata_json=metadata_json or {},
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def upsert_expansion_readiness_snapshot(
+    db: Session,
+    org_id: _uuid.UUID,
+    *,
+    scope_key: str,
+    status: str,
+    summary_json: dict,
+    readiness_score: int | None = None,
+) -> ExpansionReadinessSnapshot:
+    """Upsert the optional cached expansion readiness summary."""
+    row = (
+        db.query(ExpansionReadinessSnapshot)
+        .filter(
+            ExpansionReadinessSnapshot.org_id == org_id,
+            ExpansionReadinessSnapshot.scope_key == scope_key,
+        )
+        .first()
+    )
+    if row is None:
+        row = ExpansionReadinessSnapshot(org_id=org_id, scope_key=scope_key)
+        db.add(row)
+
+    row.status = status
+    row.summary_json = summary_json
+    row.readiness_score = readiness_score
+
+    db.commit()
+    db.refresh(row)
+    return row


### PR DESCRIPTION
### Motivation
- Introduce first-class persistence for org-scoped commercial and content features (plans/entitlements, demo scenarios, help/trust content) and optional readiness caches to support APIs and UI publication/telemetry workflows.
- Provide efficient org-scoped read patterns and publication filters via composite indexes to keep reads performant and tenant-isolated.
- Add a migration that creates the schema and backfills sensible defaults (e.g., `core_incident_protocol=true`) for existing orgs so runtime code can rely on entitlement defaults.

### Description
- Extended `backend/app/db/models.py` with new SQLAlchemy models: `OrgPlanEntitlement`, `DemoScenario`, `HelpCategory`, `HelpArticle`, `TrustSection`, `DeploymentScopeSnapshot`, `HelpArticleView`, and `ExpansionReadinessSnapshot`, and added org/publication-focused `__table_args__` indexes for read patterns.
- Added Alembic migration `backend/app/db/migrations/versions/0025_add_org_content_and_readiness_tables.py` to create all new tables, indexes, and a backfill that inserts default entitlement rows for existing orgs (implemented with safe bulk insert logic).
- Added repository helpers in `backend/app/db/repo/org_content.py` implementing CRUD/query patterns used by APIs, including `get_org_plan_entitlement`, `upsert_org_plan_entitlement`, demo scenario helpers, help/trust content creation/listing, deployment snapshot APIs, article view recording, and expansion readiness upsert.
- Created composite indexes for org-scoped lookups and publication filters and ensured foreign keys where appropriate to maintain referential integrity.

### Testing
- Ran linting with `make lint` and the lint step completed successfully.
- Ran the full backend test suite with `make test` (which runs `pytest tests/`) and the run completed successfully with `458 passed` (and `4 warnings`).
- Ran schema validation with `python scripts/validate_schemas.py` as part of `make test` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51b12d1fc8321ad382beb9eb031a4)