### PR TITLE
Preserve early driver timeline events and enforce incident ownership

### DIFF
--- a/backend/app/api/routes_driver.py
+++ b/backend/app/api/routes_driver.py
@@ -548,6 +548,8 @@ def write_driver_timeline_event(
     incident = get_incident(db, incident_id, org_ids=[driver.org_id])
     if incident is None:
         raise HTTPException(status_code=404, detail="Incident not found")
+    if incident.adc_driver_id != str(driver.driver_id):
+        raise HTTPException(status_code=403, detail="Incident not assigned to driver")
 
     event_kwargs = {
         "org_id": incident.org_id,

--- a/backend/tests/test_driver_admin_endpoints.py
+++ b/backend/tests/test_driver_admin_endpoints.py
@@ -657,6 +657,35 @@ class TestDriverTimelineEvents:
         assert event.occurred_at_utc is not None
         assert event.payload["source"] == "driver-app"
 
+    def test_timeline_event_write_rejects_other_driver_incident(
+        self, client, db_session, test_org, test_driver, driver_headers
+    ):
+        other_driver = Driver(
+            org_id=test_org.id,
+            phone_e164="+15557654321",
+            display_name="Other Driver",
+        )
+        db_session.add(other_driver)
+        db_session.commit()
+        db_session.refresh(other_driver)
+
+        incident = Incident(
+            org_id=test_org.id,
+            adc_vehicle_id="veh-789",
+            adc_driver_id=str(other_driver.driver_id),
+            status="evidence_capturing",
+        )
+        db_session.add(incident)
+        db_session.commit()
+
+        resp = client.post(
+            f"/driver/incidents/{incident.incident_id}/timeline-events",
+            json={"event_name": "driver_safety_gate_viewed"},
+            headers=driver_headers,
+        )
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "Incident not assigned to driver"
+
 
 class TestDriverActiveIncidentAndStatus:
     def test_get_active_incident_returns_latest_for_driver(

--- a/driver-app/src/telemetry/protocolEvents.ts
+++ b/driver-app/src/telemetry/protocolEvents.ts
@@ -39,10 +39,77 @@ const PERSISTED_TIMELINE_EVENT_NAMES: Set<DriverTimelineEventName> = new Set([
   'driver_report_submitted',
 ]);
 
+type PendingTimelineEvent = {
+  eventName: DriverTimelineEventName;
+  occurredAtUtc: string;
+  payload: Record<string, unknown>;
+};
+
+const pendingTimelineEvents: PendingTimelineEvent[] = [];
+const MAX_PENDING_TIMELINE_EVENTS = 50;
+const RETRY_FLUSH_DELAY_MS = 1500;
+let timelineFlushInProgress = false;
+let timelineFlushRetryTimer: ReturnType<typeof setTimeout> | null = null;
+
 function isPersistedTimelineEventName(
   eventName: DriverProtocolEventName,
 ): eventName is DriverTimelineEventName {
   return PERSISTED_TIMELINE_EVENT_NAMES.has(eventName as DriverTimelineEventName);
+}
+
+function schedulePendingTimelineFlush(): void {
+  if (timelineFlushRetryTimer || pendingTimelineEvents.length === 0) {
+    return;
+  }
+  timelineFlushRetryTimer = setTimeout(() => {
+    timelineFlushRetryTimer = null;
+    void flushPendingTimelineEvents();
+  }, RETRY_FLUSH_DELAY_MS);
+}
+
+function enqueuePendingTimelineEvent(event: PendingTimelineEvent): void {
+  if (pendingTimelineEvents.length >= MAX_PENDING_TIMELINE_EVENTS) {
+    pendingTimelineEvents.shift();
+  }
+  pendingTimelineEvents.push(event);
+  schedulePendingTimelineFlush();
+}
+
+async function flushPendingTimelineEvents(): Promise<void> {
+  if (timelineFlushInProgress || pendingTimelineEvents.length === 0) {
+    return;
+  }
+
+  timelineFlushInProgress = true;
+  try {
+    const resolvedIncidentId = (await getDriverActiveIncident())?.incident_id?.trim();
+    if (!resolvedIncidentId) {
+      schedulePendingTimelineFlush();
+      return;
+    }
+
+    const queuedEvents = pendingTimelineEvents.splice(0, pendingTimelineEvents.length);
+    const failedEvents: PendingTimelineEvent[] = [];
+
+    for (const queuedEvent of queuedEvents) {
+      try {
+        await postDriverTimelineEvent(resolvedIncidentId, {
+          event_name: queuedEvent.eventName,
+          occurred_at_utc: queuedEvent.occurredAtUtc,
+          payload: queuedEvent.payload,
+        });
+      } catch {
+        failedEvents.push(queuedEvent);
+      }
+    }
+
+    if (failedEvents.length > 0) {
+      pendingTimelineEvents.unshift(...failedEvents);
+      schedulePendingTimelineFlush();
+    }
+  } finally {
+    timelineFlushInProgress = false;
+  }
 }
 
 export function emitTimelineAndAnalyticsEvent(
@@ -60,17 +127,25 @@ export function emitTimelineAndAnalyticsEvent(
   void (async () => {
     try {
       const explicitIncidentId = options?.incidentId?.trim();
+      const occurredAtUtc = new Date().toISOString();
       const resolvedIncidentId =
         explicitIncidentId || (await getDriverActiveIncident())?.incident_id?.trim();
       if (!resolvedIncidentId) {
+        enqueuePendingTimelineEvent({
+          eventName,
+          occurredAtUtc,
+          payload: options?.payload ?? {},
+        });
         return;
       }
 
       await postDriverTimelineEvent(resolvedIncidentId, {
         event_name: eventName,
-        occurred_at_utc: new Date().toISOString(),
+        occurred_at_utc: occurredAtUtc,
         payload: options?.payload ?? {},
       });
+
+      void flushPendingTimelineEvents();
     } catch {
       // Non-blocking telemetry write.
     }


### PR DESCRIPTION
### Motivation

- Prevent loss of driver protocol milestones emitted before incident creation by ensuring timeline events are persisted or retried when no incident is yet resolvable.
- Prevent cross-driver corruption of audit/export timelines by enforcing that timeline writes are only allowed for the driver assigned to the incident.

### Description

- Added an in-memory, bounded pending queue and retry-based flush logic in `driver-app/src/telemetry/protocolEvents.ts` so persisted timeline events emitted before an incident exists are queued with their original `occurred_at_utc` and backfilled once an active incident can be resolved, while keeping telemetry non-blocking and best-effort.
- Updated `POST /driver/incidents/{incident_id}/timeline-events` in `backend/app/api/routes_driver.py` to check `incident.adc_driver_id == str(driver.driver_id)` and return `403` when the authenticated driver does not own the incident.
- Added backend test `test_timeline_event_write_rejects_other_driver_incident` in `backend/tests/test_driver_admin_endpoints.py` to assert that timeline writes for another driver’s incident are rejected with `403`.

### Testing

- Ran backend static checks with `ruff` on the modified files (`cd backend && ruff check app/api/routes_driver.py tests/test_driver_admin_endpoints.py`) which passed.
- Attempted to run `pytest tests/test_driver_admin_endpoints.py`, but collection failed due to a pre-existing, unrelated import-time `NameError` in `app/api/routes_incidents.py`, so full test execution was blocked and the new test could not be executed end-to-end in this environment.
- Attempted to run `npx tsc --noEmit` in `driver-app`, but the TypeScript build is blocked by unrelated local environment/tsconfig/Expo typings issues and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e919818a1883219a7b45801d99e736)