### PR TITLE
Recover missing incident initiation tasks on idempotent retries

### DIFF
--- a/backend/app/api/routes_driver.py
+++ b/backend/app/api/routes_driver.py
@@ -402,6 +402,78 @@ def _evidence_capture_state(events: list, incident_status: str) -> str:
     return "pending"
 
 
+_INCIDENT_INITIATION_TASKS = (
+    ("dashcam", capture_dashcam),
+    ("telematics", capture_telematics_bundle),
+    ("safety_manager", notify_safety_manager),
+)
+
+
+def _get_protocol_event(
+    db: Session,
+    *,
+    incident_id: uuid.UUID,
+    driver_id: uuid.UUID,
+) -> Event | None:
+    """Return the driver's incident protocol event if present."""
+    return (
+        db.query(Event)
+        .filter(
+            Event.incident_id == incident_id,
+            Event.event_type == SystemEventType.INCIDENT_PROTOCOL_INITIATED.value,
+            Event.actor_type == "driver_app",
+            Event.actor_id == str(driver_id),
+        )
+        .order_by(Event.created_at_utc.asc())
+        .first()
+    )
+
+
+def _enqueue_initiation_tasks(
+    db: Session,
+    *,
+    incident_id: uuid.UUID,
+    driver_id: uuid.UUID,
+    window_start: str | None,
+    window_end: str | None,
+) -> bool:
+    """Enqueue incident initiation tasks and persist per-task enqueue progress.
+
+    Returns True when at least one task was newly enqueued in this request.
+    """
+    protocol_event = _get_protocol_event(
+        db,
+        incident_id=incident_id,
+        driver_id=driver_id,
+    )
+    payload = protocol_event.payload if protocol_event and isinstance(protocol_event.payload, dict) else {}
+    enqueued_tasks = payload.setdefault("enqueued_tasks", [])
+
+    if not isinstance(enqueued_tasks, list):
+        enqueued_tasks = []
+        payload["enqueued_tasks"] = enqueued_tasks
+
+    incident_id_str = str(incident_id)
+    enqueued_any = False
+    for task_key, task_func in _INCIDENT_INITIATION_TASKS:
+        if task_key in enqueued_tasks:
+            continue
+
+        if task_key in {"dashcam", "telematics"}:
+            task_func.delay(incident_id_str, window_start, window_end)
+        else:
+            task_func.delay(incident_id_str)
+
+        enqueued_tasks.append(task_key)
+        enqueued_any = True
+        if protocol_event is not None:
+            protocol_event.payload = payload
+            db.add(protocol_event)
+            db.commit()
+
+    return enqueued_any
+
+
 @router.post("/incidents/initiate", response_model=DriverIncidentInitiateResponse)
 def initiate_incident(
     body: DriverIncidentInitiateRequest,
@@ -423,16 +495,18 @@ def initiate_incident(
         idempotency_key=idempotency_key,
     )
 
-    if not initiation.protocol_already_started:
-        str_id = str(initiation.incident.incident_id)
-        capture_dashcam.delay(str_id, body.window_start, body.window_end)
-        capture_telematics_bundle.delay(str_id, body.window_start, body.window_end)
-        notify_safety_manager.delay(str_id)
+    capture_started = _enqueue_initiation_tasks(
+        db,
+        incident_id=initiation.incident.incident_id,
+        driver_id=driver.driver_id,
+        window_start=body.window_start,
+        window_end=body.window_end,
+    )
 
     return DriverIncidentInitiateResponse(
         incident_id=initiation.incident.incident_id,
         safety_notified=True,
-        capture_started=not initiation.protocol_already_started,
+        capture_started=capture_started,
     )
 
 

--- a/backend/tests/test_driver_admin_endpoints.py
+++ b/backend/tests/test_driver_admin_endpoints.py
@@ -496,6 +496,58 @@ class TestDriverInitiate:
     @patch("app.api.routes_driver.notify_safety_manager")
     @patch("app.api.routes_driver.capture_telematics_bundle")
     @patch("app.api.routes_driver.capture_dashcam")
+    def test_driver_initiate_retry_reenqueues_missing_tasks_after_partial_failure(
+        self,
+        mock_dash,
+        mock_tele,
+        mock_notify_manager,
+        client,
+        db_session,
+        test_driver,
+        driver_headers,
+        test_assignment,
+    ):
+        mock_dash.delay = MagicMock()
+        mock_tele.delay = MagicMock(side_effect=[RuntimeError("broker outage"), None])
+        mock_notify_manager.delay = MagicMock()
+
+        first = client.post(
+            "/driver/incidents/initiate",
+            json={"vehicle_strategy": "last_assigned"},
+            headers={**driver_headers, "Idempotency-Key": "idem-002"},
+        )
+        assert first.status_code == 500
+
+        second = client.post(
+            "/driver/incidents/initiate",
+            json={"vehicle_strategy": "last_assigned"},
+            headers={**driver_headers, "Idempotency-Key": "idem-002"},
+        )
+        assert second.status_code == 200
+        assert second.json()["capture_started"] is True
+
+        incident_id = second.json()["incident_id"]
+        protocol_event = (
+            db_session.query(Event)
+            .filter(
+                Event.incident_id == incident_id,
+                Event.event_type == "incident_protocol_initiated",
+            )
+            .one()
+        )
+        assert protocol_event.payload["enqueued_tasks"] == [
+            "dashcam",
+            "telematics",
+            "safety_manager",
+        ]
+
+        mock_dash.delay.assert_called_once()
+        assert mock_tele.delay.call_count == 2
+        mock_notify_manager.delay.assert_called_once()
+
+    @patch("app.api.routes_driver.notify_safety_manager")
+    @patch("app.api.routes_driver.capture_telematics_bundle")
+    @patch("app.api.routes_driver.capture_dashcam")
     def test_driver_initiate_reuses_existing_active_incident_for_driver(
         self,
         mock_dash,


### PR DESCRIPTION
### Motivation

- Fix a high-priority bug where transient Celery enqueue failures during `POST /driver/incidents/initiate` could permanently drop evidence/notification tasks on retries because the idempotency gate prevented re-enqueueing.

### Description

- Added an ordered initiation task list and reconciliation helpers in `backend/app/api/routes_driver.py` (`_INCIDENT_INITIATION_TASKS`, `_get_protocol_event`, `_enqueue_initiation_tasks`) that read the `incident_protocol_initiated` event payload and persist an `enqueued_tasks` list as each `.delay(...)` call succeeds.
- Changed `POST /driver/incidents/initiate` to call `_enqueue_initiation_tasks` on every request so retries will enqueue any missing tasks without duplicating already-enqueued work and return a `capture_started` boolean reflecting whether new enqueues occurred.
- Added a regression test `test_driver_initiate_retry_reenqueues_missing_tasks_after_partial_failure` in `backend/tests/test_driver_admin_endpoints.py` that simulates a partial broker failure on the first request and verifies the retry enqueues the remaining tasks and persists `enqueued_tasks` in the protocol event.

### Testing

- Ran linting/format checks with `python -m ruff check backend/app/api/routes_driver.py backend/tests/test_driver_admin_endpoints.py` and all checks passed.
- Ran targeted `pytest` for the new/related tests but test collection failed due to an unrelated `NameError: get_current_user_org_ids` in `backend/app/api/routes_incidents.py`, so the new regression test could not complete in this environment.
- Added and committed the changes on the branch with message `Recover missing incident tasks on idempotent retries` and created a follow-up PR message summarizing the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91976320483219e0a48c659cbaf44)