### PR TITLE
Fix offline narrative draft hydration when active-incident lookup fails

### DIFF
--- a/driver-app/src/screens/NarrativeScreen.tsx
+++ b/driver-app/src/screens/NarrativeScreen.tsx
@@ -78,14 +78,22 @@ export default function NarrativeScreen({ navigation }: Props) {
   useEffect(() => {
     const initializeDraft = async () => {
       try {
-        const [activeIncident, storedRaw] = await Promise.all([
+        const [activeIncidentResult, storedDraftResult] = await Promise.allSettled([
           getDriverActiveIncident(),
           SecureStore.getItemAsync(STORAGE_KEY),
         ]);
 
-        const nextIncidentId = activeIncident?.incident_id ?? null;
+        const nextIncidentId =
+          activeIncidentResult.status === 'fulfilled'
+            ? activeIncidentResult.value?.incident_id ?? null
+            : null;
         setIncidentId(nextIncidentId);
 
+        if (storedDraftResult.status !== 'fulfilled') {
+          return;
+        }
+
+        const storedRaw = storedDraftResult.value;
         if (!storedRaw) {
           return;
         }


### PR DESCRIPTION
### Motivation
- The initialization used `Promise.all(...)` which fail-fasted when `getDriverActiveIncident()` rejected, preventing locally persisted narrative drafts from being restored when the network or server was unavailable.
- The change aims to preserve local draft hydration as the offline source of truth while still attempting to resolve the active incident ID when available.

### Description
- Replace the fail-fast parallel `Promise.all` with `Promise.allSettled` when loading the active incident and the stored draft to avoid blocking local hydration on network failures.
- Resolve `incidentId` only when the active-incident promise is fulfilled and safely fall back to `null` when it rejects, using the settled result shape.
- Add an explicit guard for the settled SecureStore result before parsing and preserve the existing incident-scoped draft matching behavior when both IDs are available.

### Testing
- Ran TypeScript check with `cd driver-app && npx tsc --noEmit`, which was attempted but failed in this environment due to missing project dependencies and base TS config (`expo/tsconfig.base` and React Native typings). 
- No other automated tests were modified or added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9170ff17883219a425b6b20a5a777)