### PR TITLE
Follow-up: chain integration tracking migration into backend Alembic history

### DIFF
--- a/backend/app/db/migrations/versions/0017_add_integration_tracking_tables.py
+++ b/backend/app/db/migrations/versions/0017_add_integration_tracking_tables.py
@@ -1,7 +1,7 @@
 """Add integration tracking and webhook persistence tables.
 
-Revision ID: 20260411_0001
-Revises:
+Revision ID: 0017
+Revises: 0016
 Create Date: 2026-04-11
 """
 
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = "20260411_0001"
-down_revision = None
+revision = "0017"
+down_revision = "0016"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
### Motivation
- Ensure the new integration-tracking schema migration is applied by backend runtime/CI by placing it in the backend Alembic history so `alembic upgrade head` will create the new tables used by repository code.

### Description
- Moved the migration from `migrations/versions/20260411_0001_add_integration_tracking_tables.py` into the backend migration tree at `backend/app/db/migrations/versions/0017_add_integration_tracking_tables.py` and updated the Alembic metadata by setting `revision = "0017"`, `down_revision = "0016"`, and the docstring `Revises: 0016` so it chains correctly from the existing backend head.

### Testing
- Ran `cd backend && alembic heads` and verified `0017 (head)` and ran `cd backend && alembic history | head -n 5` and verified the history shows `0016 -> 0017 (head)`, both confirming the migration is now part of the backend Alembic lineage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91ac0795c832194bb48ca7991668b)