### PR TITLE
Preserve unanswered scene safety fields and restore draft if incident fetch fails

### DIFF
--- a/driver-app/src/api.ts
+++ b/driver-app/src/api.ts
@@ -96,9 +96,9 @@ export type DriverSceneFactsPayload = {
     latitude: number;
     longitude: number;
   } | null;
-  injuries_reported: boolean;
-  police_called: boolean;
-  vehicle_drivable: boolean;
+  injuries_reported: boolean | null;
+  police_called: boolean | null;
+  vehicle_drivable: boolean | null;
   short_description: string;
 };
 

--- a/driver-app/src/screens/SceneFactsScreen.tsx
+++ b/driver-app/src/screens/SceneFactsScreen.tsx
@@ -70,9 +70,9 @@ function buildSceneFactsPayload(draft: SceneFactsDraft): DriverSceneFactsPayload
             longitude,
           }
         : null,
-    injuries_reported: Boolean(draft.injuriesReported),
-    police_called: Boolean(draft.policeCalled),
-    vehicle_drivable: Boolean(draft.vehicleDrivable),
+    injuries_reported: draft.injuriesReported,
+    police_called: draft.policeCalled,
+    vehicle_drivable: draft.vehicleDrivable,
     short_description: draft.shortDescription.trim(),
   };
 }
@@ -170,15 +170,18 @@ export default function SceneFactsScreen({ navigation }: Props) {
 
   useEffect(() => {
     const initializeDraft = async () => {
+      let nextIncidentId: string | null = null;
+
       try {
-        const [activeIncident, storedRaw] = await Promise.all([
-          getDriverActiveIncident(),
-          SecureStore.getItemAsync(STORAGE_KEY),
-        ]);
-
-        const nextIncidentId = activeIncident?.incident_id ?? null;
+        const activeIncident = await getDriverActiveIncident();
+        nextIncidentId = activeIncident?.incident_id ?? null;
         setIncidentId(nextIncidentId);
+      } catch {
+        // Offline or server unavailable; proceed with locally saved draft if present.
+      }
 
+      try {
+        const storedRaw = await SecureStore.getItemAsync(STORAGE_KEY);
         if (!storedRaw) {
           return;
         }


### PR DESCRIPTION
### Motivation
- Prevent autosave from coercing unanswered yes/no safety answers to `false` and accidentally overwriting previously saved scene facts.
- Ensure locally autosaved drafts are restored even when `getDriverActiveIncident()` transiently fails (e.g., offline startup).
- Align the API payload typing with the local draft model so nullable answers are preserved end-to-end.

### Description
- Changed `DriverSceneFactsPayload` in `driver-app/src/api.ts` so `injuries_reported`, `police_called`, and `vehicle_drivable` are `boolean | null` instead of `boolean`.
- Updated `buildSceneFactsPayload` in `driver-app/src/screens/SceneFactsScreen.tsx` to pass through nullable safety fields instead of coercing them with `Boolean(...)`.
- Refactored the `useEffect` initialization in `SceneFactsScreen` to fetch the active incident and read the `SecureStore` draft independently so draft restoration still runs when the incident fetch throws.

### Testing
- Ran TypeScript check with `cd driver-app && npx tsc --noEmit`, which failed in this environment due to missing project dependencies/config (e.g., `expo/tsconfig.base` and RN/Expo typings), so a full typecheck could not be completed here.
- No other repository-level automated `lint` or `test` scripts ran because the environment lacks the required configs and dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e915c557608321a83a6ab67dba0b40)