### PR TITLE
Restore MediaCapture draft when incident lookup fails

### DIFF
--- a/driver-app/src/screens/MediaCaptureScreen.tsx
+++ b/driver-app/src/screens/MediaCaptureScreen.tsx
@@ -157,15 +157,24 @@ export default function MediaCaptureScreen({ navigation }: Props) {
 
   useEffect(() => {
     const initialize = async () => {
-      try {
-        const [activeIncident, storedRaw] = await Promise.all([
-          getDriverActiveIncident(),
-          SecureStore.getItemAsync(STORAGE_KEY),
-        ]);
+      let nextIncidentId: string | null = null;
+      let storedRaw: string | null = null;
 
-        const nextIncidentId = activeIncident?.incident_id ?? null;
+      const [activeIncidentResult, storedDraftResult] = await Promise.allSettled([
+        getDriverActiveIncident(),
+        SecureStore.getItemAsync(STORAGE_KEY),
+      ]);
+
+      if (activeIncidentResult.status === 'fulfilled') {
+        nextIncidentId = activeIncidentResult.value?.incident_id ?? null;
         setIncidentId(nextIncidentId);
+      }
 
+      if (storedDraftResult.status === 'fulfilled') {
+        storedRaw = storedDraftResult.value;
+      }
+
+      try {
         if (!storedRaw) {
           return;
         }


### PR DESCRIPTION
### Motivation
- Ensure locally saved media capture drafts are restored even if the active-incident API request fails so users do not lose in-progress captures while offline or during transient API/auth errors.

### Description
- Replaced the hard `Promise.all` dependency with `Promise.allSettled` when initializing active incident and reading the SecureStore draft in `driver-app/src/screens/MediaCaptureScreen.tsx` so each operation can succeed or fail independently.
- Only apply `setIncidentId` when the incident lookup `Promise` is fulfilled and only parse/use the stored draft when the SecureStore read `Promise` is fulfilled, preserving the existing incident-id mismatch guard.
- Kept the non-blocking initialization fallback and final `setIsInitializing(false)` behavior so the UI continues to load even on errors.

### Testing
- Ran `npx tsc --noEmit` in `driver-app` after the change and the type-check failed in this execution environment due to missing Expo/React Native TypeScript dependencies and `expo/tsconfig.base`, which is unrelated to this logic-only change.
- No repository `lint` or `test` scripts were executed because the project does not expose those scripts in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e917f4cf448321914253d6c8e6eb3a)