### PR TITLE
Follow-up: sanitize unavailable artifact messages in incident API

### DIFF
--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -45,6 +45,20 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+_UNAVAILABLE_REASON_MESSAGES: dict[str, str] = {
+    "camera_offline": "Camera footage is unavailable for the requested time window.",
+    "stream_unavailable": "Dashcam footage is temporarily unavailable. Please retry shortly.",
+    "dataset_unavailable": "Telematics data is unavailable for the requested time window.",
+}
+_DEFAULT_UNAVAILABLE_MESSAGE = "This artifact is currently unavailable."
+
+
+def _safe_unavailable_message(reason_code: str | None) -> str | None:
+    if not reason_code:
+        return None
+    return _UNAVAILABLE_REASON_MESSAGES.get(reason_code, _DEFAULT_UNAVAILABLE_MESSAGE)
+
+
 @router.get("/", response_model=list[IncidentListItem])
 def list_incidents_endpoint(
     db: Session = Depends(get_db),
@@ -184,7 +198,7 @@ def get_incident_endpoint(
                     else None
                 ),
                 unavailable_reason=a.unavailable_reason_code,
-                unavailable_message=a.unavailable_reason_detail,
+                unavailable_message=_safe_unavailable_message(a.unavailable_reason_code),
             )
             for a in artifacts
         ],

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -315,6 +315,7 @@ class TestGetIncident:
             artifact_type="dashcam_road",
             status="unavailable",
             unavailable_reason_code="camera_offline",
+            unavailable_reason_detail="RuntimeError: provider token=secret",
         )
         db_session.add(art)
         db_session.commit()
@@ -328,6 +329,51 @@ class TestGetIncident:
         ]
         assert len(found) == 1
         assert found[0]["unavailable_reason"] == "camera_offline"
+        assert (
+            found[0]["unavailable_message"]
+            == "Camera footage is unavailable for the requested time window."
+        )
+
+    @patch("app.api.routes_incidents.capture_telematics_bundle")
+    @patch("app.api.routes_incidents.capture_dashcam")
+    def test_get_incident_artifact_uses_default_safe_unavailable_message(
+        self, mock_dash, mock_tele, client, db_session, auth_headers
+    ):
+        mock_dash.delay = MagicMock()
+        mock_tele.delay = MagicMock()
+
+        create_resp = client.post(
+            "/incidents/",
+            json={
+                "severity": "serious",
+                "adc_vehicle_id": "veh-1",
+                "samsara_vehicle_id": "sm-1",
+                "adc_driver_id": "drv-1",
+            },
+            headers=auth_headers,
+        )
+        incident_id = create_resp.json()["incident_id"]
+
+        art = Artifact(
+            incident_id=uuid.UUID(incident_id),
+            artifact_type="telematics_trip",
+            status="unavailable",
+            unavailable_reason_code="unknown_failure",
+            unavailable_reason_detail="ConnectionError: provider account 123 failed",
+        )
+        db_session.add(art)
+        db_session.commit()
+
+        resp = client.get(f"/incidents/{incident_id}", headers=auth_headers)
+        data = resp.json()
+        found = [
+            a
+            for a in data["evidence_inventory"]
+            if a["artifact_type"] == "telematics_trip"
+        ]
+        assert len(found) == 1
+        assert found[0]["unavailable_reason"] == "unknown_failure"
+        assert found[0]["unavailable_message"] == "This artifact is currently unavailable."
 
     def test_get_incident_not_found(self, client, auth_headers):
         fake_id = str(uuid.uuid4())


### PR DESCRIPTION
### Motivation
- Close a P1 security/privacy regression where `artifact.unavailable_reason_detail` could leak raw provider/internal exception text to end users via the incident API.

### Description
- Stop exposing `unavailable_reason_detail` in responses and instead derive `unavailable_message` from a controlled map by adding `_UNAVAILABLE_REASON_MESSAGES` and `_safe_unavailable_message` in `backend/app/api/routes_incidents.py`.
- Replace `unavailable_message=a.unavailable_reason_detail` with `unavailable_message=_safe_unavailable_message(a.unavailable_reason_code)` so only UI-safe messages (or a generic fallback) are returned.
- Update `backend/tests/test_api_endpoints.py` to add a persisted `unavailable_reason_detail` to an artifact and add a test that verifies known reason codes return the mapped safe message while unknown codes return the generic fallback.

### Testing
- Ran the focused API tests with `cd backend && pytest -q tests/test_api_endpoints.py -k unavailable_message`, which passed (1 passed, others deselected).
- Ran linter checks with `cd backend && ruff check app/api/routes_incidents.py tests/test_api_endpoints.py`, which completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91ade49f083218cfa0d71b47a1b5a)