### PR TITLE
Add commercial capability model and enforce route authorization

### DIFF
--- a/backend/app/api/routes/routes_deployment.py
+++ b/backend/app/api/routes/routes_deployment.py
@@ -37,7 +37,7 @@ def _first_org_id(user_context) -> uuid.UUID:
 
 
 def _require_deployment_access(user: User, *, write: bool = False) -> None:
-    capability = Capability.ONBOARDING_WRITE if write else Capability.READINESS_VIEW
+    capability = Capability.DEPLOYMENT_SCOPE_MANAGE if write else Capability.READINESS_VIEW
     if not has_capability(user.role, capability):
         raise_api_error(
             status_code=403,

--- a/backend/app/api/routes/routes_entitlements.py
+++ b/backend/app/api/routes/routes_entitlements.py
@@ -15,7 +15,7 @@ from app.commercial.enforcement import (
     is_internal_override_actor,
     resolve_org_access_snapshot,
 )
-from app.core.deps import get_current_user, require_user_role
+from app.core.deps import get_current_user
 from app.db.models import User
 from app.db.repo.org_content import (
     get_org_plan_entitlement,
@@ -23,16 +23,9 @@ from app.db.repo.org_content import (
 )
 from app.db.session import get_db
 from app.security.authn import build_user_auth_context
+from app.security.permissions import Capability, has_capability
 
 router = APIRouter(prefix="/org", tags=["org-entitlements"])
-
-_org_entitlement_mutator = require_user_role(
-    "system_admin",
-    "org_admin",
-    "support_admin",
-    "support_agent",
-)
-
 
 class OrgPlanResponse(BaseModel):
     org_id: uuid.UUID
@@ -152,8 +145,13 @@ def get_org_entitlements(
 def patch_org_entitlements(
     payload: OrgEntitlementPatchRequest,
     db: Session = Depends(get_db),
-    current_user: User = Depends(_org_entitlement_mutator),
+    current_user: User = Depends(get_current_user),
 ):
+    if not has_capability(current_user.role, Capability.ENTITLEMENTS_MANAGE):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Insufficient permissions",
+        )
     org_id, _ = _resolve_org_context(db, current_user)
     existing = get_org_plan_entitlement(db, org_id)
     if existing is None:

--- a/backend/app/api/routes/routes_reporting.py
+++ b/backend/app/api/routes/routes_reporting.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.api.schemas import (
@@ -30,6 +30,7 @@ from app.core.deps import require_workspace_view_permission
 from app.db.models import User
 from app.db.session import get_db
 from app.security.authn import build_user_auth_context
+from app.security.permissions import Capability, has_capability
 
 router = APIRouter(prefix="/org/reports", tags=["reporting"])
 
@@ -41,6 +42,17 @@ def _require_report_access(
     current_user: User,
     feature_key: str,
 ) -> None:
+    if not has_capability(current_user.role, Capability.REPORTING_BASIC_READ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Insufficient permission to access reporting",
+        )
+    if feature_key in PREMIUM_REPORTING_FEATURES or feature_key in FUTURE_REPORTING_FEATURES:
+        if not has_capability(current_user.role, Capability.REPORTING_PREMIUM_READ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Insufficient permission for premium reporting",
+            )
     require_feature_enabled(
         db,
         org_id=org_id,

--- a/backend/app/api/routes/routes_trust.py
+++ b/backend/app/api/routes/routes_trust.py
@@ -19,15 +19,13 @@ from app.commercial.trust import (
     unpublish_trust_section,
     upsert_trust_section,
 )
-from app.core.deps import get_current_user, require_user_role
+from app.core.deps import get_current_user
 from app.db.models import TrustSection, User
 from app.db.session import get_db
 from app.security.authn import build_user_auth_context
+from app.security.permissions import Capability, has_capability
 
 router = APIRouter(prefix="/trust", tags=["trust"])
-
-_internal_trust_admin = require_user_role("system_admin", "support_admin")
-
 
 class TrustSectionItem(BaseModel):
     section_id: str
@@ -84,6 +82,14 @@ def _serialize_section(section: TrustSection) -> TrustSectionItem:
     )
 
 
+def _require_internal_publish_capability(current_user: User) -> None:
+    if not has_capability(current_user.role, Capability.TRUST_DOCS_PUBLISH):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Insufficient permissions",
+        )
+
+
 @router.get("/sections", response_model=list[TrustSectionItem])
 def get_sections(
     publication_state: Literal["published", "draft", "all"] = Query(default=PUBLICATION_STATE_PUBLISHED),
@@ -118,8 +124,9 @@ def get_summary(
 def put_internal_section(
     payload: TrustSectionUpsertRequest,
     db: Session = Depends(get_db),
-    current_user: User = Depends(_internal_trust_admin),
+    current_user: User = Depends(get_current_user),
 ):
+    _require_internal_publish_capability(current_user)
     org_id = _resolve_org_id(db, current_user)
     row = upsert_trust_section(
         db,
@@ -140,8 +147,9 @@ def put_internal_section(
 def post_publish_section(
     section_id: uuid.UUID,
     db: Session = Depends(get_db),
-    current_user: User = Depends(_internal_trust_admin),
+    current_user: User = Depends(get_current_user),
 ):
+    _require_internal_publish_capability(current_user)
     org_id = _resolve_org_id(db, current_user)
     try:
         row = publish_trust_section(
@@ -160,8 +168,9 @@ def post_publish_section(
 def post_unpublish_section(
     section_id: uuid.UUID,
     db: Session = Depends(get_db),
-    current_user: User = Depends(_internal_trust_admin),
+    current_user: User = Depends(get_current_user),
 ):
+    _require_internal_publish_capability(current_user)
     org_id = _resolve_org_id(db, current_user)
     try:
         row = unpublish_trust_section(

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -87,6 +87,12 @@ CapabilityName = Literal[
     "test_runs:read",
     "test_runs:write",
     "readiness:view",
+    "demo:manage",
+    "entitlements:manage",
+    "trust_docs:publish",
+    "deployment_scope:manage",
+    "reporting:basic_read",
+    "reporting:premium_read",
 ]
 assert {
     "system_admin",
@@ -121,6 +127,12 @@ assert set(ALL_RECOMMENDED_CAPABILITIES) == {
     "test_runs:read",
     "test_runs:write",
     "readiness:view",
+    "demo:manage",
+    "entitlements:manage",
+    "trust_docs:publish",
+    "deployment_scope:manage",
+    "reporting:basic_read",
+    "reporting:premium_read",
 }
 InstructionScope = Literal["default", "company", "insurer"]
 IncidentSeverity = Literal["minor", "serious", "critical"]

--- a/backend/app/commercial/docs.py
+++ b/backend/app/commercial/docs.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from app.audit.emitter import emit_audit_event
 from app.db.models import HelpArticle, HelpCategory
+from app.security.permissions import Capability, has_capability
 
 DOCS_FEATURES: tuple[str, ...] = (
     "docs.playbooks",
@@ -25,11 +26,8 @@ _VALID_PUBLICATION_STATES = {
     PUBLICATION_STATE_ALL,
 }
 
-_INTERNAL_DOCS_ROLES = {"system_admin", "support_admin", "support_agent"}
-
-
 def _is_internal_docs_actor(role: str | None) -> bool:
-    return (role or "").strip().lower() in _INTERNAL_DOCS_ROLES
+    return has_capability(role, Capability.TRUST_DOCS_PUBLISH)
 
 
 def _normalize_publication_state(publication_state: str) -> str:

--- a/backend/app/commercial/trust.py
+++ b/backend/app/commercial/trust.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from app.audit.emitter import emit_audit_event
 from app.db.models import TrustSection
+from app.security.permissions import Capability, has_capability
 
 DeploymentScope = Literal[
     "single_site",
@@ -45,9 +46,6 @@ _VALID_PUBLICATION_STATES = {
     PUBLICATION_STATE_ALL,
 }
 
-_INTERNAL_TRUST_ROLES = {"system_admin", "support_admin"}
-
-
 def _normalize_publication_state(publication_state: str) -> str:
     normalized = (publication_state or PUBLICATION_STATE_PUBLISHED).strip().lower()
     if normalized not in _VALID_PUBLICATION_STATES:
@@ -56,7 +54,7 @@ def _normalize_publication_state(publication_state: str) -> str:
 
 
 def _is_internal_trust_actor(role: str | None) -> bool:
-    return (role or "").strip().lower() in _INTERNAL_TRUST_ROLES
+    return has_capability(role, Capability.TRUST_DOCS_PUBLISH)
 
 
 def _matches_audience(metadata: dict | None, audience: str | None) -> bool:

--- a/backend/app/security/permissions.py
+++ b/backend/app/security/permissions.py
@@ -40,6 +40,12 @@ class Capability(str, Enum):
     TEST_RUNS_READ = "test_runs:read"
     TEST_RUNS_WRITE = "test_runs:write"
     READINESS_VIEW = "readiness:view"
+    DEMO_MANAGE = "demo:manage"
+    ENTITLEMENTS_MANAGE = "entitlements:manage"
+    TRUST_DOCS_PUBLISH = "trust_docs:publish"
+    DEPLOYMENT_SCOPE_MANAGE = "deployment_scope:manage"
+    REPORTING_BASIC_READ = "reporting:basic_read"
+    REPORTING_PREMIUM_READ = "reporting:premium_read"
 
 
 CANONICAL_ROLES: tuple[str, ...] = tuple(role.value for role in Role)
@@ -68,14 +74,49 @@ _ROLE_ALIASES: dict[str, Role] = {
     "readonly": Role.READ_ONLY,
     "support_admin": Role.SUPPORT_ADMIN,
     "support admin": Role.SUPPORT_ADMIN,
+    "support-admin": Role.SUPPORT_ADMIN,
+    "supportadministrator": Role.SUPPORT_ADMIN,
     "support-agent": Role.SUPPORT_AGENT,
     "support_agent": Role.SUPPORT_AGENT,
     "support agent": Role.SUPPORT_AGENT,
+    "supportagent": Role.SUPPORT_AGENT,
+    "support": Role.SUPPORT_AGENT,
 }
 
 ROLE_CAPABILITIES: dict[Role, frozenset[Capability]] = {
     Role.SYSTEM_ADMIN: frozenset(Capability),
-    Role.ORG_ADMIN: frozenset(Capability),
+    Role.ORG_ADMIN: frozenset(
+        {
+            Capability.INCIDENT_READ,
+            Capability.INCIDENT_WRITE,
+            Capability.INCIDENT_CLOSE,
+            Capability.INCIDENT_REOPEN,
+            Capability.INCIDENT_ESCALATE,
+            Capability.EXPORT_READ,
+            Capability.EXPORT_WRITE,
+            Capability.DRIVER_PROTOCOL_READ,
+            Capability.DRIVER_PROTOCOL_WRITE,
+            Capability.VEHICLE_QR_READ,
+            Capability.VEHICLE_QR_WRITE,
+            Capability.ORG_SETTINGS_READ,
+            Capability.ORG_SETTINGS_WRITE,
+            Capability.USER_MANAGEMENT_READ,
+            Capability.USER_MANAGEMENT_WRITE,
+            Capability.IMPORTS_READ,
+            Capability.IMPORTS_WRITE,
+            Capability.INTEGRATIONS_READ,
+            Capability.INTEGRATIONS_WRITE,
+            Capability.ONBOARDING_READ,
+            Capability.ONBOARDING_WRITE,
+            Capability.TEST_RUNS_READ,
+            Capability.TEST_RUNS_WRITE,
+            Capability.READINESS_VIEW,
+            Capability.ENTITLEMENTS_MANAGE,
+            Capability.DEPLOYMENT_SCOPE_MANAGE,
+            Capability.REPORTING_BASIC_READ,
+            Capability.REPORTING_PREMIUM_READ,
+        }
+    ),
     Role.SAFETY_MANAGER: frozenset(
         {
             Capability.INCIDENT_READ,
@@ -94,6 +135,9 @@ ROLE_CAPABILITIES: dict[Role, frozenset[Capability]] = {
             Capability.TEST_RUNS_READ,
             Capability.TEST_RUNS_WRITE,
             Capability.READINESS_VIEW,
+            Capability.DEPLOYMENT_SCOPE_MANAGE,
+            Capability.REPORTING_BASIC_READ,
+            Capability.REPORTING_PREMIUM_READ,
         }
     ),
     Role.CLAIMS_USER: frozenset(
@@ -103,6 +147,8 @@ ROLE_CAPABILITIES: dict[Role, frozenset[Capability]] = {
             Capability.EXPORT_READ,
             Capability.EXPORT_WRITE,
             Capability.READINESS_VIEW,
+            Capability.REPORTING_BASIC_READ,
+            Capability.REPORTING_PREMIUM_READ,
         }
     ),
     Role.READ_ONLY: frozenset(
@@ -117,6 +163,7 @@ ROLE_CAPABILITIES: dict[Role, frozenset[Capability]] = {
             Capability.ORG_SETTINGS_READ,
             Capability.USER_MANAGEMENT_READ,
             Capability.READINESS_VIEW,
+            Capability.REPORTING_BASIC_READ,
         }
     ),
     Role.SUPPORT_ADMIN: frozenset(
@@ -139,6 +186,12 @@ ROLE_CAPABILITIES: dict[Role, frozenset[Capability]] = {
             Capability.TEST_RUNS_READ,
             Capability.TEST_RUNS_WRITE,
             Capability.READINESS_VIEW,
+            Capability.DEMO_MANAGE,
+            Capability.ENTITLEMENTS_MANAGE,
+            Capability.TRUST_DOCS_PUBLISH,
+            Capability.DEPLOYMENT_SCOPE_MANAGE,
+            Capability.REPORTING_BASIC_READ,
+            Capability.REPORTING_PREMIUM_READ,
         }
     ),
     Role.SUPPORT_AGENT: frozenset(
@@ -153,6 +206,9 @@ ROLE_CAPABILITIES: dict[Role, frozenset[Capability]] = {
             Capability.ONBOARDING_READ,
             Capability.TEST_RUNS_READ,
             Capability.READINESS_VIEW,
+            Capability.ENTITLEMENTS_MANAGE,
+            Capability.TRUST_DOCS_PUBLISH,
+            Capability.REPORTING_BASIC_READ,
         }
     ),
 }
@@ -176,12 +232,6 @@ def has_capability(raw_role: str | None, capability: Capability | str) -> bool:
     return resolved in get_user_capabilities(raw_role)
 
 
-DEMO_MUTATION_ALLOWED_ROLES: frozenset[Role] = frozenset({
-    Role.SYSTEM_ADMIN,
-    Role.SUPPORT_ADMIN,
-})
-
-
 def can_mutate_demo_tenant(raw_role: str | None) -> bool:
     """Return whether the provided role can mutate demo tenant state."""
-    return normalize_role(raw_role) in DEMO_MUTATION_ALLOWED_ROLES
+    return has_capability(raw_role, Capability.DEMO_MANAGE)

--- a/backend/tests/test_deployment_scope_routes.py
+++ b/backend/tests/test_deployment_scope_routes.py
@@ -110,6 +110,23 @@ def auth_headers(seeded_org):
     return {"Authorization": f"Bearer {token}"}
 
 
+@pytest.fixture()
+def read_only_headers(db_session, seeded_org):
+    org, _ = seeded_org
+    user = User(
+        email="readonly-expansion@example.com",
+        password_hash=hash_password("testpass"),
+        role="read_only",
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    db_session.add(UserOrg(user_id=user.id, org_id=org.id))
+    db_session.commit()
+    token = create_access_token({"sub": str(user.id), "role": user.role})
+    return {"Authorization": f"Bearer {token}"}
+
+
 def test_deployment_scope_crud_and_progress_routes(client, auth_headers):
     get_scope = client.get("/org/deployment-scope", headers=auth_headers)
     assert get_scope.status_code == 200
@@ -149,3 +166,12 @@ def test_deployment_scope_crud_and_progress_routes(client, auth_headers):
     assert readiness.status_code == 200
     assert readiness.json()["status"] == "planning"
     assert readiness.json()["override_applied"] is True
+
+
+def test_read_only_cannot_mutate_deployment_scope(client, read_only_headers):
+    response = client.patch(
+        "/org/deployment-scope",
+        json={"scope": "partial_rollout"},
+        headers=read_only_headers,
+    )
+    assert response.status_code == 403

--- a/backend/tests/test_entitlements_routes.py
+++ b/backend/tests/test_entitlements_routes.py
@@ -70,6 +70,13 @@ def support_admin_user(db_session, test_org):
 
 
 @pytest.fixture()
+def support_agent_user(db_session, test_org):
+    return _create_user(
+        db_session, test_org, role="support_agent", email="support-agent@example.com"
+    )
+
+
+@pytest.fixture()
 def client(db_session):
     def _override():
         try:
@@ -184,3 +191,12 @@ def test_patch_entitlements_internal_override_writes_audit_metadata(
     metadata = feature_event.metadata_json or {}
     assert metadata["internal_override"]["applied"] is True
     assert metadata["internal_override"]["actor_role"] == "support_admin"
+
+
+def test_patch_entitlements_allows_support_agent_capability(client, support_agent_user):
+    resp = client.patch(
+        "/org/entitlements",
+        headers=_auth_headers(support_agent_user),
+        json={"entitlements": {"reporting.dashboard": True}},
+    )
+    assert resp.status_code == 200

--- a/backend/tests/test_permissions_role_mapping.py
+++ b/backend/tests/test_permissions_role_mapping.py
@@ -1,6 +1,11 @@
 """Tests for role-to-capability mapping."""
 
-from app.security.permissions import Capability, can_mutate_demo_tenant, get_user_capabilities
+from app.security.permissions import (
+    Capability,
+    can_mutate_demo_tenant,
+    get_user_capabilities,
+    has_capability,
+)
 
 
 def test_claims_user_capabilities_include_incident_write_and_export_write():
@@ -37,3 +42,14 @@ def test_only_internal_roles_can_mutate_demo_tenant():
     assert can_mutate_demo_tenant("system_admin") is True
     assert can_mutate_demo_tenant("support_admin") is True
     assert can_mutate_demo_tenant("org_admin") is False
+
+
+def test_support_agent_can_manage_entitlements_and_publish_docs_via_internal_aliases():
+    assert has_capability("support-agent", Capability.ENTITLEMENTS_MANAGE) is True
+    assert has_capability("support", Capability.TRUST_DOCS_PUBLISH) is True
+
+
+def test_reporting_tiers_split_between_read_only_and_support_admin():
+    assert has_capability("read_only", Capability.REPORTING_BASIC_READ) is True
+    assert has_capability("read_only", Capability.REPORTING_PREMIUM_READ) is False
+    assert has_capability("support_admin", Capability.REPORTING_PREMIUM_READ) is True

--- a/contracts/schemas/runtime_api_contracts.json
+++ b/contracts/schemas/runtime_api_contracts.json
@@ -1109,7 +1109,13 @@
               "onboarding:write",
               "test_runs:read",
               "test_runs:write",
-              "readiness:view"
+              "readiness:view",
+              "demo:manage",
+              "entitlements:manage",
+              "trust_docs:publish",
+              "deployment_scope:manage",
+              "reporting:basic_read",
+              "reporting:premium_read"
             ],
             "type": "string"
           },


### PR DESCRIPTION
### Motivation

- Introduce finer-grained commercial/security capabilities to support demo management, entitlement management, trust/docs publishing, deployment-scope management, and tiered reporting access. 
- Replace ad-hoc role checks with capability-driven authorization so route and service-level checks can rely on capabilities (and normalized role aliases) rather than fragile role string matching. 

### Description

- Added new capabilities to `Capability` (`demo:manage`, `entitlements:manage`, `trust_docs:publish`, `deployment_scope:manage`, `reporting:basic_read`, `reporting:premium_read`) and extended `ALL_RECOMMENDED_CAPABILITIES` and `CapabilityName` literals in `backend/app/api/schemas.py`. 
- Expanded `_ROLE_ALIASES` to recognize additional `support_*` variants and updated `ROLE_CAPABILITIES` to map new capabilities across `system_admin`, `org_admin`, `safety_manager`, `read_only`, `support_admin`, and `support_agent`. 
- Switched demo mutation check to capability-driven `can_mutate_demo_tenant` (now uses `has_capability(..., Capability.DEMO_MANAGE)`) and updated service-level internal actor checks in `app/commercial/docs.py` and `app/commercial/trust.py` to use `has_capability`. 
- Enforced capability checks on sensitive endpoints: `/org/entitlements` PATCH requires `entitlements:manage`, trust internal `PUT /trust/internal/sections` and publish/unpublish endpoints require `trust_docs:publish`, deployment-scope write requires `deployment_scope:manage`, and reporting endpoints enforce `reporting:basic_read` with premium features requiring `reporting:premium_read`. 
- Added/updated tests to cover new capability mappings, alias normalization, read-only vs mutation access for deployment scope, and support-agent entitlement access. 

### Testing

- Ran linting with `cd backend && pip install -q ruff && ruff check app/ tests/` which completed successfully. 
- Ran the focused pytest suite with `cd backend && pytest -q tests/test_permissions_role_mapping.py tests/test_demo_routes.py tests/test_trust_routes.py tests/test_entitlements_routes.py tests/test_deployment_scope_routes.py` and all tests passed (`18 passed`, with standard deprecation warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59202c2f4832182a99fc2d34a8144)