### PR TITLE
Fix artifact upload S3-key UUID timing and restrict completion to driver artifacts

### DIFF
--- a/backend/app/services/artifact_upload_service.py
+++ b/backend/app/services/artifact_upload_service.py
@@ -26,6 +26,7 @@ ALLOWED_ARTIFACT_CONTENT_TYPES = {
     "driver_document": {"application/pdf", "image/jpeg", "image/png"},
     "driver_video": {"video/mp4"},
 }
+DRIVER_ARTIFACT_TYPES = set(ALLOWED_ARTIFACT_CONTENT_TYPES.keys())
 
 
 def _validate_incident_driver_ownership(
@@ -101,14 +102,15 @@ def issue_driver_artifact_upload_url(
         artifact_type=normalized_artifact_type,
         status="pending",
     )
+    db.add(artifact)
+    db.flush()
+
     ext = _file_extension(file_name)
     artifact.s3_bucket = settings.S3_ARTIFACTS_BUCKET
     artifact.s3_key = (
         f"org/{incident.org_id}/incidents/{incident.incident_id}/"
         f"driver/{normalized_artifact_type}/{artifact.artifact_id}.{ext}"
     )
-
-    db.add(artifact)
     db.commit()
     db.refresh(artifact)
 
@@ -142,6 +144,8 @@ def complete_driver_artifact_upload(
         .filter(
             Artifact.artifact_id == artifact_id,
             Artifact.incident_id == incident_id,
+            Artifact.artifact_type.in_(DRIVER_ARTIFACT_TYPES),
+            Artifact.status == "pending",
         )
         .first()
     )

--- a/backend/tests/test_driver_artifact_routes.py
+++ b/backend/tests/test_driver_artifact_routes.py
@@ -112,6 +112,8 @@ def test_issue_upload_url_creates_pending_artifact(
     artifact = db_session.query(Artifact).filter(Artifact.incident_id == incident.incident_id).one()
     assert artifact.status == "pending"
     assert artifact.artifact_type == "driver_document"
+    assert str(artifact.artifact_id) in artifact.s3_key
+    assert "None.pdf" not in artifact.s3_key
 
 
 def test_issue_upload_url_rejects_disallowed_content_type(client, seeded_driver_and_incident):
@@ -161,6 +163,66 @@ def test_complete_upload_marks_artifact_captured(client, db_session, seeded_driv
     db_session.refresh(artifact)
     assert artifact.status == "captured"
     assert artifact.byte_size == 2048
+
+
+def test_complete_upload_rejects_non_driver_artifact_types(
+    client, db_session, seeded_driver_and_incident
+):
+    driver, incident = seeded_driver_and_incident
+
+    artifact = Artifact(
+        org_id=incident.org_id,
+        incident_id=incident.incident_id,
+        artifact_type="telematics",
+        status="pending",
+        s3_bucket="bucket",
+        s3_key="org/key",
+    )
+    db_session.add(artifact)
+    db_session.commit()
+    db_session.refresh(artifact)
+
+    response = client.post(
+        f"/driver/incidents/{incident.incident_id}/artifacts/complete",
+        headers=_driver_auth_headers(driver.driver_id),
+        json={
+            "artifact_id": str(artifact.artifact_id),
+            "byte_size": 1024,
+            "sha256": "b" * 64,
+        },
+    )
+
+    assert response.status_code == 404
+
+
+def test_complete_upload_rejects_already_captured_artifact(
+    client, db_session, seeded_driver_and_incident
+):
+    driver, incident = seeded_driver_and_incident
+
+    artifact = Artifact(
+        org_id=incident.org_id,
+        incident_id=incident.incident_id,
+        artifact_type="driver_photo",
+        status="captured",
+        s3_bucket="bucket",
+        s3_key="org/key",
+    )
+    db_session.add(artifact)
+    db_session.commit()
+    db_session.refresh(artifact)
+
+    response = client.post(
+        f"/driver/incidents/{incident.incident_id}/artifacts/complete",
+        headers=_driver_auth_headers(driver.driver_id),
+        json={
+            "artifact_id": str(artifact.artifact_id),
+            "byte_size": 512,
+            "sha256": "c" * 64,
+        },
+    )
+
+    assert response.status_code == 404
 
 
 def test_list_artifacts_enforces_driver_ownership(client, db_session, seeded_driver_and_incident):


### PR DESCRIPTION
### Motivation
- Prevent S3 object key collisions caused by composing the `s3_key` before the `Artifact.artifact_id` is populated, which produced `None` in the path. 
- Prevent drivers from marking unrelated incident artifacts (or already-captured artifacts) as completed and overwriting metadata.

### Description
- Ensure the `Artifact` row is persisted to the session and `artifact_id` is allocated by calling `db.flush()` before composing `s3_key` in `issue_driver_artifact_upload_url` in `backend/app/services/artifact_upload_service.py`.
- Add `DRIVER_ARTIFACT_TYPES = set(ALLOWED_ARTIFACT_CONTENT_TYPES.keys())` and constrain the completion lookup to `Artifact.artifact_type.in_(DRIVER_ARTIFACT_TYPES)` and `Artifact.status == "pending"` in `complete_driver_artifact_upload` to limit completion to driver-managed pending artifacts.
- Update tests in `backend/tests/test_driver_artifact_routes.py` to assert the `artifact_id` appears in the generated `s3_key` and to add cases that completion rejects non-driver artifact types and already-captured artifacts.

### Testing
- Ran `pytest -q backend/tests/test_driver_artifact_routes.py` and all tests in that module passed (`6 passed, 2 warnings`).
- Ran `python -m ruff check backend/app/services/artifact_upload_service.py backend/tests/test_driver_artifact_routes.py` and the targeted linter checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9196fb7788321b22cc60c4e07b7fc)