### PR TITLE
Add deployment scope service and expansion-readiness endpoints

### DIFF
--- a/backend/app/api/routes/routes_deployment.py
+++ b/backend/app/api/routes/routes_deployment.py
@@ -1,0 +1,137 @@
+"""Deployment scope and expansion-readiness routes."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+import uuid
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.api.error_responses import raise_api_error
+from app.api.schemas import (
+    ApiErrorResponse,
+    DeploymentProgressResponse,
+    DeploymentScopeRequest,
+    DeploymentScopeResponse,
+    ExpansionReadinessResponse,
+)
+from app.audit.emitter import emit_standard_audit_event
+from app.commercial.expansion import (
+    get_deployment_progress,
+    get_deployment_scope,
+    get_expansion_readiness,
+    set_deployment_scope,
+)
+from app.core.deps import get_current_user
+from app.db.models import User
+from app.db.session import get_db
+from app.security.authn import build_user_auth_context
+from app.security.permissions import Capability, has_capability
+
+router = APIRouter(prefix="/org", tags=["deployment"])
+
+
+def _first_org_id(user_context) -> uuid.UUID:
+    return user_context.org_ids[0]
+
+
+def _require_deployment_access(user: User, *, write: bool = False) -> None:
+    capability = Capability.ONBOARDING_WRITE if write else Capability.READINESS_VIEW
+    if not has_capability(user.role, capability):
+        raise_api_error(
+            status_code=403,
+            message="You do not have permission to access deployment scope endpoints.",
+            code="ACCESS_DENIED",
+        )
+
+
+@router.get(
+    "/deployment-scope",
+    response_model=DeploymentScopeResponse,
+    responses={403: {"model": ApiErrorResponse}},
+    summary="Get deployment scope",
+)
+def get_org_deployment_scope(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    _require_deployment_access(current_user)
+    context = build_user_auth_context(db, current_user)
+    scope = get_deployment_scope(db, org_id=_first_org_id(context))
+    return DeploymentScopeResponse.model_validate(asdict(scope))
+
+
+@router.patch(
+    "/deployment-scope",
+    response_model=DeploymentScopeResponse,
+    responses={403: {"model": ApiErrorResponse}},
+    summary="Update deployment scope",
+)
+def patch_org_deployment_scope(
+    payload: DeploymentScopeRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    _require_deployment_access(current_user, write=True)
+    context = build_user_auth_context(db, current_user)
+    org_id = _first_org_id(context)
+    scope = set_deployment_scope(
+        db,
+        org_id=org_id,
+        scope=payload.scope,
+        actor_user_id=current_user.id,
+        targets=payload.targets,
+        readiness_override=payload.readiness_override,
+        source=payload.source,
+    )
+    emit_standard_audit_event(
+        db,
+        org_id=org_id,
+        actor_type="user",
+        actor_id=str(current_user.id),
+        action="deployment.scope.update",
+        event_type="deployment_scope_updated",
+        entity_type="deployment_scope",
+        entity_id=scope.scope,
+        outcome="success",
+        metadata={
+            "scope": scope.scope,
+            "targets": scope.targets,
+            "readiness_override": scope.readiness_override,
+            "source": scope.source,
+        },
+    )
+    return DeploymentScopeResponse.model_validate(asdict(scope))
+
+
+@router.get(
+    "/deployment-progress",
+    response_model=DeploymentProgressResponse,
+    responses={403: {"model": ApiErrorResponse}},
+    summary="Get deployment progress",
+)
+def get_org_deployment_progress(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    _require_deployment_access(current_user)
+    context = build_user_auth_context(db, current_user)
+    progress = get_deployment_progress(db, org_id=_first_org_id(context))
+    return DeploymentProgressResponse.model_validate(asdict(progress))
+
+
+@router.get(
+    "/expansion-readiness",
+    response_model=ExpansionReadinessResponse,
+    responses={403: {"model": ApiErrorResponse}},
+    summary="Get expansion readiness",
+)
+def get_org_expansion_readiness(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    _require_deployment_access(current_user)
+    context = build_user_auth_context(db, current_user)
+    readiness = get_expansion_readiness(db, org_id=_first_org_id(context))
+    return ExpansionReadinessResponse.model_validate(asdict(readiness))

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -855,7 +855,9 @@ class OrgLaunchReadinessResponse(BaseModel):
     test_incident_run: Optional[TestIncidentRunResponse] = None
     latest_export_validation: Optional[ExportValidationRunResponse] = None
     metrics: Optional[OnboardingMetricsSnapshotResponse] = None
-    alert_conditions: list[OnboardingAlertConditionResponse] = Field(default_factory=list)
+    alert_conditions: list[OnboardingAlertConditionResponse] = Field(
+        default_factory=list
+    )
     reporting_hooks: dict[str, Any] = Field(default_factory=dict)
     snapshot_created_at_utc: Optional[datetime] = None
 
@@ -874,6 +876,54 @@ class ProtocolSetupStepResponse(BaseModel):
     required_media_prompts_defaulted: bool = False
     export_profile_defaulted: bool = False
     export_profiles_available: list[ShortText] = Field(default_factory=list)
+
+
+DeploymentScopeKey = Literal["pilot", "partial_rollout", "full_rollout"]
+ExpansionReadinessState = Literal[
+    "not_started", "planning", "pilot_ready", "scale_ready", "blocked"
+]
+
+
+class DeploymentScopeRequest(BaseModel):
+    scope: DeploymentScopeKey
+    targets: dict[str, int] = Field(default_factory=dict)
+    readiness_override: Optional[ExpansionReadinessState] = None
+    source: ShortText = "manual"
+
+
+class DeploymentScopeResponse(BaseModel):
+    scope: DeploymentScopeKey = "pilot"
+    scope_version: ShortText = "v1"
+    targets: dict[str, int] = Field(default_factory=dict)
+    readiness_override: Optional[ExpansionReadinessState] = None
+    source: ShortText = "manual"
+    captured_at_utc: Optional[datetime] = None
+
+
+class DeploymentCoverageResponse(BaseModel):
+    key: ShortText
+    label: ShortText
+    covered: int = Field(default=0, ge=0)
+    total: int = Field(default=0, ge=0)
+    percent: int = Field(default=0, ge=0, le=100)
+
+
+class DeploymentProgressResponse(BaseModel):
+    scope: DeploymentScopeKey = "pilot"
+    percent_complete: int = Field(default=0, ge=0, le=100)
+    coverage: list[DeploymentCoverageResponse] = Field(default_factory=list)
+    blockers: list[ShortText] = Field(default_factory=list)
+    recommended_next_actions: list[str] = Field(default_factory=list)
+
+
+class ExpansionReadinessResponse(BaseModel):
+    scope: DeploymentScopeKey = "pilot"
+    status: ExpansionReadinessState = "not_started"
+    readiness_score: int = Field(default=0, ge=0, le=100)
+    blockers: list[ShortText] = Field(default_factory=list)
+    recommended_next_actions: list[str] = Field(default_factory=list)
+    coverage: list[DeploymentCoverageResponse] = Field(default_factory=list)
+    override_applied: bool = False
 
 
 class OrgMappingsSummaryCounts(BaseModel):

--- a/backend/app/commercial/expansion.py
+++ b/backend/app/commercial/expansion.py
@@ -1,6 +1,27 @@
-"""Expansion planning state definitions and helpers."""
+"""Deployment scope and expansion readiness service."""
 
 from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import uuid
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.db.models import (
+    Driver,
+    OrgExportValidationRun,
+    OrgTestIncidentRun,
+    User,
+    UserOrg,
+)
+from app.db.repo.org_content import (
+    create_deployment_scope_snapshot,
+    get_latest_deployment_scope_snapshot,
+    upsert_expansion_readiness_snapshot,
+)
+from app.onboarding.service import collect_onboarding_signals
 
 from typing import Literal
 
@@ -11,6 +32,7 @@ ExpansionReadiness = Literal[
     "scale_ready",
     "blocked",
 ]
+DeploymentScopeKey = Literal["pilot", "partial_rollout", "full_rollout"]
 
 EXPANSION_READINESS_STATES: tuple[ExpansionReadiness, ...] = (
     "not_started",
@@ -19,8 +41,396 @@ EXPANSION_READINESS_STATES: tuple[ExpansionReadiness, ...] = (
     "scale_ready",
     "blocked",
 )
+DEPLOYMENT_SCOPE_KEYS: tuple[DeploymentScopeKey, ...] = (
+    "pilot",
+    "partial_rollout",
+    "full_rollout",
+)
 
 EXPANSION_FEATURES: tuple[str, ...] = (
     "expansion.scorecard",
     "expansion.rollout",
 )
+
+DEFAULT_TARGETS_BY_SCOPE: dict[DeploymentScopeKey, dict[str, int]] = {
+    "pilot": {
+        "vehicles": 5,
+        "drivers": 10,
+        "admins": 1,
+        "test_incidents": 1,
+        "exports": 1,
+    },
+    "partial_rollout": {
+        "vehicles": 25,
+        "drivers": 50,
+        "admins": 2,
+        "test_incidents": 3,
+        "exports": 2,
+    },
+    "full_rollout": {
+        "vehicles": 100,
+        "drivers": 200,
+        "admins": 3,
+        "test_incidents": 5,
+        "exports": 3,
+    },
+}
+
+_COVERAGE_ORDER: tuple[str, ...] = (
+    "vehicles",
+    "drivers",
+    "qr",
+    "mapping",
+    "admin_training",
+    "test_incidents",
+    "exports",
+)
+
+_BLOCKER_ORDER: tuple[str, ...] = (
+    "vehicles_target_not_met",
+    "drivers_target_not_met",
+    "qr_coverage_incomplete",
+    "mapping_coverage_incomplete",
+    "admin_training_incomplete",
+    "test_incidents_incomplete",
+    "exports_validation_incomplete",
+)
+
+_ACTION_ORDER: dict[str, str] = {
+    "vehicles_target_not_met": "Import or activate additional vehicles in org vehicle registry.",
+    "drivers_target_not_met": "Import active drivers and verify phone coverage.",
+    "qr_coverage_incomplete": "Generate and distribute QR tokens for all active vehicles in scope.",
+    "mapping_coverage_incomplete": "Complete external ID mappings for drivers and vehicles.",
+    "admin_training_incomplete": "Assign and train at least one org admin for rollout operations.",
+    "test_incidents_incomplete": "Run successful test incidents for the current rollout scope.",
+    "exports_validation_incomplete": "Complete export validation runs with passing status.",
+}
+
+
+@dataclass(slots=True)
+class DeploymentScope:
+    scope: DeploymentScopeKey = "pilot"
+    scope_version: str = "v1"
+    targets: dict[str, int] = field(default_factory=dict)
+    readiness_override: ExpansionReadiness | None = None
+    source: str = "system"
+    captured_at_utc: datetime | None = None
+
+
+@dataclass(slots=True)
+class CoverageMetric:
+    key: str
+    label: str
+    covered: int
+    total: int
+    percent: int
+
+
+@dataclass(slots=True)
+class DeploymentProgress:
+    scope: DeploymentScopeKey
+    percent_complete: int
+    coverage: list[CoverageMetric] = field(default_factory=list)
+    blockers: list[str] = field(default_factory=list)
+    recommended_next_actions: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class ExpansionReadinessSummary:
+    scope: DeploymentScopeKey
+    status: ExpansionReadiness
+    readiness_score: int
+    blockers: list[str] = field(default_factory=list)
+    recommended_next_actions: list[str] = field(default_factory=list)
+    coverage: list[CoverageMetric] = field(default_factory=list)
+    override_applied: bool = False
+
+
+def _safe_percent(covered: int, total: int) -> int:
+    if total <= 0:
+        return 0
+    return int(max(0.0, min(1.0, covered / total)) * 100)
+
+
+def _normalize_scope(raw_scope: str | None) -> DeploymentScopeKey:
+    if raw_scope in DEPLOYMENT_SCOPE_KEYS:
+        return raw_scope
+    return "pilot"
+
+
+def _merge_targets(
+    scope: DeploymentScopeKey, incoming: dict[str, int] | None
+) -> dict[str, int]:
+    merged = {**DEFAULT_TARGETS_BY_SCOPE[scope]}
+    for key, value in (incoming or {}).items():
+        if key in merged:
+            merged[key] = max(1, int(value))
+    return merged
+
+
+def get_deployment_scope(db: Session, *, org_id: uuid.UUID) -> DeploymentScope:
+    latest = get_latest_deployment_scope_snapshot(db, org_id)
+    if latest is None:
+        scope = "pilot"
+        return DeploymentScope(scope=scope, targets=_merge_targets(scope, None))
+
+    payload = latest.scope_json or {}
+    scope = _normalize_scope(payload.get("scope"))
+    return DeploymentScope(
+        scope=scope,
+        scope_version=latest.scope_version,
+        targets=_merge_targets(scope, payload.get("targets")),
+        readiness_override=payload.get("readiness_override"),
+        source=payload.get("source") or "manual",
+        captured_at_utc=latest.captured_at_utc,
+    )
+
+
+def set_deployment_scope(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    scope: DeploymentScopeKey,
+    actor_user_id: uuid.UUID | None,
+    targets: dict[str, int] | None = None,
+    readiness_override: ExpansionReadiness | None = None,
+    source: str = "manual",
+) -> DeploymentScope:
+    normalized_scope = _normalize_scope(scope)
+    merged_targets = _merge_targets(normalized_scope, targets)
+    payload = {
+        "scope": normalized_scope,
+        "targets": merged_targets,
+        "readiness_override": readiness_override,
+        "source": source,
+    }
+    snapshot = create_deployment_scope_snapshot(
+        db,
+        org_id,
+        scope_version="v1",
+        scope_json=payload,
+        captured_by_user_id=actor_user_id,
+    )
+    return DeploymentScope(
+        scope=normalized_scope,
+        scope_version=snapshot.scope_version,
+        targets=merged_targets,
+        readiness_override=readiness_override,
+        source=source,
+        captured_at_utc=snapshot.captured_at_utc,
+    )
+
+
+def clear_deployment_scope(
+    db: Session,
+    *,
+    org_id: uuid.UUID,
+    actor_user_id: uuid.UUID | None,
+    source: str = "manual",
+) -> DeploymentScope:
+    return set_deployment_scope(
+        db,
+        org_id=org_id,
+        scope="pilot",
+        actor_user_id=actor_user_id,
+        targets=DEFAULT_TARGETS_BY_SCOPE["pilot"],
+        readiness_override=None,
+        source=source,
+    )
+
+
+def _coverage_metrics(
+    db: Session, *, org_id: uuid.UUID, scope: DeploymentScope
+) -> list[CoverageMetric]:
+    signals = collect_onboarding_signals(db, org_id=org_id)
+
+    active_driver_count = (
+        db.query(func.count(Driver.driver_id))
+        .filter(Driver.org_id == org_id, Driver.is_active.is_(True))
+        .scalar()
+        or 0
+    )
+    admin_count = (
+        db.query(func.count(User.id))
+        .join(UserOrg, UserOrg.user_id == User.id)
+        .filter(
+            UserOrg.org_id == org_id, User.is_active.is_(True), User.role == "org_admin"
+        )
+        .scalar()
+        or 0
+    )
+    successful_test_runs = (
+        db.query(func.count(OrgTestIncidentRun.run_id))
+        .filter(
+            OrgTestIncidentRun.org_id == org_id,
+            OrgTestIncidentRun.status == "completed",
+        )
+        .scalar()
+        or 0
+    )
+    passed_exports = (
+        db.query(func.count(OrgExportValidationRun.validation_run_id))
+        .filter(
+            OrgExportValidationRun.org_id == org_id,
+            OrgExportValidationRun.status == "passed",
+        )
+        .scalar()
+        or 0
+    )
+
+    target_vehicles = max(1, scope.targets.get("vehicles", 1))
+    target_drivers = max(1, scope.targets.get("drivers", 1))
+    target_admins = max(1, scope.targets.get("admins", 1))
+    target_tests = max(1, scope.targets.get("test_incidents", 1))
+    target_exports = max(1, scope.targets.get("exports", 1))
+
+    mapping_total = max(signals.vehicles_total, active_driver_count, 1)
+
+    by_key = {
+        "vehicles": CoverageMetric(
+            key="vehicles",
+            label="Vehicles onboarded",
+            covered=min(signals.vehicles_total, target_vehicles),
+            total=target_vehicles,
+            percent=_safe_percent(signals.vehicles_total, target_vehicles),
+        ),
+        "drivers": CoverageMetric(
+            key="drivers",
+            label="Drivers onboarded",
+            covered=min(active_driver_count, target_drivers),
+            total=target_drivers,
+            percent=_safe_percent(active_driver_count, target_drivers),
+        ),
+        "qr": CoverageMetric(
+            key="qr",
+            label="QR distribution",
+            covered=min(signals.qr_codes_distributed, max(signals.vehicles_total, 1)),
+            total=max(signals.vehicles_total, 1),
+            percent=_safe_percent(
+                signals.qr_codes_distributed, max(signals.vehicles_total, 1)
+            ),
+        ),
+        "mapping": CoverageMetric(
+            key="mapping",
+            label="External mapping coverage",
+            covered=min(signals.mapping_count, mapping_total),
+            total=mapping_total,
+            percent=_safe_percent(signals.mapping_count, mapping_total),
+        ),
+        "admin_training": CoverageMetric(
+            key="admin_training",
+            label="Admin training",
+            covered=min(admin_count, target_admins),
+            total=target_admins,
+            percent=_safe_percent(admin_count, target_admins),
+        ),
+        "test_incidents": CoverageMetric(
+            key="test_incidents",
+            label="Test incidents",
+            covered=min(successful_test_runs, target_tests),
+            total=target_tests,
+            percent=_safe_percent(successful_test_runs, target_tests),
+        ),
+        "exports": CoverageMetric(
+            key="exports",
+            label="Validated exports",
+            covered=min(passed_exports, target_exports),
+            total=target_exports,
+            percent=_safe_percent(passed_exports, target_exports),
+        ),
+    }
+    return [by_key[key] for key in _COVERAGE_ORDER]
+
+
+def _derive_blockers_and_actions(
+    coverage: list[CoverageMetric],
+) -> tuple[list[str], list[str]]:
+    by_key = {metric.key: metric for metric in coverage}
+    blockers: list[str] = []
+
+    if by_key["vehicles"].percent < 100:
+        blockers.append("vehicles_target_not_met")
+    if by_key["drivers"].percent < 100:
+        blockers.append("drivers_target_not_met")
+    if by_key["qr"].percent < 100:
+        blockers.append("qr_coverage_incomplete")
+    if by_key["mapping"].percent < 100:
+        blockers.append("mapping_coverage_incomplete")
+    if by_key["admin_training"].percent < 100:
+        blockers.append("admin_training_incomplete")
+    if by_key["test_incidents"].percent < 100:
+        blockers.append("test_incidents_incomplete")
+    if by_key["exports"].percent < 100:
+        blockers.append("exports_validation_incomplete")
+
+    ordered_blockers = [code for code in _BLOCKER_ORDER if code in blockers]
+    actions = [_ACTION_ORDER[code] for code in ordered_blockers]
+    return ordered_blockers, actions
+
+
+def get_deployment_progress(db: Session, *, org_id: uuid.UUID) -> DeploymentProgress:
+    scope = get_deployment_scope(db, org_id=org_id)
+    coverage = _coverage_metrics(db, org_id=org_id, scope=scope)
+    percent = (
+        int(sum(metric.percent for metric in coverage) / len(coverage))
+        if coverage
+        else 0
+    )
+    blockers, actions = _derive_blockers_and_actions(coverage)
+    return DeploymentProgress(
+        scope=scope.scope,
+        percent_complete=percent,
+        coverage=coverage,
+        blockers=blockers,
+        recommended_next_actions=actions,
+    )
+
+
+def get_expansion_readiness(
+    db: Session, *, org_id: uuid.UUID
+) -> ExpansionReadinessSummary:
+    scope = get_deployment_scope(db, org_id=org_id)
+    progress = get_deployment_progress(db, org_id=org_id)
+
+    status: ExpansionReadiness
+    if progress.percent_complete == 0:
+        status = "not_started"
+    elif progress.blockers:
+        status = "blocked"
+    elif scope.scope == "pilot":
+        status = "pilot_ready"
+    else:
+        status = "scale_ready"
+
+    if progress.percent_complete > 0 and status == "not_started":
+        status = "planning"
+
+    override_applied = False
+    if scope.readiness_override in EXPANSION_READINESS_STATES:
+        status = scope.readiness_override
+        override_applied = True
+
+    summary = ExpansionReadinessSummary(
+        scope=scope.scope,
+        status=status,
+        readiness_score=progress.percent_complete,
+        blockers=progress.blockers,
+        recommended_next_actions=progress.recommended_next_actions,
+        coverage=progress.coverage,
+        override_applied=override_applied,
+    )
+
+    upsert_expansion_readiness_snapshot(
+        db,
+        org_id,
+        scope_key=scope.scope,
+        status=summary.status,
+        readiness_score=summary.readiness_score,
+        summary_json={
+            "blockers": summary.blockers,
+            "recommended_next_actions": summary.recommended_next_actions,
+            "override_applied": summary.override_applied,
+            "computed_at_utc": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+    return summary

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,6 +25,7 @@ from app.api.routes.routes_demo import router as demo_router
 from app.api.routes.routes_entitlements import router as entitlements_router
 from app.api.routes.routes_help import router as help_router
 from app.api.routes.routes_trust import router as trust_router
+from app.api.routes.routes_deployment import router as deployment_router
 from app.api.routes_admin import router as admin_router
 from app.api.routes_twilio import router as twilio_router
 from app.health.routes import router as health_router
@@ -64,6 +65,7 @@ app.include_router(demo_router)
 app.include_router(entitlements_router)
 app.include_router(help_router)
 app.include_router(trust_router)
+app.include_router(deployment_router)
 app.include_router(admin_router, prefix="/admin", tags=["admin"])
 app.include_router(twilio_router, prefix="/twilio", tags=["twilio"])
 app.include_router(onboarding_router)

--- a/backend/tests/test_deployment_scope_routes.py
+++ b/backend/tests/test_deployment_scope_routes.py
@@ -1,0 +1,151 @@
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.security import create_access_token, hash_password
+from app.db.models import (
+    Base,
+    Driver,
+    ExternalMapping,
+    Org,
+    OrgExportValidationRun,
+    OrgTestIncidentRun,
+    OrgVehicleRegistry,
+    User,
+    UserOrg,
+)
+from app.db.session import get_db
+from app.main import app
+
+
+@pytest.fixture()
+def db_session():
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine)
+    session = TestSession()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def seeded_org(db_session):
+    org = Org(name="Expansion Org")
+    db_session.add(org)
+    db_session.commit()
+    db_session.refresh(org)
+
+    user = User(
+        email="expansion@example.com",
+        password_hash=hash_password("testpass"),
+        role="org_admin",
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    db_session.add(UserOrg(user_id=user.id, org_id=org.id))
+
+    for i in range(3):
+        db_session.add(
+            OrgVehicleRegistry(
+                org_id=org.id,
+                unit_number=f"veh-{i}",
+                is_active=True,
+                qr_deployment_status="distributed" if i < 2 else "not_generated",
+            )
+        )
+
+    for i in range(4):
+        db_session.add(
+            Driver(
+                org_id=org.id,
+                phone_e164=f"+15550000{i:03d}",
+                display_name=f"Driver {i}",
+                is_active=True,
+            )
+        )
+
+    db_session.add(
+        ExternalMapping(
+            org_id=org.id,
+            provider="samsara",
+            domain="fleet",
+            internal_entity_type="driver",
+            internal_entity_id="drv-1",
+            external_reference="ext-1",
+        )
+    )
+    db_session.add(OrgTestIncidentRun(org_id=org.id, status="completed"))
+    db_session.add(OrgExportValidationRun(org_id=org.id, status="passed"))
+    db_session.commit()
+    return org, user
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def auth_headers(seeded_org):
+    _, user = seeded_org
+    token = create_access_token({"sub": str(user.id), "role": user.role})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_deployment_scope_crud_and_progress_routes(client, auth_headers):
+    get_scope = client.get("/org/deployment-scope", headers=auth_headers)
+    assert get_scope.status_code == 200
+    assert get_scope.json()["scope"] == "pilot"
+
+    patch_scope = client.patch(
+        "/org/deployment-scope",
+        json={
+            "scope": "partial_rollout",
+            "targets": {
+                "vehicles": 3,
+                "drivers": 4,
+                "admins": 1,
+                "test_incidents": 1,
+                "exports": 1,
+            },
+            "readiness_override": "planning",
+            "source": "test",
+        },
+        headers=auth_headers,
+    )
+    assert patch_scope.status_code == 200
+    assert patch_scope.json()["scope"] == "partial_rollout"
+    assert patch_scope.json()["targets"]["vehicles"] == 3
+
+    progress = client.get("/org/deployment-progress", headers=auth_headers)
+    assert progress.status_code == 200
+    payload = progress.json()
+    assert payload["scope"] == "partial_rollout"
+    assert payload["coverage"][0]["key"] == "vehicles"
+    assert payload["blockers"] == [
+        "qr_coverage_incomplete",
+        "mapping_coverage_incomplete",
+    ]
+
+    readiness = client.get("/org/expansion-readiness", headers=auth_headers)
+    assert readiness.status_code == 200
+    assert readiness.json()["status"] == "planning"
+    assert readiness.json()["override_applied"] is True


### PR DESCRIPTION
### Motivation
- Provide an org-scoped deployment scope concept (pilot / partial_rollout / full_rollout) so operators can manage rollout targets and measure expansion readiness. 
- Compute deterministic coverage and blockers across vehicles, drivers, QR, mappings, admin training, test incidents and export validation by reusing onboarding/case-op signals. 
- Persist scope snapshots and readiness summaries and emit audit events when scope or overrides are applied to enable traceability. 

### Description
- Implemented a new deployment/expansion service in `backend/app/commercial/expansion.py` with scope CRUD helpers (`get_deployment_scope`, `set_deployment_scope`, `clear_deployment_scope`), coverage computation, deterministic blocker + recommended-action ordering, and readiness snapshot upsert. 
- Added API routes in `backend/app/api/routes/routes_deployment.py` exposing `GET /org/deployment-scope`, `PATCH /org/deployment-scope`, `GET /org/deployment-progress`, and `GET /org/expansion-readiness`, including permission checks and emitting `deployment_scope_updated` audit events via `emit_standard_audit_event`. 
- Added request/response schemas for scope/progress/readiness to `backend/app/api/schemas.py` and wired the new router into `backend/app/main.py`. 
- Added integration-style route tests in `backend/tests/test_deployment_scope_routes.py` and reused onboarding readiness signals from `backend/app/onboarding/*` to drive coverage calculations. 

### Testing
- Ran formatter and linter: `ruff format` and `ruff check` on modified files and `make lint`; the checks passed. 
- Ran targeted unit/integration tests with `pytest tests/test_deployment_scope_routes.py tests/test_onboarding_service.py tests/test_case_ops_service.py`; all tests passed. 
- Ran repository validation scripts `python scripts/check_no_duplicate_modules.py` and `python scripts/validate_schemas.py`; checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e584ded29c83218890227e7cb1025d)