### PR TITLE
Skip terminally failed uploads in queue processing

### DIFF
--- a/driver-app/src/store/uploadQueueStore.ts
+++ b/driver-app/src/store/uploadQueueStore.ts
@@ -283,7 +283,7 @@ export async function clearUploadedItemsForIncident(incidentId: string): Promise
 export function getProcessableQueueItems(now = new Date()): UploadQueueItem[] {
   const nowMs = now.getTime();
   return queueState.items.filter((item) => {
-    if (item.status === 'uploaded') {
+    if (item.status !== 'pending' && item.status !== 'uploading') {
       return false;
     }
 


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where items marked `failed` were still returned by the queue worker and retried repeatedly, bypassing the intended `MAX_ATTEMPTS` stop condition and producing duplicate failure telemetry.

### Description
- Restrict processable queue states to retryable values by updating `getProcessableQueueItems` in `driver-app/src/store/uploadQueueStore.ts` to only return items whose `status` is `pending` or `uploading`, thereby excluding `failed` and `uploaded` from further processing.

### Testing
- Ran `cd driver-app && npx tsc --noEmit`; the TypeScript check failed in this environment due to missing Expo/React dependencies and `expo/tsconfig.base`, not because of the queue-filtering change itself, and no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e917fadf408321aa9ecfa8416a296e)