### PR TITLE
Add help/docs service, read routes, view tracking, and publish workflow

### DIFF
--- a/backend/app/api/routes/routes_help.py
+++ b/backend/app/api/routes/routes_help.py
@@ -1,0 +1,189 @@
+"""Help center read routes."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.commercial.docs import (
+    PUBLICATION_STATE_PUBLISHED,
+    get_help_article,
+    list_help_articles,
+    list_help_categories,
+    list_related_help_articles,
+)
+from app.commercial.enforcement import require_feature_enabled
+from app.core.deps import get_current_user
+from app.db.models import HelpArticle, HelpCategory, User
+from app.db.repo.org_content import record_help_article_view
+from app.db.session import get_db
+from app.security.authn import build_user_auth_context
+
+router = APIRouter(prefix="/help", tags=["help"])
+
+
+class HelpArticleSummary(BaseModel):
+    article_id: str
+    category_id: str | None = None
+    slug: str
+    title: str
+    summary: str | None = None
+    metadata: dict
+    is_published: bool
+
+
+class HelpArticleDetail(HelpArticleSummary):
+    body_markdown: str
+
+
+class HelpCategoryItem(BaseModel):
+    category_id: str
+    slug: str
+    title: str
+    description: str | None = None
+    sort_order: int
+    metadata: dict
+    is_published: bool
+
+
+def _enforce_docs_read(db: Session, *, org_id: uuid.UUID, current_user: User) -> None:
+    require_feature_enabled(
+        db,
+        org_id=org_id,
+        actor_id=str(current_user.id),
+        actor_role=current_user.role,
+        feature_key="docs.playbooks",
+        action="docs.read",
+        allow_internal_override=True,
+    )
+
+
+def _serialize_article_summary(article: HelpArticle) -> HelpArticleSummary:
+    return HelpArticleSummary(
+        article_id=str(article.article_id),
+        category_id=str(article.category_id) if article.category_id else None,
+        slug=article.slug,
+        title=article.title,
+        summary=article.summary,
+        metadata=article.metadata_json or {},
+        is_published=bool(article.is_published),
+    )
+
+
+def _serialize_article_detail(article: HelpArticle) -> HelpArticleDetail:
+    payload = _serialize_article_summary(article).model_dump()
+    payload["body_markdown"] = article.body_markdown
+    return HelpArticleDetail(**payload)
+
+
+def _serialize_category(category: HelpCategory) -> HelpCategoryItem:
+    return HelpCategoryItem(
+        category_id=str(category.category_id),
+        slug=category.slug,
+        title=category.title,
+        description=category.description,
+        sort_order=category.sort_order,
+        metadata=category.metadata_json or {},
+        is_published=bool(category.is_published),
+    )
+
+
+@router.get("/articles", response_model=list[HelpArticleSummary])
+def get_articles(
+    category_id: uuid.UUID | None = Query(default=None),
+    audience: str | None = Query(default=None),
+    tag: str | None = Query(default=None),
+    publication_state: Literal["published", "draft", "all"] = Query(default=PUBLICATION_STATE_PUBLISHED),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = context.org_ids[0]
+    _enforce_docs_read(db, org_id=org_id, current_user=current_user)
+
+    rows = list_help_articles(
+        db,
+        org_id=org_id,
+        publication_state=publication_state,
+        category_id=category_id,
+        audience=audience,
+        tag=tag,
+    )
+    return [_serialize_article_summary(row) for row in rows]
+
+
+@router.get("/articles/{article_id}", response_model=HelpArticleDetail)
+def get_article_by_id(
+    article_id: uuid.UUID,
+    publication_state: Literal["published", "draft", "all"] = Query(default=PUBLICATION_STATE_PUBLISHED),
+    source: str | None = Query(default="help_api"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = context.org_ids[0]
+    _enforce_docs_read(db, org_id=org_id, current_user=current_user)
+
+    row = get_help_article(
+        db,
+        org_id=org_id,
+        article_id=article_id,
+        publication_state=publication_state,
+    )
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Help article not found",
+        )
+
+    record_help_article_view(
+        db,
+        org_id=org_id,
+        article_id=row.article_id,
+        viewer_user_id=current_user.id,
+        source=source,
+        metadata_json={
+            "publication_state": publication_state,
+        },
+    )
+    return _serialize_article_detail(row)
+
+
+@router.get("/categories", response_model=list[HelpCategoryItem])
+def get_categories(
+    publication_state: Literal["published", "draft", "all"] = Query(default=PUBLICATION_STATE_PUBLISHED),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = context.org_ids[0]
+    _enforce_docs_read(db, org_id=org_id, current_user=current_user)
+
+    rows = list_help_categories(db, org_id=org_id, publication_state=publication_state)
+    return [_serialize_category(row) for row in rows]
+
+
+@router.get("/related", response_model=list[HelpArticleSummary])
+def get_related_articles(
+    context: str = Query(..., min_length=1),
+    publication_state: Literal["published", "draft", "all"] = Query(default=PUBLICATION_STATE_PUBLISHED),
+    limit: int = Query(default=5, ge=1, le=25),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    auth_context = build_user_auth_context(db, current_user)
+    org_id = auth_context.org_ids[0]
+    _enforce_docs_read(db, org_id=org_id, current_user=current_user)
+
+    rows = list_related_help_articles(
+        db,
+        org_id=org_id,
+        context=context,
+        limit=limit,
+        publication_state=publication_state,
+    )
+    return [_serialize_article_summary(row) for row in rows]

--- a/backend/app/commercial/docs.py
+++ b/backend/app/commercial/docs.py
@@ -1,8 +1,246 @@
-"""Documentation center feature definitions."""
+"""Documentation center content service and publication workflows."""
 
 from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.audit.emitter import emit_audit_event
+from app.db.models import HelpArticle, HelpCategory
 
 DOCS_FEATURES: tuple[str, ...] = (
     "docs.playbooks",
     "docs.api_reference",
 )
+
+PUBLICATION_STATE_PUBLISHED = "published"
+PUBLICATION_STATE_DRAFT = "draft"
+PUBLICATION_STATE_ALL = "all"
+_VALID_PUBLICATION_STATES = {
+    PUBLICATION_STATE_PUBLISHED,
+    PUBLICATION_STATE_DRAFT,
+    PUBLICATION_STATE_ALL,
+}
+
+_INTERNAL_DOCS_ROLES = {"system_admin", "support_admin", "support_agent"}
+
+
+def _is_internal_docs_actor(role: str | None) -> bool:
+    return (role or "").strip().lower() in _INTERNAL_DOCS_ROLES
+
+
+def _normalize_publication_state(publication_state: str) -> str:
+    normalized = (publication_state or PUBLICATION_STATE_PUBLISHED).strip().lower()
+    if normalized not in _VALID_PUBLICATION_STATES:
+        raise ValueError(
+            "publication_state must be one of: published, draft, all"
+        )
+    return normalized
+
+
+def _matches_metadata_values(metadata: dict | None, key: str, expected: str | None) -> bool:
+    if not expected:
+        return True
+    value = (metadata or {}).get(key)
+    if value is None:
+        return False
+    expected_lower = expected.strip().lower()
+    if isinstance(value, str):
+        return expected_lower == value.strip().lower()
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        normalized_values = {str(item).strip().lower() for item in value}
+        return expected_lower in normalized_values
+    return False
+
+
+def list_help_articles(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    publication_state: str = PUBLICATION_STATE_PUBLISHED,
+    category_id: uuid.UUID | None = None,
+    audience: str | None = None,
+    tag: str | None = None,
+) -> list[HelpArticle]:
+    """List help articles with publication/category/audience/tag filtering."""
+    state = _normalize_publication_state(publication_state)
+
+    query = db.query(HelpArticle).filter(HelpArticle.org_id == org_id)
+    if state == PUBLICATION_STATE_PUBLISHED:
+        query = query.filter(HelpArticle.is_published.is_(True))
+    elif state == PUBLICATION_STATE_DRAFT:
+        query = query.filter(HelpArticle.is_published.is_(False))
+
+    if category_id is not None:
+        query = query.filter(HelpArticle.category_id == category_id)
+
+    rows = query.order_by(HelpArticle.published_at_utc.desc().nullslast(), HelpArticle.created_at_utc.desc()).all()
+    return [
+        row
+        for row in rows
+        if _matches_metadata_values(row.metadata_json, "audiences", audience)
+        and _matches_metadata_values(row.metadata_json, "tags", tag)
+    ]
+
+
+def get_help_article(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    article_id: uuid.UUID,
+    publication_state: str = PUBLICATION_STATE_PUBLISHED,
+) -> HelpArticle | None:
+    """Get a single help article for org scope and publication-state."""
+    state = _normalize_publication_state(publication_state)
+    query = db.query(HelpArticle).filter(
+        HelpArticle.org_id == org_id,
+        HelpArticle.article_id == article_id,
+    )
+    if state == PUBLICATION_STATE_PUBLISHED:
+        query = query.filter(HelpArticle.is_published.is_(True))
+    elif state == PUBLICATION_STATE_DRAFT:
+        query = query.filter(HelpArticle.is_published.is_(False))
+    return query.first()
+
+
+def list_help_categories(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    publication_state: str = PUBLICATION_STATE_PUBLISHED,
+) -> list[HelpCategory]:
+    """List categories with publication-state filtering."""
+    state = _normalize_publication_state(publication_state)
+    query = db.query(HelpCategory).filter(HelpCategory.org_id == org_id)
+    if state == PUBLICATION_STATE_PUBLISHED:
+        query = query.filter(HelpCategory.is_published.is_(True))
+    elif state == PUBLICATION_STATE_DRAFT:
+        query = query.filter(HelpCategory.is_published.is_(False))
+    return query.order_by(HelpCategory.sort_order.asc(), HelpCategory.created_at_utc.asc()).all()
+
+
+def list_related_help_articles(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    context: str,
+    limit: int = 5,
+    publication_state: str = PUBLICATION_STATE_PUBLISHED,
+) -> list[HelpArticle]:
+    """Find related help articles by lightweight context matching."""
+    lowered_context = context.strip().lower()
+    if not lowered_context:
+        return []
+
+    rows = list_help_articles(
+        db,
+        org_id=org_id,
+        publication_state=publication_state,
+    )
+
+    def _score(article: HelpArticle) -> int:
+        score = 0
+        title = (article.title or "").lower()
+        summary = (article.summary or "").lower()
+        body = (article.body_markdown or "").lower()
+        if lowered_context in title:
+            score += 3
+        if lowered_context in summary:
+            score += 2
+        if lowered_context in body:
+            score += 1
+        metadata = article.metadata_json or {}
+        tags = metadata.get("tags") or []
+        audiences = metadata.get("audiences") or []
+        values = {str(value).strip().lower() for value in [*tags, *audiences]}
+        if lowered_context in values:
+            score += 4
+        return score
+
+    scored = [(article, _score(article)) for article in rows]
+    scored = [pair for pair in scored if pair[1] > 0]
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    return [article for article, _ in scored[:limit]]
+
+
+def publish_help_article(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    article_id: uuid.UUID,
+    actor_id: uuid.UUID,
+    actor_role: str,
+) -> HelpArticle:
+    """Publish a help article (internal workflow only) and write audit event."""
+    if not _is_internal_docs_actor(actor_role):
+        raise PermissionError("Internal role required to publish help articles")
+
+    article = get_help_article(
+        db,
+        org_id=org_id,
+        article_id=article_id,
+        publication_state=PUBLICATION_STATE_ALL,
+    )
+    if article is None:
+        raise ValueError("Article not found")
+
+    now = datetime.now(timezone.utc)
+    article.is_published = True
+    article.published_at_utc = now
+    article.unpublished_at_utc = None
+    article.updated_by_user_id = actor_id
+
+    db.add(article)
+    db.commit()
+    db.refresh(article)
+
+    emit_audit_event(
+        db,
+        org_id=org_id,
+        actor_type="user",
+        actor_id=str(actor_id),
+        action="help.article.publish",
+        event_type="help_article_published",
+        outcome="success",
+        metadata={
+            "article_id": str(article.article_id),
+            "slug": article.slug,
+            "state": "published",
+        },
+    )
+    return article
+
+
+def unpublish_help_article(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    article_id: uuid.UUID,
+    actor_id: uuid.UUID,
+    actor_role: str,
+) -> HelpArticle:
+    """Unpublish a help article (internal workflow only)."""
+    if not _is_internal_docs_actor(actor_role):
+        raise PermissionError("Internal role required to unpublish help articles")
+
+    article = get_help_article(
+        db,
+        org_id=org_id,
+        article_id=article_id,
+        publication_state=PUBLICATION_STATE_ALL,
+    )
+    if article is None:
+        raise ValueError("Article not found")
+
+    now = datetime.now(timezone.utc)
+    article.is_published = False
+    article.unpublished_at_utc = now
+    article.updated_by_user_id = actor_id
+
+    db.add(article)
+    db.commit()
+    db.refresh(article)
+    return article

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,6 +23,7 @@ from app.api.routes.routes_driver_report import router as driver_report_router
 from app.api.routes.routes_tasks import router as tasks_router
 from app.api.routes.routes_demo import router as demo_router
 from app.api.routes.routes_entitlements import router as entitlements_router
+from app.api.routes.routes_help import router as help_router
 from app.api.routes_admin import router as admin_router
 from app.api.routes_twilio import router as twilio_router
 from app.health.routes import router as health_router
@@ -60,6 +61,7 @@ app.include_router(notes_router, tags=["notes"])
 app.include_router(tasks_router, tags=["tasks"])
 app.include_router(demo_router)
 app.include_router(entitlements_router)
+app.include_router(help_router)
 app.include_router(admin_router, prefix="/admin", tags=["admin"])
 app.include_router(twilio_router, prefix="/twilio", tags=["twilio"])
 app.include_router(onboarding_router)

--- a/backend/tests/test_help_routes.py
+++ b/backend/tests/test_help_routes.py
@@ -1,0 +1,216 @@
+"""Tests for help content service and API routes."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.commercial.docs import publish_help_article
+from app.core.security import create_access_token, hash_password
+from app.db.models import AuditEvent, Base, HelpArticle, HelpArticleView, HelpCategory, Org, User, UserOrg
+from app.db.session import get_db
+from app.main import app
+
+
+@pytest.fixture()
+def db_session():
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    test_session = sessionmaker(bind=engine)
+    session = test_session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def test_org(db_session):
+    org = Org(name="Help Test Org")
+    db_session.add(org)
+    db_session.commit()
+    db_session.refresh(org)
+    return org
+
+
+@pytest.fixture()
+def org_admin_user(db_session, test_org):
+    user = User(
+        email="org-admin-help@example.com",
+        password_hash=hash_password("testpass"),
+        role="org_admin",
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    db_session.add(UserOrg(user_id=user.id, org_id=test_org.id))
+    db_session.commit()
+    return user
+
+
+@pytest.fixture()
+def support_admin_user(db_session, test_org):
+    user = User(
+        email="support-admin-help@example.com",
+        password_hash=hash_password("testpass"),
+        role="support_admin",
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    db_session.add(UserOrg(user_id=user.id, org_id=test_org.id))
+    db_session.commit()
+    return user
+
+
+@pytest.fixture()
+def help_seed(db_session, test_org, org_admin_user):
+    category = HelpCategory(
+        org_id=test_org.id,
+        slug="safety",
+        title="Safety",
+        description="Safety workflows",
+        sort_order=1,
+        is_published=True,
+        published_at_utc=datetime.now(timezone.utc),
+    )
+    db_session.add(category)
+    db_session.commit()
+    db_session.refresh(category)
+
+    published = HelpArticle(
+        org_id=test_org.id,
+        category_id=category.category_id,
+        slug="incident-export",
+        title="How to export an incident",
+        summary="Export flow",
+        body_markdown="Use the export button in the incident workspace.",
+        is_published=True,
+        published_at_utc=datetime.now(timezone.utc),
+        metadata_json={"audiences": ["manager"], "tags": ["export", "incident"]},
+        created_by_user_id=org_admin_user.id,
+        updated_by_user_id=org_admin_user.id,
+    )
+    draft = HelpArticle(
+        org_id=test_org.id,
+        category_id=category.category_id,
+        slug="draft-playbook",
+        title="Draft playbook",
+        summary="Draft-only content",
+        body_markdown="internal draft",
+        is_published=False,
+        metadata_json={"audiences": ["support"], "tags": ["internal"]},
+        created_by_user_id=org_admin_user.id,
+        updated_by_user_id=org_admin_user.id,
+    )
+    db_session.add_all([published, draft])
+    db_session.commit()
+    db_session.refresh(published)
+    db_session.refresh(draft)
+    return {"category": category, "published": published, "draft": draft}
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def _auth_headers(user):
+    token = create_access_token({"sub": str(user.id), "role": user.role})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_help_routes_support_filtering_and_related(client, org_admin_user, help_seed):
+    articles_resp = client.get(
+        "/help/articles",
+        headers=_auth_headers(org_admin_user),
+        params={"audience": "manager", "tag": "export"},
+    )
+    assert articles_resp.status_code == 200
+    payload = articles_resp.json()
+    assert len(payload) == 1
+    assert payload[0]["slug"] == "incident-export"
+
+    drafts_resp = client.get(
+        "/help/articles",
+        headers=_auth_headers(org_admin_user),
+        params={"publication_state": "draft"},
+    )
+    assert drafts_resp.status_code == 200
+    assert [row["slug"] for row in drafts_resp.json()] == ["draft-playbook"]
+
+    related_resp = client.get(
+        "/help/related",
+        headers=_auth_headers(org_admin_user),
+        params={"context": "export"},
+    )
+    assert related_resp.status_code == 200
+    related = related_resp.json()
+    assert related
+    assert related[0]["slug"] == "incident-export"
+
+    categories_resp = client.get("/help/categories", headers=_auth_headers(org_admin_user))
+    assert categories_resp.status_code == 200
+    assert categories_resp.json()[0]["slug"] == "safety"
+
+
+def test_help_article_read_records_view_event(client, db_session, org_admin_user, help_seed):
+    article_id = help_seed["published"].article_id
+    response = client.get(
+        f"/help/articles/{article_id}",
+        headers=_auth_headers(org_admin_user),
+    )
+    assert response.status_code == 200
+
+    views = db_session.query(HelpArticleView).all()
+    assert len(views) == 1
+    assert views[0].article_id == article_id
+    assert views[0].viewer_user_id == org_admin_user.id
+
+
+def test_internal_publish_workflow_emits_audit_event(
+    db_session,
+    test_org,
+    support_admin_user,
+    help_seed,
+):
+    draft = help_seed["draft"]
+
+    published = publish_help_article(
+        db_session,
+        org_id=test_org.id,
+        article_id=draft.article_id,
+        actor_id=support_admin_user.id,
+        actor_role=support_admin_user.role,
+    )
+
+    assert published.is_published is True
+    assert published.published_at_utc is not None
+
+    event = (
+        db_session.query(AuditEvent)
+        .filter(AuditEvent.event_type == "help_article_published")
+        .order_by(AuditEvent.occurred_at_utc.desc())
+        .first()
+    )
+    assert event is not None
+    assert event.metadata_json["article_id"] == str(draft.article_id)


### PR DESCRIPTION
### Motivation
- Provide a small knowledge-base service and public read endpoints so clients can list and fetch help articles with filtering and related-item suggestions.
- Record article reads for telemetry/usage via `HelpArticleView` and support an internal publish/unpublish workflow with audit capture.
- Enforce docs feature gating for API access and surface publication-state (`published`, `draft`, `all`) to clients.

### Description
- Implemented the docs content service in `backend/app/commercial/docs.py` including `list_help_articles`, `get_help_article`, `list_help_categories`, `list_related_help_articles`, `publish_help_article`, and `unpublish_help_article`, plus `PUBLICATION_STATE_*` constants and lightweight audience/tag filtering.
- Added read-only Help API routes in `backend/app/api/routes/routes_help.py` exposing `GET /help/articles`, `GET /help/articles/{article_id}`, `GET /help/categories`, and `GET /help/related`, with request/response models, docs entitlement enforcement via `require_feature_enabled`, and serialization helpers.
- Recorded article view events on reads by calling `record_help_article_view`, which persists `HelpArticleView` rows for telemetry, and emitted an audit event `help_article_published` on internal publishes.
- Registered the help router in `backend/app/main.py` and added tests in `backend/tests/test_help_routes.py` that exercise filtering, related lookup, view tracking, and the internal publish+audit flow.

### Testing
- Ran linting with `ruff check` on the new files and it passed.
- Ran `pytest tests/test_help_routes.py -q` and the suite passed (`3 passed`).
- Ran `pytest tests/test_entitlements_routes.py tests/test_demo_routes.py -q` and those suites passed (`6 passed`).
- Ran `make lint` which executes the repo lint checks and the hardening matrix check, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5274840ec83219c5523e3027cdd23)