### PR TITLE
Add Section 21 Phase 7 acceptance coverage: routes, tests, QA script, and checklists

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,6 +27,7 @@ from app.api.routes.routes_help import router as help_router
 from app.api.routes.routes_reporting import router as reporting_router
 from app.api.routes.routes_trust import router as trust_router
 from app.api.routes.routes_deployment import router as deployment_router
+from app.api.routes.routes_webhooks import router as webhooks_router
 from app.api.routes_admin import router as admin_router
 from app.api.routes_twilio import router as twilio_router
 from app.health.routes import router as health_router
@@ -68,6 +69,7 @@ app.include_router(reporting_router)
 app.include_router(help_router)
 app.include_router(trust_router)
 app.include_router(deployment_router)
+app.include_router(webhooks_router, prefix="/webhooks/twilio", tags=["webhooks"])
 app.include_router(admin_router, prefix="/admin", tags=["admin"])
 app.include_router(twilio_router, prefix="/twilio", tags=["twilio"])
 app.include_router(onboarding_router)

--- a/backend/tests/test_section21_phase7_routes.py
+++ b/backend/tests/test_section21_phase7_routes.py
@@ -1,0 +1,288 @@
+"""Section 21 / Phase 7 route acceptance coverage."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.security import create_access_token, hash_password
+from app.db.models import (
+    Base,
+    Driver,
+    ExternalMapping,
+    Org,
+    OrgExportValidationRun,
+    OrgPlanEntitlement,
+    OrgTestIncidentRun,
+    OrgVehicleRegistry,
+    TrustSection,
+    User,
+    UserOrg,
+)
+from app.db.session import get_db
+from app.main import app
+
+
+@pytest.fixture()
+def db_session():
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    test_session = sessionmaker(bind=engine)
+    session = test_session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def seeded_org(db_session):
+    org = Org(name="Section 21 Acceptance Org")
+    db_session.add(org)
+    db_session.commit()
+    db_session.refresh(org)
+
+    def _make_user(email: str, role: str) -> User:
+        user = User(email=email, password_hash=hash_password("testpass"), role=role)
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+        db_session.add(UserOrg(user_id=user.id, org_id=org.id))
+        db_session.commit()
+        return user
+
+    users = {
+        "org_admin": _make_user("org-admin-section21@example.com", "org_admin"),
+        "support_admin": _make_user(
+            "support-admin-section21@example.com", "support_admin"
+        ),
+        "read_only": _make_user("readonly-section21@example.com", "read_only"),
+    }
+
+    db_session.add(
+        OrgPlanEntitlement(
+            org_id=org.id,
+            plan_code="enterprise",
+            entitlements_json={
+                "demo.workspace": True,
+                "demo.incident_seed": True,
+                "trust.audit_controls": True,
+            },
+        )
+    )
+
+    for i in range(2):
+        db_session.add(
+            OrgVehicleRegistry(
+                org_id=org.id,
+                unit_number=f"veh-{i}",
+                is_active=True,
+                qr_deployment_status="distributed",
+            )
+        )
+    for i in range(2):
+        db_session.add(
+            Driver(
+                org_id=org.id,
+                phone_e164=f"+1555111000{i}",
+                display_name=f"Driver {i}",
+                is_active=True,
+            )
+        )
+
+    db_session.add(
+        ExternalMapping(
+            org_id=org.id,
+            provider="samsara",
+            domain="fleet",
+            internal_entity_type="driver",
+            internal_entity_id="driver-1",
+            external_reference="ext-driver-1",
+        )
+    )
+    db_session.add(OrgTestIncidentRun(org_id=org.id, status="completed"))
+    db_session.add(OrgExportValidationRun(org_id=org.id, status="passed"))
+    db_session.add(
+        TrustSection(
+            org_id=org.id,
+            slug="security",
+            title="Security",
+            body_markdown="published security controls",
+            sort_order=1,
+            is_published=True,
+            metadata_json={"audiences": ["manager"]},
+        )
+    )
+    db_session.commit()
+    return org, users
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token({"sub": str(user.id), "role": user.role})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_section21_endpoint_authn_and_authz(client, seeded_org):
+    _, users = seeded_org
+
+    for method, path in [
+        ("get", "/org/entitlements"),
+        ("get", "/demo/scenarios"),
+        ("get", "/org/deployment-progress"),
+        ("get", "/trust/sections"),
+    ]:
+        response = getattr(client, method)(path)
+        assert response.status_code == 401
+
+    trust_internal_resp = client.put(
+        "/trust/internal/sections",
+        headers=_auth_headers(users["org_admin"]),
+        json={
+            "slug": "authz-denied",
+            "title": "Denied",
+            "body_markdown": "Should not be allowed",
+            "sort_order": 2,
+            "metadata": {},
+        },
+    )
+    assert trust_internal_resp.status_code == 403
+
+    deployment_patch_resp = client.patch(
+        "/org/deployment-scope",
+        headers=_auth_headers(users["read_only"]),
+        json={"scope": "pilot"},
+    )
+    assert deployment_patch_resp.status_code == 403
+
+
+def test_section21_entitlement_enforcement_hides_disabled_surfaces(
+    client, seeded_org, db_session
+):
+    org, users = seeded_org
+    row = (
+        db_session.query(OrgPlanEntitlement)
+        .filter(OrgPlanEntitlement.org_id == org.id)
+        .one()
+    )
+    row.plan_code = "starter"
+    row.entitlements_json = {
+        "demo.workspace": False,
+        "demo.incident_seed": False,
+        "trust.audit_controls": False,
+    }
+    db_session.commit()
+
+    demo_resp = client.get("/demo/scenarios", headers=_auth_headers(users["org_admin"]))
+    assert demo_resp.status_code == 404
+
+    trust_resp = client.get("/trust/sections", headers=_auth_headers(users["org_admin"]))
+    assert trust_resp.status_code == 404
+
+
+def test_section21_demo_reset_reseed_is_idempotent(client, seeded_org):
+    _, users = seeded_org
+    headers = _auth_headers(users["support_admin"])
+
+    first_seed = client.post(
+        "/demo/seed",
+        headers=headers,
+        json={"scenario_id": "driver_minor_collision"},
+    )
+    assert first_seed.status_code == 200
+
+    first_reset = client.post("/demo/reset", headers=headers)
+    assert first_reset.status_code == 200
+    deleted_first = first_reset.json()["deleted"]
+    assert all(count >= 0 for count in deleted_first.values())
+
+    second_seed = client.post(
+        "/demo/seed",
+        headers=headers,
+        json={"scenario_id": "driver_minor_collision"},
+    )
+    assert second_seed.status_code == 200
+
+    second_reset = client.post("/demo/reset", headers=headers)
+    assert second_reset.status_code == 200
+    deleted_second = second_reset.json()["deleted"]
+    assert set(deleted_second.keys()) == set(deleted_first.keys())
+
+
+def test_section21_deployment_progress_and_readiness_states(client, seeded_org):
+    _, users = seeded_org
+    headers = _auth_headers(users["org_admin"])
+
+    progress_resp = client.get("/org/deployment-progress", headers=headers)
+    assert progress_resp.status_code == 200
+    progress = progress_resp.json()
+    assert progress["scope"] == "pilot"
+    assert progress["percent_complete"] >= 0
+    assert isinstance(progress["coverage"], list)
+
+    readiness_resp = client.get("/org/expansion-readiness", headers=headers)
+    assert readiness_resp.status_code == 200
+    readiness = readiness_resp.json()
+    assert readiness["status"] in {
+        "not_started",
+        "planning",
+        "pilot_ready",
+        "scale_ready",
+        "blocked",
+    }
+    assert isinstance(readiness["blockers"], list)
+
+
+def test_section21_trust_publication_visibility_filters(client, seeded_org, db_session):
+    org, users = seeded_org
+    db_session.add(
+        TrustSection(
+            org_id=org.id,
+            slug="draft-only",
+            title="Draft Only",
+            body_markdown="unpublished content",
+            sort_order=99,
+            is_published=False,
+            metadata_json={"audiences": ["manager"]},
+        )
+    )
+    db_session.commit()
+
+    headers = _auth_headers(users["org_admin"])
+
+    published_resp = client.get(
+        "/trust/sections",
+        headers=headers,
+        params={"publication_state": "published", "audience": "manager"},
+    )
+    assert published_resp.status_code == 200
+    published_slugs = [row["slug"] for row in published_resp.json()]
+    assert "security" in published_slugs
+    assert "draft-only" not in published_slugs
+
+    all_resp = client.get(
+        "/trust/sections",
+        headers=headers,
+        params={"publication_state": "all", "audience": "manager"},
+    )
+    assert all_resp.status_code == 200
+    all_slugs = [row["slug"] for row in all_resp.json()]
+    assert "draft-only" in all_slugs

--- a/docs/section-21-mvp-acceptance-checklist.md
+++ b/docs/section-21-mvp-acceptance-checklist.md
@@ -1,0 +1,41 @@
+# Section 21 MVP Acceptance Checklist
+
+This checklist maps Section 21 MVP criteria to executable tests and repeatable QA evidence.
+
+## MVP criteria (Section 21 MVP)
+
+- [ ] **MVP-21.1 Endpoint authentication coverage**
+  - Verify unauthenticated access to Section 21 routes returns `401`.
+  - Automated evidence: `backend/tests/test_section21_phase7_routes.py::test_section21_endpoint_authn_and_authz`.
+
+- [ ] **MVP-21.2 Endpoint authorization boundaries**
+  - Verify privileged routes reject insufficient roles (`403`).
+  - Automated evidence: `backend/tests/test_section21_phase7_routes.py::test_section21_endpoint_authn_and_authz`.
+
+- [ ] **MVP-21.3 Entitlement enforcement / hidden capability behavior**
+  - Verify disabled entitlements return non-disclosing feature-unavailable responses.
+  - Automated evidence: `backend/tests/test_section21_phase7_routes.py::test_section21_entitlement_enforcement_hides_disabled_surfaces`.
+
+- [ ] **MVP-21.4 Demo reset/reseed idempotency**
+  - Repeated `seed -> reset -> seed -> reset` flows succeed with stable response shape.
+  - Automated evidence: `backend/tests/test_section21_phase7_routes.py::test_section21_demo_reset_reseed_is_idempotent`.
+
+- [ ] **MVP-21.5 Deployment progress/readiness state contracts**
+  - Verify response shape and readiness status enum behavior remain stable.
+  - Automated evidence: `backend/tests/test_section21_phase7_routes.py::test_section21_deployment_progress_and_readiness_states`.
+
+- [ ] **MVP-21.6 Docs/trust publication visibility**
+  - Verify published-only views hide drafts while `publication_state=all` includes them.
+  - Automated evidence: `backend/tests/test_section21_phase7_routes.py::test_section21_trust_publication_visibility_filters`.
+
+- [ ] **MVP-21.7 Frontend feature gates and key page render states**
+  - Verify lock/hide feature-gate semantics and deployment/trust page baseline render states.
+  - Automated evidence:
+    - `frontend/tests/featureGating.test.mjs`
+    - `frontend/tests/keyPageRenderStates.test.mjs`
+
+## Repeatable QA execution
+
+- Run scripted acceptance helper: `bash scripts/run_section21_phase7_qa.sh all`.
+- Run backend verification: `cd backend && pytest tests/test_section21_phase7_routes.py -v`.
+- Run frontend verification: `cd frontend && npm test`.

--- a/docs/section-21-production-ready-acceptance-checklist.md
+++ b/docs/section-21-production-ready-acceptance-checklist.md
@@ -1,0 +1,41 @@
+# Section 21 Production-Ready Acceptance Checklist
+
+This checklist extends Section 21 MVP validation with release-grade operational proof for production onboarding.
+
+## Production-ready criteria (Section 21 PR)
+
+- [ ] **PR-21.1 Gate MVP criteria before promotion**
+  - All entries in `docs/section-21-mvp-acceptance-checklist.md` are complete.
+
+- [ ] **PR-21.2 Deterministic QA runbook execution**
+  - Execute `bash scripts/run_section21_phase7_qa.sh all` in staging.
+  - Record pass/fail plus timestamped operator notes.
+
+- [ ] **PR-21.3 Backend regression lock for Section 21 routes**
+  - Execute `cd backend && pytest tests/test_section21_phase7_routes.py -v`.
+  - Archive test output artifact in release evidence package.
+
+- [ ] **PR-21.4 Frontend regression lock for gating + page states**
+  - Execute `cd frontend && npm run lint && npm test`.
+  - Capture and archive output for release checklist traceability.
+
+- [ ] **PR-21.5 Routing integrity checks in app bootstrap**
+  - Confirm required Section 21 routers are registered in `backend/app/main.py`.
+  - Validate `/webhooks/twilio/*` callbacks and Section 21 route prefixes resolve in deployed environment.
+
+- [ ] **PR-21.6 Release decision evidence package**
+  - Include:
+    1. backend test run output,
+    2. frontend lint + test output,
+    3. QA script execution notes,
+    4. checklist completion sign-off.
+
+## Sign-off template
+
+- Environment:
+- Build/version:
+- Date:
+- Operator:
+- Reviewer:
+- Decision: `GO` / `NO-GO`
+- Notes / blockers:

--- a/frontend/tests/featureGating.test.mjs
+++ b/frontend/tests/featureGating.test.mjs
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const featureGateSource = readFileSync(new URL('../components/commercial/FeatureGate.tsx', import.meta.url), 'utf8');
+
+test('feature gate supports hide and lock modes with disabled affordance', () => {
+  assert.match(featureGateSource, /mode\?:\s*"hide"\s*\|\s*"lock"/);
+  assert.match(featureGateSource, /if \(mode === "hide"\) return null/);
+  assert.match(featureGateSource, /aria-disabled="true"/);
+  assert.match(featureGateSource, /Locked/);
+});

--- a/frontend/tests/keyPageRenderStates.test.mjs
+++ b/frontend/tests/keyPageRenderStates.test.mjs
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const deploymentPage = readFileSync(new URL('../app/deployment/page.tsx', import.meta.url), 'utf8');
+const trustPage = readFileSync(new URL('../app/trust/page.tsx', import.meta.url), 'utf8');
+
+test('deployment page renders readiness banner and region coverage cards', () => {
+  assert.match(deploymentPage, /MainLayout title="Deployment Coverage"/);
+  assert.match(deploymentPage, /ExpansionReadinessBanner/);
+  assert.match(deploymentPage, /DeploymentCoverageCard region="US West"/);
+  assert.match(deploymentPage, /DeploymentCoverageCard region="Canada"/);
+});
+
+test('trust page renders trust center layout and core trust sections', () => {
+  assert.match(trustPage, /MainLayout title="Trust Center"/);
+  assert.match(trustPage, /TrustSectionCard/);
+  assert.match(trustPage, /title="Security controls"/);
+  assert.match(trustPage, /title="Compliance evidence"/);
+});

--- a/scripts/run_section21_phase7_qa.sh
+++ b/scripts/run_section21_phase7_qa.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCENARIO="${1:-all}"
+
+cat <<'USAGE' >&2
+Section 21 (Phase 7) QA runbook helper.
+
+Usage:
+  bash scripts/run_section21_phase7_qa.sh <scenario>
+
+Scenarios:
+  endpoint_authn_authz
+  entitlement_enforcement
+  demo_reset_reseed_idempotency
+  deployment_progress_readiness
+  docs_trust_visibility
+  frontend_feature_gates
+  all
+USAGE
+
+print_step() {
+  local scenario_name="$1"
+  shift
+  if [[ "$SCENARIO" == "all" || "$SCENARIO" == "$scenario_name" ]]; then
+    echo
+    echo "=== ${scenario_name} ==="
+    "$@"
+  fi
+}
+
+endpoint_authn_authz() {
+  cat <<'EOF_STEP'
+1) Call /org/entitlements, /demo/scenarios, /org/deployment-progress, /trust/sections without auth.
+2) Confirm all responses are HTTP 401.
+3) Call /trust/internal/sections as org_admin and confirm HTTP 403.
+4) Patch /org/deployment-scope as read_only role and confirm HTTP 403.
+Reference test: backend/tests/test_section21_phase7_routes.py::test_section21_endpoint_authn_and_authz
+EOF_STEP
+}
+
+entitlement_enforcement() {
+  cat <<'EOF_STEP'
+1) Set org entitlements for demo.workspace, demo.incident_seed, trust.audit_controls to false.
+2) Call /demo/scenarios and /trust/sections as authenticated org_admin.
+3) Confirm both responses are HTTP 404 (feature unavailable / hidden surface).
+Reference test: backend/tests/test_section21_phase7_routes.py::test_section21_entitlement_enforcement_hides_disabled_surfaces
+EOF_STEP
+}
+
+demo_reset_reseed_idempotency() {
+  cat <<'EOF_STEP'
+1) Seed demo with scenario driver_minor_collision.
+2) Reset demo and capture deleted counters.
+3) Seed again with same scenario and reset again.
+4) Confirm both reset calls return 200 and identical deleted-key shape.
+Reference test: backend/tests/test_section21_phase7_routes.py::test_section21_demo_reset_reseed_is_idempotent
+EOF_STEP
+}
+
+deployment_progress_readiness() {
+  cat <<'EOF_STEP'
+1) Query /org/deployment-progress as org_admin.
+2) Validate scope and percent_complete shape + coverage collection.
+3) Query /org/expansion-readiness and validate status is one of allowed readiness states.
+Reference test: backend/tests/test_section21_phase7_routes.py::test_section21_deployment_progress_and_readiness_states
+EOF_STEP
+}
+
+docs_trust_visibility() {
+  cat <<'EOF_STEP'
+1) Seed one published trust section and one draft trust section.
+2) Query /trust/sections with publication_state=published + audience filter.
+3) Confirm draft section is excluded.
+4) Query /trust/sections with publication_state=all and confirm draft section appears.
+Reference test: backend/tests/test_section21_phase7_routes.py::test_section21_trust_publication_visibility_filters
+EOF_STEP
+}
+
+frontend_feature_gates() {
+  cat <<'EOF_STEP'
+1) Validate feature-gating source supports lock/hide states and disabled UI semantics.
+2) Validate deployment page includes readiness banner + coverage cards.
+3) Validate trust page includes trust-center render states for core sections.
+Reference tests:
+- frontend/tests/featureGating.test.mjs
+- frontend/tests/keyPageRenderStates.test.mjs
+EOF_STEP
+}
+
+print_step "endpoint_authn_authz" endpoint_authn_authz
+print_step "entitlement_enforcement" entitlement_enforcement
+print_step "demo_reset_reseed_idempotency" demo_reset_reseed_idempotency
+print_step "deployment_progress_readiness" deployment_progress_readiness
+print_step "docs_trust_visibility" docs_trust_visibility
+print_step "frontend_feature_gates" frontend_feature_gates


### PR DESCRIPTION
### Motivation
- Provide repeatable, traceable acceptance coverage for Section 21 (Phase 7) including authn/authz, entitlement enforcement, demo reseed idempotency, deployment progress/readiness states, and trust/docs publication visibility.
- Ensure required runtime routing for Twilio webhook callbacks is registered so webhook endpoints are reachable at runtime.
- Surface frontend gating and page baseline render-state checks to protect UI behavior during MVP → production promotion.

### Description
- Registered the Twilio webhook router by importing and mounting `routes_webhooks` in `backend/app/main.py` under the prefix `/webhooks/twilio` so webhook endpoints are included at app startup.
- Added a backend acceptance test suite `backend/tests/test_section21_phase7_routes.py` that validates endpoint authn/authz, entitlement enforcement behavior, demo seed/reset idempotency, deployment progress/readiness contracts, and trust publication visibility filtering.
- Added frontend tests `frontend/tests/featureGating.test.mjs` and `frontend/tests/keyPageRenderStates.test.mjs` to validate feature-gate semantics and core page render states for Deployment and Trust pages.
- Added a Phase 7 QA helper script `scripts/run_section21_phase7_qa.sh` modeled after existing section QA scripts to provide a repeatable runbook for operators.
- Added two checklist documents `docs/section-21-mvp-acceptance-checklist.md` and `docs/section-21-production-ready-acceptance-checklist.md` mapping criteria to executable tests and scripted verification steps.

### Testing
- Ran backend lint checks with `cd backend && ruff check app tests` and the linter completed successfully.
- Executed the new backend acceptance tests with `cd backend && pytest tests/test_section21_phase7_routes.py -v` and all tests passed (`5 passed`).
- Ran frontend lint with `cd frontend && npm run lint` which completed without error.
- Ran frontend tests with `cd frontend && npm test` and the suite passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e593e64e7c832183be210f4e96fd9f)