### PR TITLE
Add org entitlement API + enforcement helpers with audit trails

### DIFF
--- a/backend/app/api/routes/routes_demo.py
+++ b/backend/app/api/routes/routes_demo.py
@@ -14,6 +14,7 @@ from app.commercial.demo import (
     reset_demo_tenant,
     seed_demo_tenant,
 )
+from app.commercial.enforcement import require_feature_enabled
 from app.core.deps import get_current_user
 from app.db.models import User
 from app.db.session import get_db
@@ -58,12 +59,38 @@ def _require_demo_mutation_role(user: User) -> None:
         )
 
 
+def _enforce_demo_feature(
+    db: Session,
+    *,
+    org_id,
+    current_user: User,
+    feature_key: str,
+    action: str,
+) -> None:
+    require_feature_enabled(
+        db,
+        org_id=org_id,
+        actor_id=str(current_user.id),
+        actor_role=current_user.role,
+        feature_key=feature_key,
+        action=action,
+        allow_internal_override=True,
+    )
+
+
 @router.get("/scenarios", response_model=list[DemoScenarioSummary])
 def get_demo_scenarios(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     context = build_user_auth_context(db, current_user)
+    _enforce_demo_feature(
+        db,
+        org_id=context.org_ids[0],
+        current_user=current_user,
+        feature_key="demo.workspace",
+        action="demo.workspace.read",
+    )
     ensure_demo_org(db, org_id=context.org_ids[0])
     return list_scenarios(db, org_id=context.org_ids[0])
 
@@ -75,7 +102,16 @@ def post_demo_reset(
 ):
     _require_demo_mutation_role(current_user)
     context = build_user_auth_context(db, current_user)
-    deleted = reset_demo_tenant(db, org_id=context.org_ids[0], actor_id=str(current_user.id))
+    _enforce_demo_feature(
+        db,
+        org_id=context.org_ids[0],
+        current_user=current_user,
+        feature_key="demo.incident_seed",
+        action="demo.workspace.mutate",
+    )
+    deleted = reset_demo_tenant(
+        db, org_id=context.org_ids[0], actor_id=str(current_user.id)
+    )
     return DemoResetResponse(deleted=deleted)
 
 
@@ -87,6 +123,13 @@ def post_demo_seed(
 ):
     _require_demo_mutation_role(current_user)
     context = build_user_auth_context(db, current_user)
+    _enforce_demo_feature(
+        db,
+        org_id=context.org_ids[0],
+        current_user=current_user,
+        feature_key="demo.incident_seed",
+        action="demo.workspace.mutate",
+    )
     try:
         seeded = seed_demo_tenant(
             db,
@@ -95,7 +138,9 @@ def post_demo_seed(
             scenario_key=payload.scenario_id,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown scenario") from exc
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Unknown scenario"
+        ) from exc
     return DemoSeedResponse(**seeded)
 
 
@@ -107,6 +152,13 @@ def post_demo_launch(
 ):
     _require_demo_mutation_role(current_user)
     context = build_user_auth_context(db, current_user)
+    _enforce_demo_feature(
+        db,
+        org_id=context.org_ids[0],
+        current_user=current_user,
+        feature_key="demo.incident_seed",
+        action="demo.workspace.mutate",
+    )
     try:
         seeded = launch_scenario(
             db,
@@ -115,5 +167,7 @@ def post_demo_launch(
             scenario_id=scenario_id,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown scenario") from exc
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Unknown scenario"
+        ) from exc
     return DemoLaunchResponse(**seeded)

--- a/backend/app/api/routes/routes_entitlements.py
+++ b/backend/app/api/routes/routes_entitlements.py
@@ -1,0 +1,249 @@
+"""Organization commercial plan + entitlement routes."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.audit.emitter import emit_standard_audit_event
+from app.commercial.enforcement import (
+    INTERNAL_OVERRIDE_ROLES,
+    is_internal_override_actor,
+    resolve_org_access_snapshot,
+)
+from app.core.deps import get_current_user, require_user_role
+from app.db.models import User
+from app.db.repo.org_content import (
+    get_org_plan_entitlement,
+    upsert_org_plan_entitlement,
+)
+from app.db.session import get_db
+from app.security.authn import build_user_auth_context
+
+router = APIRouter(prefix="/org", tags=["org-entitlements"])
+
+_org_entitlement_mutator = require_user_role(
+    "system_admin",
+    "org_admin",
+    "support_admin",
+    "support_agent",
+)
+
+
+class OrgPlanResponse(BaseModel):
+    org_id: uuid.UUID
+    plan_code: str
+    billing_status: str
+    core_incident_protocol: bool
+    effective_from_utc: str | None
+    effective_to_utc: str | None
+
+
+class EntitlementItem(BaseModel):
+    key: str
+    enabled: bool
+
+
+class ModuleItem(BaseModel):
+    key: str
+    enabled: bool = True
+
+
+class OrgEntitlementsResponse(BaseModel):
+    org_id: uuid.UUID
+    plan_code: str
+    billing_status: str
+    modules: list[ModuleItem]
+    entitlements: list[EntitlementItem]
+    feature_flags: dict[str, bool]
+    internal_override_eligible_roles: list[str]
+
+
+class OrgModulesResponse(BaseModel):
+    org_id: uuid.UUID
+    plan_code: str
+    modules: list[ModuleItem]
+
+
+class EntitlementInternalOverride(BaseModel):
+    reason: str = Field(min_length=3, max_length=256)
+    ticket_id: str | None = Field(default=None, max_length=128)
+    actor_path: str = Field(default="support")
+
+
+class OrgEntitlementPatchRequest(BaseModel):
+    plan_code: str | None = None
+    billing_status: str | None = None
+    core_incident_protocol: bool | None = None
+    entitlements: dict[str, bool] | None = None
+    internal_override: EntitlementInternalOverride | None = None
+
+
+def _resolve_org_context(db: Session, user: User) -> tuple[uuid.UUID, Any]:
+    context = build_user_auth_context(db, user)
+    return context.org_ids[0], context
+
+
+def _serialize_plan(org_id: uuid.UUID, row) -> OrgPlanResponse:
+    return OrgPlanResponse(
+        org_id=org_id,
+        plan_code=row.plan_code,
+        billing_status=row.billing_status,
+        core_incident_protocol=bool(row.core_incident_protocol),
+        effective_from_utc=row.effective_from_utc.isoformat()
+        if row.effective_from_utc
+        else None,
+        effective_to_utc=row.effective_to_utc.isoformat()
+        if row.effective_to_utc
+        else None,
+    )
+
+
+def _serialize_entitlements(org_id: uuid.UUID, db: Session) -> OrgEntitlementsResponse:
+    snapshot = resolve_org_access_snapshot(db, org_id=org_id)
+    row = get_org_plan_entitlement(db, org_id)
+    billing_status = row.billing_status if row is not None else "active"
+
+    entitlements = [
+        EntitlementItem(key=key, enabled=enabled)
+        for key, enabled in snapshot["entitlements"].items()
+    ]
+    modules = [ModuleItem(key=key, enabled=True) for key in snapshot["modules"]]
+
+    return OrgEntitlementsResponse(
+        org_id=org_id,
+        plan_code=str(snapshot["plan_code"]),
+        billing_status=billing_status,
+        modules=modules,
+        entitlements=entitlements,
+        feature_flags=dict(snapshot["entitlements"]),
+        internal_override_eligible_roles=sorted(INTERNAL_OVERRIDE_ROLES),
+    )
+
+
+@router.get("/plan", response_model=OrgPlanResponse)
+def get_org_plan(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    org_id, _ = _resolve_org_context(db, current_user)
+    row = get_org_plan_entitlement(db, org_id)
+    if row is None:
+        row = upsert_org_plan_entitlement(db, org_id, plan_code="starter")
+    return _serialize_plan(org_id, row)
+
+
+@router.get("/entitlements", response_model=OrgEntitlementsResponse)
+def get_org_entitlements(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    org_id, _ = _resolve_org_context(db, current_user)
+    if get_org_plan_entitlement(db, org_id) is None:
+        upsert_org_plan_entitlement(db, org_id, plan_code="starter")
+    return _serialize_entitlements(org_id, db)
+
+
+@router.patch("/entitlements", response_model=OrgEntitlementsResponse)
+def patch_org_entitlements(
+    payload: OrgEntitlementPatchRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(_org_entitlement_mutator),
+):
+    org_id, _ = _resolve_org_context(db, current_user)
+    existing = get_org_plan_entitlement(db, org_id)
+    if existing is None:
+        existing = upsert_org_plan_entitlement(db, org_id, plan_code="starter")
+
+    override_metadata: dict[str, Any] = {}
+    if payload.internal_override is not None:
+        if not is_internal_override_actor(current_user.role):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Internal override requires internal role",
+            )
+        override_metadata = {
+            "internal_override": {
+                "applied": True,
+                "reason": payload.internal_override.reason,
+                "ticket_id": payload.internal_override.ticket_id,
+                "actor_path": payload.internal_override.actor_path,
+                "actor_role": (current_user.role or "").strip().lower(),
+            }
+        }
+
+    previous_plan_code = existing.plan_code
+
+    updated = upsert_org_plan_entitlement(
+        db,
+        org_id,
+        plan_code=payload.plan_code or existing.plan_code,
+        billing_status=payload.billing_status or existing.billing_status,
+        core_incident_protocol=(
+            payload.core_incident_protocol
+            if payload.core_incident_protocol is not None
+            else bool(existing.core_incident_protocol)
+        ),
+        entitlements_json=(
+            payload.entitlements
+            if payload.entitlements is not None
+            else dict(existing.entitlements_json or {})
+        ),
+    )
+
+    if payload.plan_code is not None and payload.plan_code != previous_plan_code:
+        emit_standard_audit_event(
+            db,
+            org_id=org_id,
+            actor_type="user",
+            actor_id=str(current_user.id),
+            action="org.plan.update",
+            event_type="org_plan_changed",
+            entity_type="org_plan",
+            entity_id=str(org_id),
+            outcome="success",
+            metadata={
+                "before": {"plan_code": previous_plan_code},
+                "after": {"plan_code": updated.plan_code},
+                **override_metadata,
+            },
+        )
+
+    if payload.entitlements is not None:
+        emit_standard_audit_event(
+            db,
+            org_id=org_id,
+            actor_type="user",
+            actor_id=str(current_user.id),
+            action="org.entitlements.update",
+            event_type="feature_entitlement_updated",
+            entity_type="org_entitlements",
+            entity_id=str(org_id),
+            outcome="success",
+            metadata={
+                "feature_flags": dict(updated.entitlements_json or {}),
+                **override_metadata,
+            },
+        )
+
+    return _serialize_entitlements(org_id, db)
+
+
+@router.get("/modules", response_model=OrgModulesResponse)
+def get_org_modules(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    org_id, _ = _resolve_org_context(db, current_user)
+    if get_org_plan_entitlement(db, org_id) is None:
+        upsert_org_plan_entitlement(db, org_id, plan_code="starter")
+    snapshot = resolve_org_access_snapshot(db, org_id=org_id)
+    return OrgModulesResponse(
+        org_id=org_id,
+        plan_code=str(snapshot["plan_code"]),
+        modules=[ModuleItem(key=key, enabled=True) for key in snapshot["modules"]],
+    )

--- a/backend/app/commercial/enforcement.py
+++ b/backend/app/commercial/enforcement.py
@@ -1,0 +1,146 @@
+"""Entitlement enforcement helpers for API route-level feature gates."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.audit.emitter import emit_standard_audit_event
+from app.commercial.service import (
+    is_feature_enabled_for_org,
+    list_org_modules,
+    resolve_org_entitlements,
+    resolve_org_plan,
+)
+from app.db.repo.org_content import get_org_plan_entitlement
+
+INTERNAL_OVERRIDE_ROLES = {"system_admin", "support_admin", "support_agent"}
+
+
+class _OrgPlanRepository:
+    def __init__(self, db: Session):
+        self._db = db
+
+    def get_plan_for_org(self, org_id: uuid.UUID) -> str | None:
+        row = get_org_plan_entitlement(self._db, org_id)
+        return row.plan_code if row is not None else None
+
+
+class _OrgEntitlementRepository:
+    def __init__(self, db: Session):
+        self._db = db
+
+    def get_overrides_for_org(self, org_id: uuid.UUID) -> dict[str, bool]:
+        row = get_org_plan_entitlement(self._db, org_id)
+        data = dict(row.entitlements_json or {}) if row is not None else {}
+        return {str(key): bool(value) for key, value in data.items()}
+
+
+@dataclass(frozen=True)
+class EntitlementDecision:
+    enabled: bool
+    via_internal_override: bool
+
+
+def _normalize_role(role: str | None) -> str:
+    return (role or "").strip().lower()
+
+
+def is_internal_override_actor(role: str | None) -> bool:
+    return _normalize_role(role) in INTERNAL_OVERRIDE_ROLES
+
+
+def entitlement_decision(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    feature_key: str,
+    actor_role: str,
+    allow_internal_override: bool = False,
+) -> EntitlementDecision:
+    plan_repo = _OrgPlanRepository(db)
+    ent_repo = _OrgEntitlementRepository(db)
+    enabled = is_feature_enabled_for_org(
+        org_id=org_id,
+        feature_key=feature_key,
+        actor_role=actor_role,
+        plan_repo=plan_repo,
+        entitlement_repo=ent_repo,
+    )
+    if enabled:
+        return EntitlementDecision(enabled=True, via_internal_override=False)
+
+    via_internal_override = allow_internal_override and is_internal_override_actor(
+        actor_role
+    )
+    return EntitlementDecision(
+        enabled=via_internal_override, via_internal_override=via_internal_override
+    )
+
+
+def require_feature_enabled(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    actor_id: str,
+    actor_role: str,
+    feature_key: str,
+    action: str,
+    allow_internal_override: bool = False,
+) -> EntitlementDecision:
+    decision = entitlement_decision(
+        db,
+        org_id=org_id,
+        feature_key=feature_key,
+        actor_role=actor_role,
+        allow_internal_override=allow_internal_override,
+    )
+    if not decision.enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Feature unavailable",
+        )
+
+    if decision.via_internal_override:
+        emit_standard_audit_event(
+            db,
+            org_id=org_id,
+            actor_type="user",
+            actor_id=actor_id,
+            action=action,
+            event_type="feature_entitlement_override_used",
+            entity_type="feature",
+            entity_id=feature_key,
+            outcome="success",
+            metadata={
+                "internal_override": {
+                    "applied": True,
+                    "actor_role": _normalize_role(actor_role),
+                    "reason": "demo_support_override_path",
+                }
+            },
+        )
+
+    return decision
+
+
+def resolve_org_access_snapshot(db: Session, *, org_id: uuid.UUID) -> dict[str, object]:
+    plan_repo = _OrgPlanRepository(db)
+    ent_repo = _OrgEntitlementRepository(db)
+    plan = resolve_org_plan(org_id=org_id, plan_repo=plan_repo)
+    modules = [
+        module.value for module in list_org_modules(org_id=org_id, plan_repo=plan_repo)
+    ]
+    entitlements = resolve_org_entitlements(
+        org_id=org_id,
+        plan_repo=plan_repo,
+        entitlement_repo=ent_repo,
+    )
+    return {
+        "plan_code": plan.value,
+        "modules": modules,
+        "entitlements": {str(k): bool(v) for k, v in sorted(entitlements.items())},
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from app.api.routes.routes_notes import router as notes_router
 from app.api.routes.routes_driver_report import router as driver_report_router
 from app.api.routes.routes_tasks import router as tasks_router
 from app.api.routes.routes_demo import router as demo_router
+from app.api.routes.routes_entitlements import router as entitlements_router
 from app.api.routes_admin import router as admin_router
 from app.api.routes_twilio import router as twilio_router
 from app.health.routes import router as health_router
@@ -58,6 +59,7 @@ app.include_router(case_ops_router, tags=["case-ops"])
 app.include_router(notes_router, tags=["notes"])
 app.include_router(tasks_router, tags=["tasks"])
 app.include_router(demo_router)
+app.include_router(entitlements_router)
 app.include_router(admin_router, prefix="/admin", tags=["admin"])
 app.include_router(twilio_router, prefix="/twilio", tags=["twilio"])
 app.include_router(onboarding_router)
@@ -75,4 +77,7 @@ async def validate_startup_configuration() -> None:
 
     validate_startup_config(settings)
     init_sentry(service="api")
-    logger.info("startup_complete", extra={"deploy_version": settings.RELEASE, "app_env": settings.APP_ENV})
+    logger.info(
+        "startup_complete",
+        extra={"deploy_version": settings.RELEASE, "app_env": settings.APP_ENV},
+    )

--- a/backend/tests/test_entitlements_routes.py
+++ b/backend/tests/test_entitlements_routes.py
@@ -1,0 +1,186 @@
+"""Tests for org plan + entitlement routes."""
+
+import uuid
+
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.security import create_access_token, hash_password
+from app.db.models import AuditEvent, Base, Org, User, UserOrg
+from app.db.repo.org_content import upsert_org_plan_entitlement
+from app.db.session import get_db
+from app.main import app
+
+
+@pytest.fixture()
+def db_session():
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine)
+    session = TestSession()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def test_org(db_session):
+    org = Org(name="Commercial Test Org")
+    db_session.add(org)
+    db_session.commit()
+    db_session.refresh(org)
+    return org
+
+
+def _create_user(db_session, org, *, role: str, email: str) -> User:
+    user = User(
+        email=email,
+        password_hash=hash_password("testpass"),
+        role=role,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    db_session.add(UserOrg(user_id=user.id, org_id=org.id))
+    db_session.commit()
+    return user
+
+
+@pytest.fixture()
+def org_admin_user(db_session, test_org):
+    return _create_user(
+        db_session, test_org, role="org_admin", email="org-admin@example.com"
+    )
+
+
+@pytest.fixture()
+def support_admin_user(db_session, test_org):
+    return _create_user(
+        db_session, test_org, role="support_admin", email="support-admin@example.com"
+    )
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def _auth_headers(user):
+    token = create_access_token({"sub": str(user.id), "role": user.role})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_org_plan_entitlements_and_modules_are_ui_safe(client, org_admin_user):
+    plan_resp = client.get("/org/plan", headers=_auth_headers(org_admin_user))
+    assert plan_resp.status_code == 200
+    assert plan_resp.json()["plan_code"] == "starter"
+
+    ent_resp = client.get("/org/entitlements", headers=_auth_headers(org_admin_user))
+    assert ent_resp.status_code == 200
+    payload = ent_resp.json()
+    assert set(payload.keys()) == {
+        "org_id",
+        "plan_code",
+        "billing_status",
+        "modules",
+        "entitlements",
+        "feature_flags",
+        "internal_override_eligible_roles",
+    }
+    assert isinstance(payload["modules"], list)
+    assert isinstance(payload["entitlements"], list)
+    assert isinstance(payload["feature_flags"], dict)
+
+    modules_resp = client.get("/org/modules", headers=_auth_headers(org_admin_user))
+    assert modules_resp.status_code == 200
+    modules_payload = modules_resp.json()
+    assert set(modules_payload.keys()) == {"org_id", "plan_code", "modules"}
+
+
+def test_patch_entitlements_emits_plan_and_feature_audit_events(
+    client, db_session, org_admin_user, test_org
+):
+    upsert_org_plan_entitlement(db_session, test_org.id, plan_code="starter")
+
+    resp = client.patch(
+        "/org/entitlements",
+        headers=_auth_headers(org_admin_user),
+        json={
+            "plan_code": "growth",
+            "entitlements": {"reporting.dashboard": True},
+        },
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["plan_code"] == "growth"
+    assert payload["feature_flags"]["reporting.dashboard"] is True
+
+    events = db_session.query(AuditEvent).all()
+    event_types = {row.event_type for row in events}
+    assert "org_plan_changed" in event_types
+    assert "feature_entitlement_updated" in event_types
+
+
+def test_patch_entitlements_internal_override_requires_internal_role(
+    client, org_admin_user
+):
+    resp = client.patch(
+        "/org/entitlements",
+        headers=_auth_headers(org_admin_user),
+        json={
+            "entitlements": {"demo.workspace": True},
+            "internal_override": {
+                "reason": "demo assistance",
+                "ticket_id": "SUP-123",
+                "actor_path": "support",
+            },
+        },
+    )
+    assert resp.status_code == 403
+
+
+def test_patch_entitlements_internal_override_writes_audit_metadata(
+    client, db_session, support_admin_user
+):
+    resp = client.patch(
+        "/org/entitlements",
+        headers=_auth_headers(support_admin_user),
+        json={
+            "entitlements": {"demo.workspace": True},
+            "internal_override": {
+                "reason": "demo support enablement",
+                "ticket_id": str(uuid.uuid4()),
+                "actor_path": "demo_support",
+            },
+        },
+    )
+    assert resp.status_code == 200
+
+    feature_event = (
+        db_session.query(AuditEvent)
+        .filter(AuditEvent.event_type == "feature_entitlement_updated")
+        .order_by(AuditEvent.occurred_at_utc.desc())
+        .first()
+    )
+    assert feature_event is not None
+    metadata = feature_event.metadata_json or {}
+    assert metadata["internal_override"]["applied"] is True
+    assert metadata["internal_override"]["actor_role"] == "support_admin"


### PR DESCRIPTION
### Motivation
- Expose organization plan/modules/feature state through stable, UI-safe endpoints and avoid leaking unavailable functionality from existing routes.
- Provide a centralized enforcement path that can 404 shield features while allowing an internal override path for demo/support workflows with explicit audit metadata.
- Ensure plan/feature mutations are auditable with structured events for observability and support traceability.

### Description
- Added a new router `backend/app/api/routes/routes_entitlements.py` with endpoints `GET /org/plan`, `GET /org/entitlements`, `PATCH /org/entitlements` (admin/internal only), and `GET /org/modules`, returning a stable payload shape and carrying internal-override metadata when applied.
- Implemented enforcement helpers in `backend/app/commercial/enforcement.py` that adapt persisted org entitlement state, make feature gate decisions, return a 404 when a feature is unavailable, and emit override audit events when internal actors use the override path.
- Updated demo orchestration routes (`backend/app/api/routes/routes_demo.py`) to consume the enforcement helpers so demo read/mutate flows are entitlement-gated and use the internal override path when permitted. 
- Emitted structured audit events for plan/feature mutations (`org_plan_changed`, `feature_entitlement_updated`) and for runtime override usage (`feature_entitlement_override_used`) with explicit `internal_override` metadata.
- Added tests `backend/tests/test_entitlements_routes.py` that validate UI-safe response shapes, audit event emission, internal override role enforcement, and audit metadata persistence; wired the new router into `backend/app/main.py`.

### Testing
- Ran `ruff check app/ tests/` and formatting; lint checks passed. (success)
- Ran `pytest tests/test_entitlements_routes.py tests/test_demo_routes.py -q` and all tests passed (6 passed, 3 warnings). (success)
- Ran repository lint via `make lint` which completed without errors. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e521f7d75083219bb6aa8936d81358)