### PR TITLE
Fix telematics overall status when all datasets unavailable

### DIFF
--- a/backend/app/tasks/evidence_tasks.py
+++ b/backend/app/tasks/evidence_tasks.py
@@ -994,10 +994,10 @@ def capture_telematics_bundle(
         overall_status = "available"
         if failed_count == len(datasets):
             overall_status = "failed"
+        elif available_count == 0 and failed_count == 0 and unavailable_count > 0:
+            overall_status = "unavailable"
         elif failed_count > 0 or unavailable_count > 0:
             overall_status = "partial"
-        elif available_count == 0:
-            overall_status = "unavailable"
         operation.result_json = {
             "status": overall_status,
             "request_statuses": request_statuses,

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -479,6 +479,35 @@ class TestCaptureTelematicsBundle:
         assert len(unavailable) == 1
         assert len(captured) == 9
 
+    @patch("app.tasks.evidence_tasks._get_db")
+    @patch("app.services.vault_s3.VaultS3")
+    @patch("app.services.samsara_client.SamsaraClient")
+    def test_all_datasets_unavailable_sets_unavailable_status(
+        self, MockSamsara, MockS3, mock_get_db, db_session, incident
+    ):
+        mock_get_db.return_value = db_session
+
+        samsara_inst = MagicMock()
+        samsara_inst.get_eld_logs.return_value = []
+        samsara_inst.get_vehicle_locations.return_value = []
+        samsara_inst.get_safety_events.return_value = []
+        samsara_inst.get_vehicle_state.return_value = []
+        MockSamsara.return_value = samsara_inst
+
+        s3_inst = MagicMock()
+        s3_inst.put_bytes.return_value = "s3://b/k"
+        MockS3.return_value = s3_inst
+
+        from app.tasks.evidence_tasks import capture_telematics_bundle
+
+        result = capture_telematics_bundle(
+            str(incident.incident_id),
+            "2024-01-01T00:00:00Z",
+            "2024-01-01T01:00:00Z",
+        )
+
+        assert result["status"] == "unavailable"
+
     @patch("app.services.schema_validate.validate_payload", return_value=True)
     @patch("app.tasks.evidence_tasks._get_db")
     @patch("app.services.vault_s3.VaultS3")


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where runs in which every telematics dataset returns zero records were being classified as `partial` instead of the terminal `unavailable`, causing `result_json.status` to misreport complete data absence.

### Description
- Update `capture_telematics_bundle` in `backend/app/tasks/evidence_tasks.py` to set `overall_status = "unavailable"` when `available_count == 0`, `failed_count == 0`, and `unavailable_count > 0`, while preserving the existing `failed` precedence when all datasets fail.
- Add a regression test `test_all_datasets_unavailable_sets_unavailable_status` to `backend/tests/test_celery_tasks.py` that simulates empty responses for all datasets and asserts the task returns `status == "unavailable"`.

### Testing
- Ran `pytest backend/tests/test_celery_tasks.py -q` and observed `34 passed, 1 warning`.
- The new regression test executed successfully and no existing tests regressed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91b33cf0083219cf9e3bdae19b086)