### PR TITLE
Add org reporting aggregations, schemas, and gated report routes

### DIFF
--- a/backend/app/api/routes/routes_reporting.py
+++ b/backend/app/api/routes/routes_reporting.py
@@ -1,0 +1,125 @@
+"""Organization reporting routes."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.api.schemas import (
+    ReportAdoptionResponse,
+    ReportEvidenceCompletenessResponse,
+    ReportExportTurnaroundResponse,
+    ReportIncidentOperationsResponse,
+)
+from app.commercial.enforcement import require_feature_enabled
+from app.commercial.reporting import (
+    FUTURE_REPORTING_FEATURES,
+    PREMIUM_REPORTING_FEATURES,
+    REPORT_ADOPTION_FEATURE,
+    REPORT_EVIDENCE_COMPLETENESS_FEATURE,
+    REPORT_EXPORT_TURNAROUND_FEATURE,
+    REPORT_INCIDENT_OPERATIONS_FEATURE,
+    query_adoption_report,
+    query_evidence_completeness_report,
+    query_export_turnaround_report,
+    query_incident_operations_report,
+)
+from app.core.deps import require_workspace_view_permission
+from app.db.models import User
+from app.db.session import get_db
+from app.security.authn import build_user_auth_context
+
+router = APIRouter(prefix="/org/reports", tags=["reporting"])
+
+
+def _require_report_access(
+    *,
+    db: Session,
+    org_id: uuid.UUID,
+    current_user: User,
+    feature_key: str,
+) -> None:
+    require_feature_enabled(
+        db,
+        org_id=org_id,
+        actor_id=str(current_user.id),
+        actor_role=str(current_user.role),
+        feature_key=feature_key,
+        action=f"reporting.{feature_key}.read",
+        allow_internal_override=(
+            feature_key in PREMIUM_REPORTING_FEATURES
+            or feature_key in FUTURE_REPORTING_FEATURES
+        ),
+    )
+
+
+@router.get("/adoption", response_model=ReportAdoptionResponse)
+def get_adoption_report(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_workspace_view_permission),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = context.org_ids[0]
+    _require_report_access(
+        db=db,
+        org_id=org_id,
+        current_user=current_user,
+        feature_key=REPORT_ADOPTION_FEATURE,
+    )
+    return ReportAdoptionResponse(**query_adoption_report(db, org_ids=list(context.org_ids)))
+
+
+@router.get("/incident-operations", response_model=ReportIncidentOperationsResponse)
+def get_incident_operations_report(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_workspace_view_permission),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = context.org_ids[0]
+    _require_report_access(
+        db=db,
+        org_id=org_id,
+        current_user=current_user,
+        feature_key=REPORT_INCIDENT_OPERATIONS_FEATURE,
+    )
+    return ReportIncidentOperationsResponse(
+        **query_incident_operations_report(db, org_ids=list(context.org_ids))
+    )
+
+
+@router.get("/export-turnaround", response_model=ReportExportTurnaroundResponse)
+def get_export_turnaround_report(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_workspace_view_permission),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = context.org_ids[0]
+    _require_report_access(
+        db=db,
+        org_id=org_id,
+        current_user=current_user,
+        feature_key=REPORT_EXPORT_TURNAROUND_FEATURE,
+    )
+    return ReportExportTurnaroundResponse(
+        **query_export_turnaround_report(db, org_ids=list(context.org_ids))
+    )
+
+
+@router.get("/evidence-completeness", response_model=ReportEvidenceCompletenessResponse)
+def get_evidence_completeness_report(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_workspace_view_permission),
+):
+    context = build_user_auth_context(db, current_user)
+    org_id = context.org_ids[0]
+    _require_report_access(
+        db=db,
+        org_id=org_id,
+        current_user=current_user,
+        feature_key=REPORT_EVIDENCE_COMPLETENESS_FEATURE,
+    )
+    return ReportEvidenceCompletenessResponse(
+        **query_evidence_completeness_report(db, org_ids=list(context.org_ids))
+    )

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -486,6 +486,48 @@ class CaseOpsAlertsResponse(BaseModel):
     export_aging: int = 0
 
 
+class ReportAdoptionResponse(BaseModel):
+    total_incidents: int = 0
+    reviewed_incidents: int = 0
+    assigned_incidents: int = 0
+    ready_for_export_incidents: int = 0
+    exported_incidents: int = 0
+    review_rate_percent: float = 0.0
+    assignment_rate_percent: float = 0.0
+    export_readiness_rate_percent: float = 0.0
+    export_completion_rate_percent: float = 0.0
+    adoption_score_percent: float = 0.0
+
+
+class ReportIncidentOperationsResponse(BaseModel):
+    open_incidents: int = 0
+    unassigned_incidents: int = 0
+    blocked_incidents: int = 0
+    export_aging_incidents: int = 0
+    stalled_incidents: int = 0
+    overdue_tasks: int = 0
+    case_status_counts: dict[str, int] = Field(default_factory=dict)
+    avg_time_to_first_review_hours: float = 0.0
+    incidents_reviewed: int = 0
+
+
+class ReportExportTurnaroundResponse(BaseModel):
+    total_exports: int = 0
+    completed_exports: int = 0
+    failed_exports: int = 0
+    in_flight_exports: int = 0
+    avg_turnaround_hours: float = 0.0
+    p95_turnaround_hours: float = 0.0
+    within_24h_rate_percent: float = 0.0
+
+
+class ReportEvidenceCompletenessResponse(BaseModel):
+    total_incidents: int = 0
+    avg_completeness_percent: float = 0.0
+    readiness_breakdown: dict[str, int] = Field(default_factory=dict)
+    artifact_status_counts: dict[str, int] = Field(default_factory=dict)
+
+
 class CaseTaskWidgetItem(BaseModel):
     task_id: uuid.UUID
     incident_id: uuid.UUID

--- a/backend/app/commercial/reporting.py
+++ b/backend/app/commercial/reporting.py
@@ -1,9 +1,285 @@
-"""Reporting feature gates keyed by canonical feature ids."""
+"""Reporting feature gates and aggregate query helpers."""
 
 from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.case_ops.completeness import calculate_completeness
+from app.case_ops.metrics import query_summary_metrics
+from app.db.models import Artifact, Event, Export, Incident
+
+REPORT_ADOPTION_FEATURE = "reporting.adoption"
+REPORT_INCIDENT_OPERATIONS_FEATURE = "reporting.incident_operations"
+REPORT_EXPORT_TURNAROUND_FEATURE = "reporting.export_turnaround"
+REPORT_EVIDENCE_COMPLETENESS_FEATURE = "reporting.evidence_completeness"
+
+PREMIUM_REPORTING_FEATURES: tuple[str, ...] = (
+    REPORT_INCIDENT_OPERATIONS_FEATURE,
+    REPORT_EXPORT_TURNAROUND_FEATURE,
+)
+FUTURE_REPORTING_FEATURES: tuple[str, ...] = (REPORT_EVIDENCE_COMPLETENESS_FEATURE,)
 
 REPORTING_FEATURES: tuple[str, ...] = (
     "reporting.dashboard",
     "reporting.audit_trail",
     "reporting.export_history",
+    REPORT_ADOPTION_FEATURE,
 )
+
+
+def _normalize_to_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _percent(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round((numerator / denominator) * 100.0, 2)
+
+
+def query_adoption_report(db: Session, *, org_ids: list[uuid.UUID]) -> dict[str, Any]:
+    if not org_ids:
+        return {
+            "total_incidents": 0,
+            "reviewed_incidents": 0,
+            "assigned_incidents": 0,
+            "ready_for_export_incidents": 0,
+            "exported_incidents": 0,
+            "review_rate_percent": 0.0,
+            "assignment_rate_percent": 0.0,
+            "export_readiness_rate_percent": 0.0,
+            "export_completion_rate_percent": 0.0,
+            "adoption_score_percent": 0.0,
+        }
+
+    base_query = db.query(Incident).filter(
+        Incident.org_id.in_(org_ids),
+        Incident.is_test_incident.is_(False),
+    )
+    total_incidents = base_query.count()
+    reviewed_incidents = base_query.filter(Incident.first_reviewed_at_utc.is_not(None)).count()
+    assigned_incidents = base_query.filter(Incident.owner_user_id.is_not(None)).count()
+    ready_for_export_incidents = base_query.filter(
+        Incident.ready_for_export_at_utc.is_not(None)
+    ).count()
+    exported_incidents = (
+        db.query(func.count(func.distinct(Export.incident_id)))
+        .filter(
+            Export.org_id.in_(org_ids),
+            Export.status == "ready",
+        )
+        .scalar()
+        or 0
+    )
+
+    review_rate = _percent(reviewed_incidents, total_incidents)
+    assignment_rate = _percent(assigned_incidents, total_incidents)
+    readiness_rate = _percent(ready_for_export_incidents, total_incidents)
+    export_completion_rate = _percent(exported_incidents, total_incidents)
+    adoption_score = round((review_rate + assignment_rate + readiness_rate) / 3.0, 2)
+    return {
+        "total_incidents": total_incidents,
+        "reviewed_incidents": reviewed_incidents,
+        "assigned_incidents": assigned_incidents,
+        "ready_for_export_incidents": ready_for_export_incidents,
+        "exported_incidents": int(exported_incidents),
+        "review_rate_percent": review_rate,
+        "assignment_rate_percent": assignment_rate,
+        "export_readiness_rate_percent": readiness_rate,
+        "export_completion_rate_percent": export_completion_rate,
+        "adoption_score_percent": adoption_score,
+    }
+
+
+def query_incident_operations_report(
+    db: Session, *, org_ids: list[uuid.UUID]
+) -> dict[str, Any]:
+    summary = query_summary_metrics(db, org_ids=org_ids)
+    if not org_ids:
+        return {
+            **summary,
+            "case_status_counts": {},
+            "avg_time_to_first_review_hours": 0.0,
+            "incidents_reviewed": 0,
+        }
+
+    case_status_rows = (
+        db.query(Incident.case_status, func.count(Incident.incident_id))
+        .filter(
+            Incident.org_id.in_(org_ids),
+            Incident.is_test_incident.is_(False),
+        )
+        .group_by(Incident.case_status)
+        .all()
+    )
+    case_status_counts = {str(status): int(count) for status, count in case_status_rows}
+
+    review_seconds_expr = (
+        func.extract("epoch", Incident.first_reviewed_at_utc)
+        - func.extract("epoch", Incident.created_at_utc)
+    )
+    avg_review_seconds = (
+        db.query(func.avg(review_seconds_expr))
+        .filter(
+            Incident.org_id.in_(org_ids),
+            Incident.is_test_incident.is_(False),
+            Incident.first_reviewed_at_utc.is_not(None),
+        )
+        .scalar()
+    )
+    incidents_reviewed = (
+        db.query(func.count(Incident.incident_id))
+        .filter(
+            Incident.org_id.in_(org_ids),
+            Incident.is_test_incident.is_(False),
+            Incident.first_reviewed_at_utc.is_not(None),
+        )
+        .scalar()
+        or 0
+    )
+
+    return {
+        **summary,
+        "case_status_counts": case_status_counts,
+        "avg_time_to_first_review_hours": round(float(avg_review_seconds or 0.0) / 3600.0, 2),
+        "incidents_reviewed": int(incidents_reviewed),
+    }
+
+
+def query_export_turnaround_report(
+    db: Session, *, org_ids: list[uuid.UUID]
+) -> dict[str, Any]:
+    if not org_ids:
+        return {
+            "total_exports": 0,
+            "completed_exports": 0,
+            "failed_exports": 0,
+            "in_flight_exports": 0,
+            "avg_turnaround_hours": 0.0,
+            "p95_turnaround_hours": 0.0,
+            "within_24h_rate_percent": 0.0,
+        }
+
+    exports = (
+        db.query(Export)
+        .filter(Export.org_id.in_(org_ids))
+        .order_by(Export.created_at_utc.desc())
+        .all()
+    )
+    total_exports = len(exports)
+    completed_exports = 0
+    failed_exports = 0
+    in_flight_exports = 0
+    turnaround_hours: list[float] = []
+    within_24h = 0
+    for export in exports:
+        if export.status == "failed":
+            failed_exports += 1
+        elif export.status == "ready":
+            completed_exports += 1
+        else:
+            in_flight_exports += 1
+
+        start = _normalize_to_utc(export.requested_at_utc)
+        end = _normalize_to_utc(export.completed_at_utc)
+        if start is None or end is None or end < start:
+            continue
+        hours = (end - start).total_seconds() / 3600.0
+        turnaround_hours.append(hours)
+        if hours <= 24.0:
+            within_24h += 1
+
+    sorted_turnaround = sorted(turnaround_hours)
+    p95_turnaround = (
+        sorted_turnaround[max(0, round(0.95 * (len(sorted_turnaround) - 1)))]
+        if sorted_turnaround
+        else 0.0
+    )
+    avg_turnaround = (
+        sum(sorted_turnaround) / len(sorted_turnaround) if sorted_turnaround else 0.0
+    )
+
+    return {
+        "total_exports": total_exports,
+        "completed_exports": completed_exports,
+        "failed_exports": failed_exports,
+        "in_flight_exports": in_flight_exports,
+        "avg_turnaround_hours": round(avg_turnaround, 2),
+        "p95_turnaround_hours": round(float(p95_turnaround), 2),
+        "within_24h_rate_percent": _percent(within_24h, len(sorted_turnaround)),
+    }
+
+
+def query_evidence_completeness_report(
+    db: Session, *, org_ids: list[uuid.UUID]
+) -> dict[str, Any]:
+    if not org_ids:
+        return {
+            "total_incidents": 0,
+            "avg_completeness_percent": 0.0,
+            "readiness_breakdown": {"not_ready": 0, "conditionally_ready": 0, "ready": 0},
+            "artifact_status_counts": {"captured": 0, "pending": 0, "unavailable": 0},
+        }
+
+    incidents = (
+        db.query(Incident)
+        .filter(Incident.org_id.in_(org_ids), Incident.is_test_incident.is_(False))
+        .all()
+    )
+    if not incidents:
+        return {
+            "total_incidents": 0,
+            "avg_completeness_percent": 0.0,
+            "readiness_breakdown": {"not_ready": 0, "conditionally_ready": 0, "ready": 0},
+            "artifact_status_counts": {"captured": 0, "pending": 0, "unavailable": 0},
+        }
+
+    incident_ids = [incident.incident_id for incident in incidents]
+    artifacts = db.query(Artifact).filter(Artifact.incident_id.in_(incident_ids)).all()
+    events = db.query(Event).filter(Event.incident_id.in_(incident_ids)).all()
+    exports = db.query(Export).filter(Export.incident_id.in_(incident_ids)).all()
+
+    artifacts_by_incident: dict[uuid.UUID, list[Artifact]] = {}
+    events_by_incident: dict[uuid.UUID, list[Event]] = {}
+    exports_by_incident: dict[uuid.UUID, list[Export]] = {}
+    artifact_status_counts = {"captured": 0, "pending": 0, "unavailable": 0}
+    for artifact in artifacts:
+        artifacts_by_incident.setdefault(artifact.incident_id, []).append(artifact)
+        if artifact.status in artifact_status_counts:
+            artifact_status_counts[str(artifact.status)] += 1
+    for event in events:
+        events_by_incident.setdefault(event.incident_id, []).append(event)
+    for export in exports:
+        exports_by_incident.setdefault(export.incident_id, []).append(export)
+
+    completeness_total = 0
+    readiness_breakdown = {"not_ready": 0, "conditionally_ready": 0, "ready": 0}
+    for incident in incidents:
+        completeness = calculate_completeness(
+            artifacts=artifacts_by_incident.get(incident.incident_id, []),
+            events=events_by_incident.get(incident.incident_id, []),
+            exports=exports_by_incident.get(incident.incident_id, []),
+        )
+        completeness_total += completeness.percent
+        if completeness.percent >= 90:
+            readiness_breakdown["ready"] += 1
+        elif completeness.percent >= 60:
+            readiness_breakdown["conditionally_ready"] += 1
+        else:
+            readiness_breakdown["not_ready"] += 1
+
+    return {
+        "total_incidents": len(incidents),
+        "avg_completeness_percent": round(completeness_total / len(incidents), 2),
+        "readiness_breakdown": readiness_breakdown,
+        "artifact_status_counts": artifact_status_counts,
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.api.routes.routes_tasks import router as tasks_router
 from app.api.routes.routes_demo import router as demo_router
 from app.api.routes.routes_entitlements import router as entitlements_router
 from app.api.routes.routes_help import router as help_router
+from app.api.routes.routes_reporting import router as reporting_router
 from app.api.routes.routes_trust import router as trust_router
 from app.api.routes.routes_deployment import router as deployment_router
 from app.api.routes_admin import router as admin_router
@@ -63,6 +64,7 @@ app.include_router(notes_router, tags=["notes"])
 app.include_router(tasks_router, tags=["tasks"])
 app.include_router(demo_router)
 app.include_router(entitlements_router)
+app.include_router(reporting_router)
 app.include_router(help_router)
 app.include_router(trust_router)
 app.include_router(deployment_router)


### PR DESCRIPTION
### Motivation
- Provide organization-level reporting (adoption, incident operations, export turnaround, evidence completeness) so customers can observe operational KPIs and adoption metrics using existing case/incident/export data.
- Ensure access to reports is plan-aware and can be internally overridden for premium/future features.
- Reuse existing incident/export/artifact/event tables and case-ops helpers to avoid duplication and keep metrics consistent.

### Description
- Implemented aggregation helpers in `backend/app/commercial/reporting.py` for: adoption, incident operations (reuses `query_summary_metrics`), export turnaround, and evidence completeness (reuses `calculate_completeness` and existing DB models). Added reporting feature keys and grouped premium/future features used for gating.
- Added new reporting routes in `backend/app/api/routes/routes_reporting.py` exposing the endpoints:
  - `GET /org/reports/adoption`
  - `GET /org/reports/incident-operations`
  - `GET /org/reports/export-turnaround`
  - `GET /org/reports/evidence-completeness`
  Each route enforces plan-aware checks via `require_feature_enabled` and permits internal override for premium/future features.
- Added response contracts for the four report endpoints in `backend/app/api/schemas.py`.
- Wired the new reporting router into the application startup in `backend/app/main.py`.

### Testing
- Ran linter with `make lint`; fixed an unused-import lint failure and re-ran until clean (no lint errors).
- Ran the full test suite with `make test`; all tests passed (`472 passed`).
- Verified schema validation with `python scripts/validate_schemas.py` as part of the test run (succeeds).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e589036df48321915a4ac3b8a11209)