### PR TITLE
Follow-up: prevent duplicate IncidentConfirm workflow transitions

### DIFF
--- a/driver-app/src/navigation/ProtocolFlowContext.tsx
+++ b/driver-app/src/navigation/ProtocolFlowContext.tsx
@@ -41,26 +41,28 @@ export function ProtocolFlowProvider({ children }: { children: ReactNode }) {
       },
       transitionWorkflow: (toState) => {
         setWorkflowState((previousState) =>
-          transitionProtocol(
-            {
-              state: previousState,
-              incidentDraftStatus: 'idle',
-              uploadState: 'idle',
-              updatedAt: new Date().toISOString(),
-              version: 1,
-              context: {
-                isAuthenticated: true,
-                vehicleResolved: false,
-                safetyAcknowledged: false,
-                submissionValidations: {
-                  hasIncidentType: false,
-                  hasDescription: false,
-                  hasMedia: false,
+          previousState === toState
+            ? previousState
+            : transitionProtocol(
+                {
+                  state: previousState,
+                  incidentDraftStatus: 'idle',
+                  uploadState: 'idle',
+                  updatedAt: new Date().toISOString(),
+                  version: 1,
+                  context: {
+                    isAuthenticated: true,
+                    vehicleResolved: false,
+                    safetyAcknowledged: false,
+                    submissionValidations: {
+                      hasIncidentType: false,
+                      hasDescription: false,
+                      hasMedia: false,
+                    },
+                  },
                 },
-              },
-            },
-            toState,
-          ).state,
+                toState,
+              ).state,
         );
       },
       resetProtocol: () => {


### PR DESCRIPTION
### Motivation
- Prevent crashes caused by repeated same-state transitions when `transitionWorkflow('incident_confirmed')` is invoked multiple times (e.g., double-tap Continue or revisit + Continue) because `transitionProtocol` throws for invalid same-state transitions.

### Description
- Add an idempotency guard in `ProtocolFlowContext.transitionWorkflow` so that if `previousState === toState` the update is a no-op and otherwise the existing `transitionProtocol` logic is used.

### Testing
- Ran `cd driver-app && npx tsc --noEmit`, which failed in this environment due to missing project dependencies / Expo TypeScript base config, so no successful typecheck or other automated tests were available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e914bfff48832192ec4949d5d89b90)