### PR TITLE
[PR #127 Follow-up] Fix resume state persistence and vehicle context restore

### DIFF
--- a/driver-app/src/navigation/ProtocolFlowContext.tsx
+++ b/driver-app/src/navigation/ProtocolFlowContext.tsx
@@ -1,4 +1,12 @@
-import { ReactNode, createContext, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { INITIAL_PROTOCOL_CONTEXT } from '../types/protocol';
 import { transitionProtocol } from '../store/protocolStore';
@@ -42,10 +50,14 @@ export function ProtocolFlowProvider({ children }: { children: ReactNode }) {
     useState<DriverProtocolState>('authenticated');
   const [protocolContext, setProtocolContext] =
     useState<ProtocolContext>(INITIAL_PROTOCOL_CONTEXT);
-
-
+  const hasCompletedRoutesHydrated = useRef(false);
 
   useEffect(() => {
+    if (!hasCompletedRoutesHydrated.current) {
+      hasCompletedRoutesHydrated.current = true;
+      return;
+    }
+
     void persistProtocolResumeState(null, completedRoutes);
   }, [completedRoutes]);
 
@@ -66,8 +78,8 @@ export function ProtocolFlowProvider({ children }: { children: ReactNode }) {
         setCompletedRoutes(new Set(routes));
         setWorkflowState('authenticated');
         setProtocolContext((previous) => ({
-          ...previous,
           ...INITIAL_PROTOCOL_CONTEXT,
+          ...previous,
           isAuthenticated: true,
         }));
       },


### PR DESCRIPTION
### Motivation
- Fix two high-priority issues in protocol resume handling: prevent accidental overwrite of persisted resume state on provider mount and preserve vehicle resolution context when restoring progress.

### Description
- Add a hydration guard `hasCompletedRoutesHydrated` to the `completedRoutes` persistence effect so the initial mount does not immediately call `persistProtocolResumeState` with an empty set.
- Update `restoreProtocol` to merge `INITIAL_PROTOCOL_CONTEXT` first and then spread the previous `protocolContext`, preserving `vehicleResolutionMethod`, `vehicleId`, and `qrToken` while still enforcing `isAuthenticated: true`.

### Testing
- Ran `cd driver-app && npx tsc --noEmit`, which failed in this environment due to missing Expo/React Native TypeScript configuration and type declarations (e.g., `expo/tsconfig.base`, `react`, `react-native` typings) and not due to the applied changes.
- No additional automated test or lint scripts were executed for the follow-up because `driver-app/package.json` does not expose `lint` or `test` scripts in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91807173c832196c7550f2bef13d9)