### PR TITLE
Add trust center service/routes with internal publish workflows and audit events

### DIFF
--- a/backend/app/api/routes/routes_trust.py
+++ b/backend/app/api/routes/routes_trust.py
@@ -1,0 +1,176 @@
+"""Trust center read + internal content management routes."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.commercial.enforcement import require_feature_enabled
+from app.commercial.trust import (
+    PUBLICATION_STATE_PUBLISHED,
+    TRUST_CONTENT_FEATURE,
+    get_trust_summary,
+    list_trust_sections,
+    publish_trust_section,
+    unpublish_trust_section,
+    upsert_trust_section,
+)
+from app.core.deps import get_current_user, require_user_role
+from app.db.models import TrustSection, User
+from app.db.session import get_db
+from app.security.authn import build_user_auth_context
+
+router = APIRouter(prefix="/trust", tags=["trust"])
+
+_internal_trust_admin = require_user_role("system_admin", "support_admin")
+
+
+class TrustSectionItem(BaseModel):
+    section_id: str
+    slug: str
+    title: str
+    body_markdown: str
+    sort_order: int
+    metadata: dict
+    is_published: bool
+
+
+class TrustSummaryResponse(BaseModel):
+    section_count: int
+    section_slugs: list[str]
+    latest_published_at_utc: str | None
+    audience: str | None = None
+
+
+class TrustSectionUpsertRequest(BaseModel):
+    section_id: uuid.UUID | None = None
+    slug: str = Field(min_length=1)
+    title: str = Field(min_length=1)
+    body_markdown: str = Field(min_length=1)
+    sort_order: int = 0
+    metadata: dict = Field(default_factory=dict)
+
+
+def _resolve_org_id(db: Session, current_user: User) -> uuid.UUID:
+    context = build_user_auth_context(db, current_user)
+    return context.org_ids[0]
+
+
+def _enforce_trust_read(db: Session, *, org_id: uuid.UUID, current_user: User) -> None:
+    require_feature_enabled(
+        db,
+        org_id=org_id,
+        actor_id=str(current_user.id),
+        actor_role=current_user.role,
+        feature_key=TRUST_CONTENT_FEATURE,
+        action="trust.read",
+        allow_internal_override=True,
+    )
+
+
+def _serialize_section(section: TrustSection) -> TrustSectionItem:
+    return TrustSectionItem(
+        section_id=str(section.section_id),
+        slug=section.slug,
+        title=section.title,
+        body_markdown=section.body_markdown,
+        sort_order=section.sort_order,
+        metadata=section.metadata_json or {},
+        is_published=bool(section.is_published),
+    )
+
+
+@router.get("/sections", response_model=list[TrustSectionItem])
+def get_sections(
+    publication_state: Literal["published", "draft", "all"] = Query(default=PUBLICATION_STATE_PUBLISHED),
+    audience: str | None = Query(default=None),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    org_id = _resolve_org_id(db, current_user)
+    _enforce_trust_read(db, org_id=org_id, current_user=current_user)
+
+    rows = list_trust_sections(
+        db,
+        org_id=org_id,
+        publication_state=publication_state,
+        audience=audience,
+    )
+    return [_serialize_section(row) for row in rows]
+
+
+@router.get("/summary", response_model=TrustSummaryResponse)
+def get_summary(
+    audience: str | None = Query(default=None),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    org_id = _resolve_org_id(db, current_user)
+    _enforce_trust_read(db, org_id=org_id, current_user=current_user)
+    return TrustSummaryResponse(**get_trust_summary(db, org_id=org_id, audience=audience))
+
+
+@router.put("/internal/sections", response_model=TrustSectionItem)
+def put_internal_section(
+    payload: TrustSectionUpsertRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(_internal_trust_admin),
+):
+    org_id = _resolve_org_id(db, current_user)
+    row = upsert_trust_section(
+        db,
+        org_id=org_id,
+        actor_id=current_user.id,
+        actor_role=current_user.role,
+        section_id=payload.section_id,
+        slug=payload.slug,
+        title=payload.title,
+        body_markdown=payload.body_markdown,
+        sort_order=payload.sort_order,
+        metadata_json=payload.metadata,
+    )
+    return _serialize_section(row)
+
+
+@router.post("/internal/sections/{section_id}/publish", response_model=TrustSectionItem)
+def post_publish_section(
+    section_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(_internal_trust_admin),
+):
+    org_id = _resolve_org_id(db, current_user)
+    try:
+        row = publish_trust_section(
+            db,
+            org_id=org_id,
+            section_id=section_id,
+            actor_id=current_user.id,
+            actor_role=current_user.role,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return _serialize_section(row)
+
+
+@router.post("/internal/sections/{section_id}/unpublish", response_model=TrustSectionItem)
+def post_unpublish_section(
+    section_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(_internal_trust_admin),
+):
+    org_id = _resolve_org_id(db, current_user)
+    try:
+        row = unpublish_trust_section(
+            db,
+            org_id=org_id,
+            section_id=section_id,
+            actor_id=current_user.id,
+            actor_role=current_user.role,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return _serialize_section(row)

--- a/backend/app/commercial/trust.py
+++ b/backend/app/commercial/trust.py
@@ -1,8 +1,16 @@
-"""Trust and deployment scope state definitions."""
+"""Trust center content service and publication workflows."""
 
 from __future__ import annotations
 
-from typing import Literal
+import uuid
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from sqlalchemy.orm import Session
+
+from app.audit.emitter import emit_audit_event
+from app.db.models import TrustSection
 
 DeploymentScope = Literal[
     "single_site",
@@ -24,3 +32,262 @@ TRUST_FEATURES: tuple[str, ...] = (
     "trust.sso",
     "trust.audit_controls",
 )
+
+TRUST_CONTENT_FEATURE = "trust.audit_controls"
+
+PUBLICATION_STATE_PUBLISHED = "published"
+PUBLICATION_STATE_DRAFT = "draft"
+PUBLICATION_STATE_ALL = "all"
+
+_VALID_PUBLICATION_STATES = {
+    PUBLICATION_STATE_PUBLISHED,
+    PUBLICATION_STATE_DRAFT,
+    PUBLICATION_STATE_ALL,
+}
+
+_INTERNAL_TRUST_ROLES = {"system_admin", "support_admin"}
+
+
+def _normalize_publication_state(publication_state: str) -> str:
+    normalized = (publication_state or PUBLICATION_STATE_PUBLISHED).strip().lower()
+    if normalized not in _VALID_PUBLICATION_STATES:
+        raise ValueError("publication_state must be one of: published, draft, all")
+    return normalized
+
+
+def _is_internal_trust_actor(role: str | None) -> bool:
+    return (role or "").strip().lower() in _INTERNAL_TRUST_ROLES
+
+
+def _matches_audience(metadata: dict | None, audience: str | None) -> bool:
+    if not audience:
+        return True
+    value = (metadata or {}).get("audiences")
+    if value is None:
+        return False
+    expected = audience.strip().lower()
+    if isinstance(value, str):
+        return expected == value.strip().lower()
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        normalized = {str(item).strip().lower() for item in value}
+        return expected in normalized
+    return False
+
+
+def list_trust_sections(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    publication_state: str = PUBLICATION_STATE_PUBLISHED,
+    audience: str | None = None,
+) -> list[TrustSection]:
+    """List trust sections with publication/audience filtering."""
+    state = _normalize_publication_state(publication_state)
+
+    query = db.query(TrustSection).filter(TrustSection.org_id == org_id)
+    if state == PUBLICATION_STATE_PUBLISHED:
+        query = query.filter(TrustSection.is_published.is_(True))
+    elif state == PUBLICATION_STATE_DRAFT:
+        query = query.filter(TrustSection.is_published.is_(False))
+
+    rows = query.order_by(TrustSection.sort_order.asc(), TrustSection.created_at_utc.asc()).all()
+    return [row for row in rows if _matches_audience(row.metadata_json, audience)]
+
+
+def get_trust_summary(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    audience: str | None = None,
+) -> dict[str, Any]:
+    """Return a simple trust center summary for the active published scope."""
+    sections = list_trust_sections(
+        db,
+        org_id=org_id,
+        publication_state=PUBLICATION_STATE_PUBLISHED,
+        audience=audience,
+    )
+    published_at_values = [section.published_at_utc for section in sections if section.published_at_utc is not None]
+    return {
+        "section_count": len(sections),
+        "section_slugs": [section.slug for section in sections],
+        "latest_published_at_utc": max(published_at_values).isoformat() if published_at_values else None,
+        "audience": audience,
+    }
+
+
+def _emit_trust_center_updated(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    actor_id: uuid.UUID,
+    action: str,
+    metadata: dict[str, Any],
+) -> None:
+    emit_audit_event(
+        db,
+        org_id=org_id,
+        actor_type="user",
+        actor_id=str(actor_id),
+        action=action,
+        event_type="trust_center_updated",
+        outcome="success",
+        metadata=metadata,
+    )
+
+
+def upsert_trust_section(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    actor_id: uuid.UUID,
+    actor_role: str,
+    section_id: uuid.UUID | None,
+    slug: str,
+    title: str,
+    body_markdown: str,
+    sort_order: int = 0,
+    metadata_json: dict | None = None,
+) -> TrustSection:
+    """Create or update trust section draft content and emit audit event."""
+    if not _is_internal_trust_actor(actor_role):
+        raise PermissionError("Internal admin role required to update trust sections")
+
+    row: TrustSection | None = None
+    if section_id is not None:
+        row = (
+            db.query(TrustSection)
+            .filter(TrustSection.org_id == org_id, TrustSection.section_id == section_id)
+            .first()
+        )
+    if row is None:
+        row = (
+            db.query(TrustSection)
+            .filter(TrustSection.org_id == org_id, TrustSection.slug == slug)
+            .first()
+        )
+
+    creating = row is None
+    if creating:
+        row = TrustSection(org_id=org_id, slug=slug)
+
+    before = {
+        "title": row.title if not creating else None,
+        "sort_order": row.sort_order if not creating else None,
+        "audiences": (row.metadata_json or {}).get("audiences") if not creating else None,
+    }
+
+    row.title = title
+    row.body_markdown = body_markdown
+    row.sort_order = int(sort_order)
+    row.metadata_json = dict(metadata_json or {})
+
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+
+    _emit_trust_center_updated(
+        db,
+        org_id=org_id,
+        actor_id=actor_id,
+        action="trust.section.create" if creating else "trust.section.update",
+        metadata={
+            "section_id": str(row.section_id),
+            "slug": row.slug,
+            "before": before,
+            "after": {
+                "title": row.title,
+                "sort_order": row.sort_order,
+                "audiences": (row.metadata_json or {}).get("audiences"),
+            },
+            "config_changed": True,
+        },
+    )
+    return row
+
+
+def publish_trust_section(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    section_id: uuid.UUID,
+    actor_id: uuid.UUID,
+    actor_role: str,
+) -> TrustSection:
+    """Publish trust section content and emit trust_center_updated audit event."""
+    if not _is_internal_trust_actor(actor_role):
+        raise PermissionError("Internal admin role required to publish trust sections")
+
+    section = (
+        db.query(TrustSection)
+        .filter(TrustSection.org_id == org_id, TrustSection.section_id == section_id)
+        .first()
+    )
+    if section is None:
+        raise ValueError("Trust section not found")
+
+    now = datetime.now(timezone.utc)
+    section.is_published = True
+    section.published_at_utc = now
+    section.unpublished_at_utc = None
+
+    db.add(section)
+    db.commit()
+    db.refresh(section)
+
+    _emit_trust_center_updated(
+        db,
+        org_id=org_id,
+        actor_id=actor_id,
+        action="trust.section.publish",
+        metadata={
+            "section_id": str(section.section_id),
+            "slug": section.slug,
+            "state": "published",
+            "published": True,
+        },
+    )
+    return section
+
+
+def unpublish_trust_section(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    section_id: uuid.UUID,
+    actor_id: uuid.UUID,
+    actor_role: str,
+) -> TrustSection:
+    """Unpublish trust section content and emit trust_center_updated audit event."""
+    if not _is_internal_trust_actor(actor_role):
+        raise PermissionError("Internal admin role required to publish trust sections")
+
+    section = (
+        db.query(TrustSection)
+        .filter(TrustSection.org_id == org_id, TrustSection.section_id == section_id)
+        .first()
+    )
+    if section is None:
+        raise ValueError("Trust section not found")
+
+    now = datetime.now(timezone.utc)
+    section.is_published = False
+    section.unpublished_at_utc = now
+
+    db.add(section)
+    db.commit()
+    db.refresh(section)
+
+    _emit_trust_center_updated(
+        db,
+        org_id=org_id,
+        actor_id=actor_id,
+        action="trust.section.unpublish",
+        metadata={
+            "section_id": str(section.section_id),
+            "slug": section.slug,
+            "state": "draft",
+            "published": False,
+        },
+    )
+    return section

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.api.routes.routes_tasks import router as tasks_router
 from app.api.routes.routes_demo import router as demo_router
 from app.api.routes.routes_entitlements import router as entitlements_router
 from app.api.routes.routes_help import router as help_router
+from app.api.routes.routes_trust import router as trust_router
 from app.api.routes_admin import router as admin_router
 from app.api.routes_twilio import router as twilio_router
 from app.health.routes import router as health_router
@@ -62,6 +63,7 @@ app.include_router(tasks_router, tags=["tasks"])
 app.include_router(demo_router)
 app.include_router(entitlements_router)
 app.include_router(help_router)
+app.include_router(trust_router)
 app.include_router(admin_router, prefix="/admin", tags=["admin"])
 app.include_router(twilio_router, prefix="/twilio", tags=["twilio"])
 app.include_router(onboarding_router)

--- a/backend/tests/test_trust_routes.py
+++ b/backend/tests/test_trust_routes.py
@@ -1,0 +1,212 @@
+"""Tests for trust center service and API routes."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.security import create_access_token, hash_password
+from app.db.models import AuditEvent, Base, Org, OrgPlanEntitlement, TrustSection, User, UserOrg
+from app.db.session import get_db
+from app.main import app
+
+
+@pytest.fixture()
+def db_session():
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    test_session = sessionmaker(bind=engine)
+    session = test_session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def test_org(db_session):
+    org = Org(name="Trust Test Org")
+    db_session.add(org)
+    db_session.commit()
+    db_session.refresh(org)
+    return org
+
+
+@pytest.fixture()
+def org_admin_user(db_session, test_org):
+    user = User(
+        email="org-admin-trust@example.com",
+        password_hash=hash_password("testpass"),
+        role="org_admin",
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    db_session.add(UserOrg(user_id=user.id, org_id=test_org.id))
+    db_session.commit()
+    return user
+
+
+@pytest.fixture()
+def support_admin_user(db_session, test_org):
+    user = User(
+        email="support-admin-trust@example.com",
+        password_hash=hash_password("testpass"),
+        role="support_admin",
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    db_session.add(UserOrg(user_id=user.id, org_id=test_org.id))
+    db_session.commit()
+    return user
+
+
+@pytest.fixture()
+def trust_seed(db_session, test_org):
+    db_session.add(
+        OrgPlanEntitlement(
+            org_id=test_org.id,
+            plan_code="enterprise",
+            entitlements_json={"trust.audit_controls": True},
+        )
+    )
+    db_session.add_all(
+        [
+            TrustSection(
+                org_id=test_org.id,
+                slug="security",
+                title="Security",
+                body_markdown="published-manager",
+                sort_order=2,
+                is_published=True,
+                metadata_json={"audiences": ["manager"]},
+            ),
+            TrustSection(
+                org_id=test_org.id,
+                slug="privacy",
+                title="Privacy",
+                body_markdown="published-all",
+                sort_order=1,
+                is_published=True,
+                metadata_json={"audiences": ["manager", "driver"]},
+            ),
+            TrustSection(
+                org_id=test_org.id,
+                slug="draft-internal",
+                title="Draft",
+                body_markdown="draft",
+                sort_order=3,
+                is_published=False,
+                metadata_json={"audiences": ["support"]},
+            ),
+        ]
+    )
+    db_session.commit()
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def _auth_headers(user):
+    token = create_access_token({"sub": str(user.id), "role": user.role})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_get_trust_sections_and_summary(client, org_admin_user, trust_seed):
+    sections_resp = client.get(
+        "/trust/sections",
+        headers=_auth_headers(org_admin_user),
+        params={"audience": "manager"},
+    )
+    assert sections_resp.status_code == 200
+    sections = sections_resp.json()
+    assert [section["slug"] for section in sections] == ["privacy", "security"]
+
+    summary_resp = client.get(
+        "/trust/summary",
+        headers=_auth_headers(org_admin_user),
+        params={"audience": "manager"},
+    )
+    assert summary_resp.status_code == 200
+    summary = summary_resp.json()
+    assert summary["section_count"] == 2
+    assert summary["section_slugs"] == ["privacy", "security"]
+
+
+def test_internal_update_publish_unpublish_emits_audit_events(
+    client,
+    db_session,
+    support_admin_user,
+    trust_seed,
+):
+    create_resp = client.put(
+        "/trust/internal/sections",
+        headers=_auth_headers(support_admin_user),
+        json={
+            "slug": "compliance",
+            "title": "Compliance",
+            "body_markdown": "compliance controls",
+            "sort_order": 0,
+            "metadata": {"audiences": ["manager"]},
+        },
+    )
+    assert create_resp.status_code == 200
+    created = create_resp.json()
+    section_id = created["section_id"]
+
+    publish_resp = client.post(
+        f"/trust/internal/sections/{section_id}/publish",
+        headers=_auth_headers(support_admin_user),
+    )
+    assert publish_resp.status_code == 200
+    assert publish_resp.json()["is_published"] is True
+
+    unpublish_resp = client.post(
+        f"/trust/internal/sections/{section_id}/unpublish",
+        headers=_auth_headers(support_admin_user),
+    )
+    assert unpublish_resp.status_code == 200
+    assert unpublish_resp.json()["is_published"] is False
+
+    events = (
+        db_session.query(AuditEvent)
+        .filter(AuditEvent.event_type == "trust_center_updated")
+        .order_by(AuditEvent.occurred_at_utc.asc())
+        .all()
+    )
+    assert len(events) == 3
+
+
+def test_internal_endpoints_restricted(client, org_admin_user, trust_seed):
+    response = client.put(
+        "/trust/internal/sections",
+        headers=_auth_headers(org_admin_user),
+        json={
+            "slug": "attempt",
+            "title": "Nope",
+            "body_markdown": "denied",
+            "sort_order": 5,
+            "metadata": {},
+        },
+    )
+    assert response.status_code == 403


### PR DESCRIPTION
### Motivation
- Provide a managed Trust Center content service so orgs can publish ordered, audience-scoped sections and surface a concise trust summary.
- Support an internal workflow for admins to create/update/publish/unpublish trust content while producing an immutable audit trail for changes.

### Description
- Expanded `backend/app/commercial/trust.py` into a full content service that supports publication-state filtering (`published`/`draft`/`all`), ordered section listing by `sort_order`, audience-scoped filtering via `metadata_json["audiences"]`, and trust summary generation; internal upsert/publish/unpublish flows now emit `trust_center_updated` audit events.
- Added read and internal management routes in `backend/app/api/routes/routes_trust.py` exposing `GET /trust/sections`, `GET /trust/summary`, `PUT /trust/internal/sections`, `POST /trust/internal/sections/{section_id}/publish`, and `POST /trust/internal/sections/{section_id}/unpublish`.
- Gate reads by the `trust.audit_controls` entitlement (with internal override support) and restrict mutation/publish endpoints to internal admin roles (`system_admin`, `support_admin`).
- Registered the new router in `backend/app/main.py` and added integration tests in `backend/tests/test_trust_routes.py` that validate ordering, audience filtering, summary output, admin restrictions, and that `trust_center_updated` audit events are emitted.

### Testing
- Ran code style checks with `ruff check` on modified files and no issues were found.
- Executed the focused test suite with `pytest tests/test_trust_routes.py tests/test_help_routes.py -q` and all tests passed (`6 passed`, with warnings only from startup/config deprecations).
- Ran repository lint target via `make lint` and the checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e582168a988321a395f7b6964de737)