### PR TITLE
Fix P1: implement POST /driver/incidents/{incident_id}/submit-driver-report

### DIFF
--- a/backend/app/api/routes_driver.py
+++ b/backend/app/api/routes_driver.py
@@ -15,6 +15,7 @@ from app.api.schemas import (
     DriverIncidentInitiateRequest,
     DriverIncidentInitiateResponse,
     DriverIncidentStatusResponse,
+    DriverSubmitIncidentReportResponse,
     DriverInstructionAckRequest,
     DriverInstructionAckResponse,
     DriverInstructionSetResponse,
@@ -570,4 +571,41 @@ def driver_incident_status(
         safety_notified=safety_notified,
         capture_state=_evidence_capture_state(events, incident.status),
         last_evidence_update_utc=last_evidence_update,
+    )
+
+
+@router.post(
+    "/incidents/{incident_id}/submit-driver-report",
+    response_model=DriverSubmitIncidentReportResponse,
+)
+def submit_driver_incident_report(
+    incident_id: uuid.UUID,
+    driver: Driver = Depends(get_current_driver),
+    db: Session = Depends(get_db),
+):
+    """Finalize a driver incident report."""
+    incident = get_incident(db, incident_id, org_ids=[driver.org_id])
+    if incident is None:
+        raise HTTPException(status_code=404, detail="Incident not found")
+
+    if incident.status != "closed":
+        incident.status = "closed"
+        submission_event = Event(
+            org_id=driver.org_id,
+            incident_id=incident.incident_id,
+            event_type=SystemEventType.INCIDENT_UPDATED.value,
+            actor_type="driver_app",
+            actor_id=str(driver.driver_id),
+            payload={
+                "status": "closed",
+                "source": "driver_submit_incident_report",
+            },
+        )
+        db.add(submission_event)
+        db.commit()
+        db.refresh(incident)
+
+    return DriverSubmitIncidentReportResponse(
+        incident_id=incident.incident_id,
+        status=incident.status,
     )

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -282,6 +282,11 @@ class DriverIncidentStatusResponse(BaseModel):
     last_evidence_update_utc: Optional[datetime] = None
 
 
+class DriverSubmitIncidentReportResponse(BaseModel):
+    incident_id: uuid.UUID
+    status: IncidentStatus
+
+
 # ── Admin vehicles / QR ────────────────────────────────────────────
 
 

--- a/backend/tests/test_driver_admin_endpoints.py
+++ b/backend/tests/test_driver_admin_endpoints.py
@@ -531,6 +531,55 @@ class TestDriverInstructionAck:
         )
 
 
+# ── POST /driver/incidents/{incident_id}/submit-driver-report ──────
+
+
+class TestSubmitDriverIncidentReport:
+    def test_submit_closes_incident_and_writes_event(
+        self, client, db_session, test_org, test_driver, driver_headers
+    ):
+        incident = Incident(
+            org_id=test_org.id,
+            adc_vehicle_id="veh-100",
+            adc_driver_id=str(test_driver.driver_id),
+            status="evidence_capturing",
+        )
+        db_session.add(incident)
+        db_session.commit()
+        db_session.refresh(incident)
+
+        resp = client.post(
+            f"/driver/incidents/{incident.incident_id}/submit-driver-report",
+            headers=driver_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["incident_id"] == str(incident.incident_id)
+        assert data["status"] == "closed"
+
+        db_session.refresh(incident)
+        assert incident.status == "closed"
+
+        events = (
+            db_session.query(Event)
+            .filter(
+                Event.incident_id == incident.incident_id,
+                Event.event_type == "incident_updated",
+            )
+            .all()
+        )
+        assert len(events) == 1
+        assert events[0].payload["status"] == "closed"
+        assert events[0].payload["source"] == "driver_submit_incident_report"
+
+    def test_submit_returns_404_for_unknown_incident(self, client, driver_headers):
+        resp = client.post(
+            "/driver/incidents/00000000-0000-0000-0000-000000000000/submit-driver-report",
+            headers=driver_headers,
+        )
+        assert resp.status_code == 404
+
+
 # ── GET /admin/vehicles/{vehicle_id}/qr ─────────────────────────────
 
 


### PR DESCRIPTION
### Motivation
- The driver app already calls `POST /driver/incidents/{incident_id}/submit-driver-report` but the backend lacked a handler, causing 404s when drivers attempted to finalize reports. 
- The backend must finalize the incident (transition to `closed`) and record an event so the system reflects a driver-submitted report. 
- Provide a typed response contract so the driver client can rely on `incident_id` and `status` in the response.

### Description
- Added a backend route handler `POST /driver/incidents/{incident_id}/submit-driver-report` that validates driver ownership, marks an incident `closed` when needed, emits an `incident_updated` event with `source: driver_submit_incident_report`, and returns `{ incident_id, status }` (file: `backend/app/api/routes_driver.py`).
- Added the `DriverSubmitIncidentReportResponse` Pydantic schema so the endpoint has an explicit typed response (file: `backend/app/api/schemas.py`).
- Added tests covering the new endpoint to verify the success path (incident is closed and event payload is written) and the 404 path for unknown incident IDs (file: `backend/tests/test_driver_admin_endpoints.py`).

### Testing
- Attempted to run targeted backend tests with `pytest -q backend/tests/test_driver_admin_endpoints.py -k "submit_driver_incident_report or TestDriverInstructionAck"`, but test collection failed due to an unrelated `NameError: task_prerun is not defined` in `backend/app/tasks/celery_app.py`, so the new tests could not be executed.
- Verified syntax/compilation of the modified files with `python -m compileall backend/app/api/routes_driver.py backend/app/api/schemas.py backend/tests/test_driver_admin_endpoints.py`, which completed successfully.
- The added tests are present and ready to run once the unrelated test-collection issue in `backend/app/tasks/celery_app.py` is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e917142e448321b5058197061ba3c1)