### PR TITLE
[PR #120 Follow-up] Align `capture_state` handling with backend value `complete`

### DIFF
--- a/driver-app/src/api.ts
+++ b/driver-app/src/api.ts
@@ -85,7 +85,15 @@ export type DriverIncidentStatusResponse = {
   incident_id: string;
   status: 'open' | 'evidence_capturing' | 'closed' | string;
   safety_notified: boolean;
-  capture_state: 'pending' | 'in_progress' | 'completed' | 'failed' | string;
+  capture_state:
+    | 'pending'
+    | 'in_progress'
+    | 'requested'
+    | 'lockdown'
+    | 'complete'
+    | 'closed'
+    | 'failed'
+    | string;
   last_evidence_update_utc?: string | null;
 };
 

--- a/driver-app/src/screens/IncidentStatusScreen.tsx
+++ b/driver-app/src/screens/IncidentStatusScreen.tsx
@@ -62,7 +62,7 @@ export default function IncidentStatusScreen({ navigation }: Props) {
     if (!incidentStatus.safety_notified) {
       items.push('Notify safety manager.');
     }
-    if (incidentStatus.capture_state !== 'completed') {
+    if (incidentStatus.capture_state !== 'complete') {
       items.push('Continue evidence upload and verification.');
     }
     if (incidentStatus.status !== 'closed') {
@@ -77,7 +77,7 @@ export default function IncidentStatusScreen({ navigation }: Props) {
       return { uploaded: 0, pending: 0, failed: 0 };
     }
 
-    if (incidentStatus.capture_state === 'completed') {
+    if (incidentStatus.capture_state === 'complete') {
       return { uploaded: 1, pending: 0, failed: 0 };
     }
 
@@ -121,7 +121,7 @@ export default function IncidentStatusScreen({ navigation }: Props) {
             <Chip selected={Boolean(incidentStatus?.safety_notified)}>
               Safety notified: {incidentStatus?.safety_notified ? 'Yes' : 'No'}
             </Chip>
-            <Chip selected={incidentStatus?.capture_state === 'completed'}>
+            <Chip selected={incidentStatus?.capture_state === 'complete'}>
               Capture: {incidentStatus?.capture_state ?? 'unknown'}
             </Chip>
           </View>


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where the UI treated `capture_state === 'completed'` as a successful upload while the backend returns `"complete"`, causing completed incidents to be shown as pending.

### Description
- Updated `driver-app/src/screens/IncidentStatusScreen.tsx` to treat `capture_state === 'complete'` as the success state for pending-item logic, artifact summary, and the capture-status chip selected state.
- Updated the `DriverIncidentStatusResponse.capture_state` type in `driver-app/src/api.ts` to match backend enum values (`'pending'`, `'in_progress'`, `'requested'`, `'lockdown'`, `'complete'`, `'closed'`, `'failed'`) and removed the incorrect frontend-only `'completed'` literal.

### Testing
- Ran TypeScript check in the driver app with `cd driver-app && npx tsc --noEmit`, which failed in this environment due to missing project/tooling dependencies and the `expo/tsconfig.base` reference, not because of the code change; no other automated tests were run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91516818c8321aab3339341f82d4d)