### PR TITLE
Fix datetime serialization for incident orchestration window bounds

### DIFF
--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -129,8 +129,10 @@ def create_incident_endpoint(
             actor_id=str(current_user.id),
         )
 
-        window_start = body.window_start
-        window_end = body.window_end
+        window_start = (
+            body.window_start.isoformat() if body.window_start is not None else None
+        )
+        window_end = body.window_end.isoformat() if body.window_end is not None else None
         request_correlation_id = (
             request.headers.get("x-correlation-id") or get_request_id() or str(uuid.uuid4())
         )

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -145,6 +145,28 @@ class TestCreateIncident:
         assert str(call_kwargs["incident_id"]) == incident_id
 
     @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
+    def test_create_incident_normalizes_window_bounds_for_orchestration(
+        self, mock_begin_capture, client, auth_headers
+    ):
+        resp = client.post(
+            "/incidents/",
+            json={
+                "severity": "minor",
+                "adc_vehicle_id": "v2",
+                "samsara_vehicle_id": "s2",
+                "adc_driver_id": "d2",
+                "window_start": "2026-01-01T10:00:00Z",
+                "window_end": "2026-01-01T10:30:00Z",
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 201
+        mock_begin_capture.assert_called_once()
+        call_kwargs = mock_begin_capture.call_args.kwargs
+        assert call_kwargs["window_start"] == "2026-01-01T10:00:00+00:00"
+        assert call_kwargs["window_end"] == "2026-01-01T10:30:00+00:00"
+
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_create_incident_writes_events(
         self, mock_begin_capture, client, db_session, auth_headers
     ):


### PR DESCRIPTION
### Motivation
- The orchestrator path persists incoming payloads as JSON, and forwarding `CreateIncidentRequest.window_start` / `window_end` as `datetime` objects can cause SQLAlchemy `StatementError` during JSON serialization.  
- Normalize timestamps at the API boundary to ensure orchestration payloads are JSON-serializable and avoid runtime failures when callers supply window bounds.

### Description
- Convert `body.window_start` and `body.window_end` to ISO-8601 strings in `create_incident_endpoint` (in `backend/app/api/routes_incidents.py`) before calling `IncidentEvidenceOrchestrator.begin_capture(...)`.  
- Pass `None` when the bounds are absent to preserve existing behavior.  
- Add a regression test `test_create_incident_normalizes_window_bounds_for_orchestration` in `backend/tests/test_api_endpoints.py` that posts window bounds and asserts the orchestrator is called with normalized UTC ISO strings (`+00:00`).

### Testing
- Ran the incident API tests with `cd backend && pytest tests/test_api_endpoints.py -q`.  
- Test run result: `57 passed` with unrelated deprecation warnings; the new regression test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91b2a79fc8321ab102892248bd753)