### PR TITLE
Migrate legacy SecureStore upload queue to AsyncStorage during hydration

### DIFF
--- a/driver-app/src/store/uploadQueueStore.ts
+++ b/driver-app/src/store/uploadQueueStore.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
 
 const UPLOAD_QUEUE_STORAGE_KEY = 'driver_upload_queue_v1';
 const UPLOAD_QUEUE_VERSION = 1;
@@ -100,6 +101,23 @@ async function persistState(nextState: UploadQueueState): Promise<void> {
   await AsyncStorage.setItem(UPLOAD_QUEUE_STORAGE_KEY, JSON.stringify(nextState));
 }
 
+async function readPersistedState(): Promise<UploadQueueState | null> {
+  const asyncRaw = await AsyncStorage.getItem(UPLOAD_QUEUE_STORAGE_KEY);
+  if (asyncRaw) {
+    return normalizeState(JSON.parse(asyncRaw) as Partial<UploadQueueState>);
+  }
+
+  const secureRaw = await SecureStore.getItemAsync(UPLOAD_QUEUE_STORAGE_KEY);
+  if (!secureRaw) {
+    return null;
+  }
+
+  const migratedState = normalizeState(JSON.parse(secureRaw) as Partial<UploadQueueState>);
+  await AsyncStorage.setItem(UPLOAD_QUEUE_STORAGE_KEY, JSON.stringify(migratedState));
+  await SecureStore.deleteItemAsync(UPLOAD_QUEUE_STORAGE_KEY);
+  return migratedState;
+}
+
 function emit(nextState: UploadQueueState): void {
   for (const listener of listeners) {
     listener(nextState);
@@ -132,12 +150,11 @@ export async function hydrateUploadQueueStore(): Promise<void> {
 
   hydrateInFlight = (async () => {
     try {
-      const raw = await AsyncStorage.getItem(UPLOAD_QUEUE_STORAGE_KEY);
-      if (!raw) {
+      const persistedState = await readPersistedState();
+      if (!persistedState) {
         queueState = { ...EMPTY_STATE, updatedAt: makeNowIso() };
       } else {
-        const parsed = JSON.parse(raw) as Partial<UploadQueueState>;
-        queueState = normalizeState(parsed);
+        queueState = persistedState;
       }
     } catch {
       queueState = { ...EMPTY_STATE, updatedAt: makeNowIso() };


### PR DESCRIPTION
### Motivation
- Prevent silent loss of pending uploads when upgrading from a version that persisted the upload queue in `expo-secure-store` to the new AsyncStorage-backed queue by detecting and migrating legacy data during store hydration.

### Description
- Updated `driver-app/src/store/uploadQueueStore.ts` to import `expo-secure-store` and add a new `readPersistedState()` helper that checks `AsyncStorage` first and falls back to the legacy `driver_upload_queue_v1` key in `SecureStore`.
- When legacy data is found `readPersistedState()` normalizes the payload, writes the normalized state into `AsyncStorage`, and deletes the legacy `SecureStore` key to complete a one-time migration.
- Replaced the previous direct `AsyncStorage.getItem` usage in `hydrateUploadQueueStore()` with the migration-aware `readPersistedState()` path, preserving existing `EMPTY_STATE` behavior for empty or corrupt payloads.

### Testing
- Ran `cd driver-app && npx tsc --noEmit`, which fails in this environment due to missing project dependencies and Expo TypeScript base config (e.g. missing `expo/tsconfig.base` and type declarations), not because of the migration logic in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91a973d5083219c818b8f474f053d)