### PR TITLE
Add commercial pages, feature gates, and contextual help

### DIFF
--- a/frontend/app/admin/plan-features/page.tsx
+++ b/frontend/app/admin/plan-features/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import MainLayout from "@/components/MainLayout";
+import CommercialSummaryCards from "@/components/commercial/CommercialSummaryCards";
+import FeatureGate from "@/components/commercial/FeatureGate";
+import PlanBadge from "@/components/commercial/PlanBadge";
+import { hasRoleCapability } from "@/lib/permissions";
+import { useAuth } from "@/lib/useAuth";
+
+export default function PlanFeaturesPage() {
+  const { user } = useAuth();
+  const isOrgOrInternalAdmin = hasRoleCapability(user?.role, "user_management:write");
+
+  return (
+    <MainLayout title="Plan & Features">
+      <div className="space-y-4">
+        <header>
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">Plan and feature controls</h2>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            Feature availability by plan tier for organization and internal administrators.
+          </p>
+        </header>
+
+        <FeatureGate
+          available={isOrgOrInternalAdmin}
+          mode="hide"
+          reason="Only organization and internal admins can access commercial feature controls."
+        >
+          <>
+            <CommercialSummaryCards
+              items={[
+                { label: "Current tier", value: "Growth", detail: "Billing cycle renews in 14 days" },
+                { label: "Enabled add-ons", value: "3", detail: "Includes export governance" },
+                { label: "Locked features", value: "2", detail: "Available with Enterprise" },
+                { label: "Admin seats", value: "8", detail: "2 seats available" },
+              ]}
+            />
+
+            <div className="grid gap-3 md:grid-cols-2">
+              <section className="rounded-lg border bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+                <div className="flex items-center justify-between">
+                  <h3 className="font-semibold">Demo orchestration</h3>
+                  <PlanBadge plan="Growth" />
+                </div>
+                <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+                  Single-tenant scenario launcher and canned onboarding recovery playbooks.
+                </p>
+              </section>
+
+              <FeatureGate
+                available={false}
+                requiredPlan="Enterprise"
+                reason="Cross-organization orchestration and delegated support controls require Enterprise tier."
+              >
+                <section className="rounded-lg border bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+                  <div className="flex items-center justify-between">
+                    <h3 className="font-semibold">Cross-org controls</h3>
+                    <PlanBadge plan="Enterprise" />
+                  </div>
+                  <button
+                    type="button"
+                    disabled
+                    className="mt-3 rounded bg-gray-300 px-3 py-1 text-sm font-medium text-gray-700"
+                  >
+                    Enable delegated support access
+                  </button>
+                </section>
+              </FeatureGate>
+            </div>
+          </>
+        </FeatureGate>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/app/demo/page.tsx
+++ b/frontend/app/demo/page.tsx
@@ -1,0 +1,45 @@
+import MainLayout from "@/components/MainLayout";
+import DemoScenarioLauncher from "@/components/commercial/DemoScenarioLauncher";
+import DemoTenantBanner from "@/components/commercial/DemoTenantBanner";
+import FeatureGate from "@/components/commercial/FeatureGate";
+
+export default function DemoPage() {
+  return (
+    <MainLayout title="Demo Workspace">
+      <div className="space-y-4">
+        <DemoTenantBanner tenantName="Northstar Logistics" mode="Sandbox" />
+        <DemoScenarioLauncher
+          scenarios={[
+            {
+              id: "onboarding-recovery",
+              label: "Onboarding recovery",
+              description: "Simulates mapping + integration blockers with guided remediation.",
+            },
+            {
+              id: "incident-queue-spike",
+              label: "Incident queue spike",
+              description: "Loads a high-volume queue with mixed driver response status.",
+            },
+            {
+              id: "enterprise-multi-org",
+              label: "Enterprise multi-org",
+              description: "Cross-org tenancy demo for internal teams.",
+              enabled: false,
+            },
+          ]}
+        />
+
+        <FeatureGate
+          available={false}
+          requiredPlan="Enterprise"
+          reason="Cross-org demo orchestration is available only on Enterprise plans."
+        >
+          <div className="rounded border bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+            <h3 className="font-semibold">Cross-org orchestration console</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-300">Provision demo users across tenants.</p>
+          </div>
+        </FeatureGate>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/app/deployment/page.tsx
+++ b/frontend/app/deployment/page.tsx
@@ -1,0 +1,19 @@
+import MainLayout from "@/components/MainLayout";
+import DeploymentCoverageCard from "@/components/commercial/DeploymentCoverageCard";
+import ExpansionReadinessBanner from "@/components/commercial/ExpansionReadinessBanner";
+
+export default function DeploymentPage() {
+  return (
+    <MainLayout title="Deployment Coverage">
+      <div className="space-y-4">
+        <ExpansionReadinessBanner readyMarkets={5} blockedMarkets={2} />
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <DeploymentCoverageCard region="US West" coveragePercent={94} gapCount={2} />
+          <DeploymentCoverageCard region="US Central" coveragePercent={90} gapCount={3} />
+          <DeploymentCoverageCard region="US East" coveragePercent={96} gapCount={1} />
+          <DeploymentCoverageCard region="Canada" coveragePercent={82} gapCount={5} />
+        </div>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/app/exports/page.tsx
+++ b/frontend/app/exports/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import MainLayout from "@/components/MainLayout";
+import FeatureGate from "@/components/commercial/FeatureGate";
+import RelatedDocsPanel from "@/components/commercial/RelatedDocsPanel";
 import {
   listExports,
   downloadExport,
@@ -183,6 +185,22 @@ export default function ExportsPage() {
           Export history with filters, package health, and detailed audit/download visibility.
         </p>
       </div>
+
+      <FeatureGate
+        available={false}
+        requiredPlan="Enterprise"
+        reason="Export package comparison and anomaly scoring are available on Enterprise plans."
+      >
+        <section className="mb-4 rounded-lg border bg-white p-3 shadow dark:border-gray-700 dark:bg-gray-800">
+          <h3 className="font-semibold">Compliance package compare</h3>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            Compare two exports for missing evidence artifacts and timeline drift.
+          </p>
+          <button type="button" disabled className="mt-3 rounded bg-gray-300 px-3 py-1 text-sm text-gray-700">
+            Compare exports
+          </button>
+        </section>
+      </FeatureGate>
 
       <div className="mb-4 grid grid-cols-1 gap-3 rounded-lg border bg-white p-3 shadow dark:border-gray-700 dark:bg-gray-800 md:grid-cols-6">
         <input
@@ -382,6 +400,28 @@ export default function ExportsPage() {
           </aside>
         </div>
       )}
+
+      <div className="mt-4">
+        <RelatedDocsPanel
+          docs={[
+            {
+              title: "Incident queue",
+              href: "/incidents",
+              description: "Return to incident operations to complete evidence capture gaps.",
+            },
+            {
+              title: "Onboarding export validation",
+              href: "/onboarding?step=export-validation",
+              description: "Verify export generation as part of launch readiness.",
+            },
+            {
+              title: "Deployment coverage",
+              href: "/deployment",
+              description: "Track market-level operational readiness before broader rollout.",
+            },
+          ]}
+        />
+      </div>
     </MainLayout>
   );
 }

--- a/frontend/app/help/page.tsx
+++ b/frontend/app/help/page.tsx
@@ -1,0 +1,25 @@
+import MainLayout from "@/components/MainLayout";
+import DocumentationCenter from "@/components/commercial/DocumentationCenter";
+import RelatedDocsPanel from "@/components/commercial/RelatedDocsPanel";
+
+export default function HelpPage() {
+  const docs = [
+    { title: "Onboarding setup guide", href: "/onboarding", description: "Step-by-step launch checklist and blockers." },
+    { title: "Incident operations", href: "/incidents", description: "Queue management, response tracking, and evidence coverage." },
+    { title: "Export package details", href: "/exports", description: "Audit history, package manifests, and legal-ready delivery." },
+  ];
+
+  return (
+    <MainLayout title="Help Center">
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <DocumentationCenter docs={docs} />
+        <RelatedDocsPanel
+          docs={[
+            { title: "Trust center", href: "/trust", description: "Security and compliance posture details." },
+            { title: "Deployment coverage", href: "/deployment", description: "Market expansion and rollout readiness." },
+          ]}
+        />
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/app/incidents/page.tsx
+++ b/frontend/app/incidents/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import MainLayout from "@/components/MainLayout";
+import DocumentationCenter from "@/components/commercial/DocumentationCenter";
 import { listIncidents, type Incident } from "@/lib/api";
 import { useAuth } from "@/lib/useAuth";
 
@@ -201,6 +202,29 @@ export default function IncidentsPage() {
           </table>
         </div>
       )}
+
+      <div className="mt-4">
+        <DocumentationCenter
+          title="Incident workflow help"
+          docs={[
+            {
+              title: "Onboarding readiness",
+              href: "/onboarding",
+              description: "Use launch checklist status to identify unresolved setup blockers.",
+            },
+            {
+              title: "Export handoff",
+              href: "/exports",
+              description: "Review package completeness and legal download audit before sharing.",
+            },
+            {
+              title: "Trust center",
+              href: "/trust",
+              description: "Reference security and compliance controls used for evidence handling.",
+            },
+          ]}
+        />
+      </div>
     </MainLayout>
   );
 }

--- a/frontend/app/onboarding/OnboardingWizardClient.tsx
+++ b/frontend/app/onboarding/OnboardingWizardClient.tsx
@@ -9,6 +9,8 @@ import {
   type OrgLaunchReadiness,
   type OnboardingStepStatus,
 } from "@/lib/api";
+import DemoTenantBanner from "@/components/commercial/DemoTenantBanner";
+import RelatedDocsPanel from "@/components/commercial/RelatedDocsPanel";
 import { ONBOARDING_WIZARD_STORAGE_KEY } from "@/lib/onboarding";
 
 type WizardStep = {
@@ -176,6 +178,7 @@ export default function OnboardingWizardClient() {
   return (
     <MainLayout title="Onboarding Wizard">
       <div className="space-y-4">
+        <DemoTenantBanner tenantName="Org onboarding workspace" mode="Pilot" />
         <header className="space-y-2">
           <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">Launch onboarding wizard</h2>
           <p className="text-sm text-gray-600 dark:text-gray-400">
@@ -287,6 +290,26 @@ export default function OnboardingWizardClient() {
             </div>
           </section>
         </div>
+
+        <RelatedDocsPanel
+          docs={[
+            {
+              title: "Integration setup",
+              href: "/onboarding/integration-setup",
+              description: "Resolve connectivity and validation failures for data sources.",
+            },
+            {
+              title: "QR deployment",
+              href: "/onboarding/qr-deployment",
+              description: "Track distribution coverage and assignment gaps by vehicle.",
+            },
+            {
+              title: "Sample incident validation",
+              href: "/onboarding/sample-incident-validation",
+              description: "Run a dry-run workflow before launch readiness sign-off.",
+            },
+          ]}
+        />
       </div>
     </MainLayout>
   );

--- a/frontend/app/reports/page.tsx
+++ b/frontend/app/reports/page.tsx
@@ -1,0 +1,20 @@
+import MainLayout from "@/components/MainLayout";
+import CommercialSummaryCards from "@/components/commercial/CommercialSummaryCards";
+
+export default function ReportsPage() {
+  return (
+    <MainLayout title="Commercial Reports">
+      <div className="space-y-4">
+        <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">Commercial performance reports</h2>
+        <CommercialSummaryCards
+          items={[
+            { label: "Active tenants", value: "48", detail: "+6 from last quarter" },
+            { label: "Pilot conversions", value: "73%", detail: "12-month rolling average" },
+            { label: "Expansion-ready markets", value: "5", detail: "2 blocked by protocol gaps" },
+            { label: "Support SLA attainment", value: "99.4%", detail: "Last 30 days" },
+          ]}
+        />
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/app/trust/page.tsx
+++ b/frontend/app/trust/page.tsx
@@ -1,0 +1,29 @@
+import MainLayout from "@/components/MainLayout";
+import TrustSectionCard from "@/components/commercial/TrustSectionCard";
+
+export default function TrustPage() {
+  return (
+    <MainLayout title="Trust Center">
+      <div className="grid gap-4 md:grid-cols-2">
+        <TrustSectionCard
+          title="Security controls"
+          summary="Operational controls designed for legal and safety workflows."
+          highlights={[
+            "Role-based access control across operations and administration surfaces.",
+            "Immutable export audit trail with event-level timestamps.",
+            "Scoped production and sandbox tenant isolation.",
+          ]}
+        />
+        <TrustSectionCard
+          title="Compliance evidence"
+          summary="Artifacts and runbooks used by internal and customer compliance teams."
+          highlights={[
+            "Incident evidence retention policies aligned with export obligations.",
+            "Onboarding readiness checkpoints with blocker ownership.",
+            "Documented deployment SOPs for phased market launches.",
+          ]}
+        />
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/components/MainLayout.tsx
+++ b/frontend/components/MainLayout.tsx
@@ -130,6 +130,12 @@ export default function MainLayout({ title, children }: MainLayoutProps) {
           activePrefixes: ["/admin/vehicles"],
           hidden: !canManageQr,
         },
+        {
+          href: "/admin/plan-features",
+          label: "Plan & Features",
+          activePrefixes: ["/admin/plan-features"],
+          hidden: !hasRoleCapability(user.role, "user_management:write"),
+        },
       ],
     },
   ];

--- a/frontend/components/commercial/CommercialSummaryCards.tsx
+++ b/frontend/components/commercial/CommercialSummaryCards.tsx
@@ -1,0 +1,23 @@
+interface SummaryItem {
+  label: string;
+  value: string;
+  detail?: string;
+}
+
+interface CommercialSummaryCardsProps {
+  items: SummaryItem[];
+}
+
+export default function CommercialSummaryCards({ items }: CommercialSummaryCardsProps) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      {items.map((item) => (
+        <article key={item.label} className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <p className="text-xs uppercase tracking-wide text-gray-500">{item.label}</p>
+          <p className="mt-1 text-xl font-semibold text-gray-900 dark:text-white">{item.value}</p>
+          {item.detail ? <p className="mt-1 text-xs text-gray-600 dark:text-gray-300">{item.detail}</p> : null}
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/commercial/DemoScenarioLauncher.tsx
+++ b/frontend/components/commercial/DemoScenarioLauncher.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+
+interface DemoScenario {
+  id: string;
+  label: string;
+  description: string;
+  enabled?: boolean;
+}
+
+interface DemoScenarioLauncherProps {
+  scenarios: DemoScenario[];
+}
+
+export default function DemoScenarioLauncher({ scenarios }: DemoScenarioLauncherProps) {
+  const defaultScenario = scenarios.find((scenario) => scenario.enabled !== false)?.id ?? "";
+  const [selected, setSelected] = useState(defaultScenario);
+
+  const current = scenarios.find((scenario) => scenario.id === selected);
+  const available = Boolean(current && current.enabled !== false);
+
+  return (
+    <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <h3 className="text-base font-semibold text-gray-900 dark:text-white">Demo scenario launcher</h3>
+      <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+        Preview tenant behavior for onboarding, incident response, and exports.
+      </p>
+
+      <div className="mt-3 space-y-3">
+        <select
+          value={selected}
+          onChange={(event) => setSelected(event.target.value)}
+          className="w-full rounded border px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
+        >
+          {scenarios.map((scenario) => (
+            <option key={scenario.id} value={scenario.id}>
+              {scenario.label}
+            </option>
+          ))}
+        </select>
+
+        <p className="text-sm text-gray-600 dark:text-gray-300">{current?.description ?? "Select a scenario."}</p>
+
+        <button
+          type="button"
+          disabled={!available}
+          className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+          aria-disabled={!available}
+          title={available ? "Launch selected scenario" : "This scenario is currently unavailable."}
+        >
+          {available ? "Launch scenario" : "Scenario unavailable"}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/commercial/DemoTenantBanner.tsx
+++ b/frontend/components/commercial/DemoTenantBanner.tsx
@@ -1,0 +1,15 @@
+interface DemoTenantBannerProps {
+  tenantName: string;
+  mode: "Sandbox" | "Pilot";
+}
+
+export default function DemoTenantBanner({ tenantName, mode }: DemoTenantBannerProps) {
+  return (
+    <div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-200">
+      <p className="font-semibold">{tenantName} demo tenant</p>
+      <p>
+        Environment mode: <span className="font-medium">{mode}</span>. Actions in this workspace are non-production.
+      </p>
+    </div>
+  );
+}

--- a/frontend/components/commercial/DeploymentCoverageCard.tsx
+++ b/frontend/components/commercial/DeploymentCoverageCard.tsx
@@ -1,0 +1,16 @@
+interface DeploymentCoverageCardProps {
+  region: string;
+  coveragePercent: number;
+  gapCount: number;
+}
+
+export default function DeploymentCoverageCard({ region, coveragePercent, gapCount }: DeploymentCoverageCardProps) {
+  return (
+    <article className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <p className="text-sm font-medium text-gray-600 dark:text-gray-300">{region}</p>
+      <p className="mt-1 text-2xl font-semibold text-gray-900 dark:text-white">{coveragePercent}%</p>
+      <p className="text-xs text-gray-500">Fleet QR + protocol deployment coverage</p>
+      <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">Open coverage gaps: {gapCount}</p>
+    </article>
+  );
+}

--- a/frontend/components/commercial/DocumentationCenter.tsx
+++ b/frontend/components/commercial/DocumentationCenter.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+
+export interface DocumentationLink {
+  title: string;
+  href: string;
+  description: string;
+}
+
+interface DocumentationCenterProps {
+  title?: string;
+  docs: DocumentationLink[];
+}
+
+export default function DocumentationCenter({ title = "Documentation center", docs }: DocumentationCenterProps) {
+  return (
+    <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <h3 className="text-base font-semibold text-gray-900 dark:text-white">{title}</h3>
+      <ul className="mt-3 space-y-2">
+        {docs.map((doc) => (
+          <li key={doc.href} className="rounded border p-3 dark:border-gray-700">
+            <Link href={doc.href} className="font-medium text-blue-600 hover:underline dark:text-blue-400">
+              {doc.title}
+            </Link>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">{doc.description}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/components/commercial/ExpansionReadinessBanner.tsx
+++ b/frontend/components/commercial/ExpansionReadinessBanner.tsx
@@ -1,0 +1,15 @@
+interface ExpansionReadinessBannerProps {
+  readyMarkets: number;
+  blockedMarkets: number;
+}
+
+export default function ExpansionReadinessBanner({ readyMarkets, blockedMarkets }: ExpansionReadinessBannerProps) {
+  return (
+    <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-200">
+      <p className="font-semibold">Expansion readiness snapshot</p>
+      <p>
+        {readyMarkets} markets ready to launch. {blockedMarkets} markets need blocker remediation.
+      </p>
+    </div>
+  );
+}

--- a/frontend/components/commercial/FeatureGate.tsx
+++ b/frontend/components/commercial/FeatureGate.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import PlanBadge from "./PlanBadge";
+
+interface FeatureGateProps {
+  available: boolean;
+  mode?: "hide" | "lock";
+  reason?: string;
+  requiredPlan?: "Starter" | "Growth" | "Enterprise";
+  children: ReactNode;
+}
+
+export default function FeatureGate({
+  available,
+  mode = "lock",
+  reason = "Not available for your current plan.",
+  requiredPlan,
+  children,
+}: FeatureGateProps) {
+  if (available) return <>{children}</>;
+  if (mode === "hide") return null;
+
+  return (
+    <div className="space-y-2 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900/50">
+      <div className="flex flex-wrap items-center gap-2 text-sm text-gray-700 dark:text-gray-200">
+        <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700">
+          Locked
+        </span>
+        {requiredPlan ? <PlanBadge plan={requiredPlan} /> : null}
+      </div>
+      <p className="text-sm text-gray-600 dark:text-gray-300">{reason}</p>
+      <div
+        className="pointer-events-none select-none rounded-md opacity-60"
+        aria-disabled="true"
+        title={reason}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/commercial/PlanBadge.tsx
+++ b/frontend/components/commercial/PlanBadge.tsx
@@ -1,0 +1,17 @@
+interface PlanBadgeProps {
+  plan: "Starter" | "Growth" | "Enterprise";
+}
+
+const PLAN_STYLES: Record<PlanBadgeProps["plan"], string> = {
+  Starter: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200",
+  Growth: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-200",
+  Enterprise: "bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-200",
+};
+
+export default function PlanBadge({ plan }: PlanBadgeProps) {
+  return (
+    <span className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${PLAN_STYLES[plan]}`}>
+      {plan}
+    </span>
+  );
+}

--- a/frontend/components/commercial/RelatedDocsPanel.tsx
+++ b/frontend/components/commercial/RelatedDocsPanel.tsx
@@ -1,0 +1,13 @@
+import DocumentationCenter, { type DocumentationLink } from "./DocumentationCenter";
+
+interface RelatedDocsPanelProps {
+  docs: DocumentationLink[];
+}
+
+export default function RelatedDocsPanel({ docs }: RelatedDocsPanelProps) {
+  return (
+    <aside>
+      <DocumentationCenter title="Related docs" docs={docs} />
+    </aside>
+  );
+}

--- a/frontend/components/commercial/TrustSectionCard.tsx
+++ b/frontend/components/commercial/TrustSectionCard.tsx
@@ -1,0 +1,19 @@
+interface TrustSectionCardProps {
+  title: string;
+  summary: string;
+  highlights: string[];
+}
+
+export default function TrustSectionCard({ title, summary, highlights }: TrustSectionCardProps) {
+  return (
+    <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <h3 className="text-base font-semibold text-gray-900 dark:text-white">{title}</h3>
+      <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">{summary}</p>
+      <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-gray-700 dark:text-gray-200">
+        {highlights.map((highlight) => (
+          <li key={highlight}>{highlight}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide internal/commercial surfaces (demo, help, trust, deployment, reports) and an admin plan/features page to support org/internal admin workflows.
- Create reusable UI primitives for commercial features and plan gating so unavailable features are either hidden or shown as locked (no dead controls).

### Description
- Added new pages: `frontend/app/demo/page.tsx`, `frontend/app/help/page.tsx`, `frontend/app/trust/page.tsx`, `frontend/app/deployment/page.tsx`, and `frontend/app/reports/page.tsx` wired to `MainLayout` and new commercial components.
- Added admin-only route `frontend/app/admin/plan-features/page.tsx` and added a gated "Plan & Features" nav item in `frontend/components/MainLayout.tsx` that is visible to roles with `user_management:write` capability.
- Introduced reusable components under `frontend/components/commercial/`: `FeatureGate`, `PlanBadge`, `DemoScenarioLauncher`, `DemoTenantBanner`, `DocumentationCenter`, `RelatedDocsPanel`, `TrustSectionCard`, `DeploymentCoverageCard`, `ExpansionReadinessBanner`, and `CommercialSummaryCards` for consistent UI and plan-aware UX.
- Integrated contextual help and demos into onboarding, incidents, and exports pages using `DemoTenantBanner`, `DocumentationCenter`, and `RelatedDocsPanel`, and used `FeatureGate` to hide or lock enterprise-only controls (disabled buttons and explanatory messaging) to avoid dead controls.

### Testing
- Ran lint: `npm run lint` — succeeded.
- Ran typecheck: `npm run typecheck` (`tsc --noEmit`) — succeeded.
- Ran unit/smoke tests: `npm test` — all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58fab43c8832189b0d0847eca9b56)