### PR TITLE
Follow-up: abort timed-out incident initiate requests before retry

### DIFF
--- a/driver-app/src/api.ts
+++ b/driver-app/src/api.ts
@@ -143,12 +143,16 @@ export const resolveQr = (qrToken: string) =>
     true,
   );
 
-export const initiateDriverIncident = (payload: DriverIncidentInitiateRequest) =>
+export const initiateDriverIncident = (
+  payload: DriverIncidentInitiateRequest,
+  signal?: AbortSignal,
+) =>
   request<DriverIncidentInitiateResponse>(
     '/driver/incidents/initiate',
     {
       method: 'POST',
       body: JSON.stringify(payload),
+      signal,
     },
     true,
   );

--- a/driver-app/src/screens/IncidentStartLoadingScreen.tsx
+++ b/driver-app/src/screens/IncidentStartLoadingScreen.tsx
@@ -31,10 +31,13 @@ export default function IncidentStartLoadingScreen({ navigation }: Props) {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isRetrying, setIsRetrying] = useState(false);
   const isMountedRef = useRef(true);
+  const currentInitiationAbortRef = useRef<AbortController | null>(null);
 
   useEffect(
     () => () => {
       isMountedRef.current = false;
+      currentInitiationAbortRef.current?.abort();
+      currentInitiationAbortRef.current = null;
     },
     [],
   );
@@ -78,16 +81,6 @@ export default function IncidentStartLoadingScreen({ navigation }: Props) {
       );
     });
   }, []);
-
-  const withTimeout = useCallback(
-    async <T,>(work: Promise<T>, timeoutMs: number) => {
-      const timeoutPromise = new Promise<T>((_, reject) => {
-        setTimeout(() => reject(new Error('Request timed out.')), timeoutMs);
-      });
-      return await Promise.race([work, timeoutPromise]);
-    },
-    [],
-  );
 
   const attemptAmbiguousRecovery = useCallback(async () => {
     try {
@@ -135,23 +128,35 @@ export default function IncidentStartLoadingScreen({ navigation }: Props) {
 
     try {
       const locationPromise = collectDeviceLocation();
+      currentInitiationAbortRef.current?.abort();
+      const initiateController = new AbortController();
+      currentInitiationAbortRef.current = initiateController;
+      const timeoutId = setTimeout(() => initiateController.abort(), INITIATE_TIMEOUT_MS);
+
       setActiveStageIndex(1);
       setActiveStageIndex(2);
 
-      await withTimeout(
-        initiateDriverIncident({
-          ...vehicleStrategyPayload,
-          device,
-          device_location: await locationPromise,
-        }),
-        INITIATE_TIMEOUT_MS,
-      );
+      try {
+        await initiateDriverIncident(
+          {
+            ...vehicleStrategyPayload,
+            device,
+            device_location: await locationPromise,
+          },
+          initiateController.signal,
+        );
+      } finally {
+        clearTimeout(timeoutId);
+      }
+      currentInitiationAbortRef.current = null;
 
       setActiveStageIndex(3);
       continueToInstructions();
     } catch (error) {
+      currentInitiationAbortRef.current = null;
       const ambiguousFailure =
         isNetworkFailure(error) ||
+        (error instanceof Error && error.name === 'AbortError') ||
         (error instanceof Error && /timed out/i.test(error.message));
       const duplicateFailure = isDuplicateFailure(error);
 
@@ -189,7 +194,6 @@ export default function IncidentStartLoadingScreen({ navigation }: Props) {
     collectDeviceLocation,
     continueToInstructions,
     vehicleStrategyPayload,
-    withTimeout,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation

- Fix a high-priority bug where the UI timeout for `POST /driver/incidents/initiate` used `Promise.race` without canceling the underlying request, allowing timed-out requests to complete server-side and cause duplicate side effects. 
- Ensure the driver app cancels in-flight initiation attempts on timeout, retry, or unmount so backend capture/notification jobs are not duplicated. 

### Description

- Added optional `signal?: AbortSignal` to `initiateDriverIncident` and forwarded it to the underlying `request` options so fetches can be cancelled (`driver-app/src/api.ts`).
- Reworked `IncidentStartLoadingScreen` to create an `AbortController` per initiation attempt, abort previous attempts before starting a new one, and abort the request when `INITIATE_TIMEOUT_MS` elapses using `setTimeout` (with `clearTimeout` in a `finally` block).
- Abort any outstanding initiation on component unmount and clear the controller reference to avoid background completion after the UI moves on.
- Treated `AbortError` as an ambiguous/timeout-like failure to preserve the existing recovery flow that calls `getDriverActiveIncident` before surfacing errors, and removed the prior `Promise.race` timeout helper.

### Testing

- Ran TypeScript checks with `cd driver-app && npx tsc --noEmit`, which failed in this environment due to missing project dependencies / Expo TS base config (errors like missing `expo/tsconfig.base` and React Native types) and not due to the changes in this patch.
- No new unit/integration tests were added; changes are limited to request cancellation and timeout handling logic and validated by local type-check attempts above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e915b85d9483219cc98acbb733e948)