### PR TITLE
Follow-up: count existing dashcam artifacts as captured to avoid false unavailable status

### DIFF
--- a/backend/app/tasks/evidence_tasks.py
+++ b/backend/app/tasks/evidence_tasks.py
@@ -301,6 +301,17 @@ def capture_dashcam(
                 )
                 art_id = _deterministic_uuid(artifact_key)
                 if _artifact_exists(db, art_id):
+                    set_evidence_request_status(
+                        db,
+                        evidence_request=evidence_request,
+                        status="fulfilled",
+                        response_payload_json={
+                            "artifact_id": str(art_id),
+                            "artifact_type": artifact_type,
+                            "status": "already_captured",
+                        },
+                    )
+                    captured_stream_count += 1
                     continue
                 s3_key = s3_key_builder.dashcam_key(
                     org_id=org_id,

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -421,6 +421,56 @@ class TestCaptureDashcam:
         assert first["status"] == "captured"
         assert second["status"] == "skipped_duplicate"
 
+    @patch("app.tasks.evidence_tasks._get_db")
+    @patch("app.services.vault_s3.VaultS3")
+    @patch("app.services.samsara_client.SamsaraClient")
+    def test_existing_artifact_counts_as_captured_for_final_status(
+        self, MockSamsara, MockS3, mock_get_db, db_session, incident
+    ):
+        """A retry should stay downloaded when a clip artifact already exists."""
+        mock_get_db.return_value = db_session
+
+        samsara_inst = MagicMock()
+        samsara_inst.fetch_dashcam_stream.return_value = b"video-bytes"
+        MockSamsara.return_value = samsara_inst
+        MockS3.return_value = MagicMock()
+
+        from app.tasks.evidence_tasks import capture_dashcam
+        from app.tasks.evidence_tasks import _deterministic_uuid, _idempotency_key
+        from app.db.repo.artifacts import create_artifact
+
+        workflow_key = f"dashcam:{incident.incident_id}:2024-01-01T00:00:00Z:2024-01-01T01:00:00Z"
+        artifact_type = "dash_cam_video_road"
+        art_id = _deterministic_uuid(
+            _idempotency_key(workflow_key, "road_facing", artifact_type, "video")
+        )
+
+        create_artifact(
+            db_session,
+            incident_id=incident.incident_id,
+            artifact_type=artifact_type,
+            status="captured",
+            artifact_id=art_id,
+        )
+
+        result = capture_dashcam(
+            str(incident.incident_id),
+            "2024-01-01T00:00:00Z",
+            "2024-01-01T01:00:00Z",
+        )
+
+        assert result["status"] == "captured"
+        assert result["captured_streams"] == 2
+
+        operation = (
+            db_session.query(IntegrationOperation)
+            .filter(IntegrationOperation.incident_id == incident.incident_id)
+            .order_by(IntegrationOperation.requested_at_utc.desc())
+            .first()
+        )
+        assert operation is not None
+        assert operation.status == "downloaded"
+
 
 # ── capture_telematics_bundle ───────────────────────────────────────
 


### PR DESCRIPTION
### Motivation
- Prevent a retry of the `capture_dashcam` task from concluding the overall operation as `unavailable` when deterministic artifacts already exist from a prior partial run. 
- Ensure per-stream `EvidenceRequest` state accurately reflects when an artifact was previously recorded so provider-level and UI state remain consistent.

### Description
- Updated `backend/app/tasks/evidence_tasks.py` so that when a deterministic artifact already exists (`_artifact_exists(db, art_id)`), the task now calls `set_evidence_request_status` with a `fulfilled` response payload indicating `already_captured` and increments `captured_stream_count` before continuing, instead of skipping without counting. 
- This change preserves the intended final operation status logic (`downloaded` when any stream is captured) by including existing artifacts in the captured tally. 
- Added a regression test `test_existing_artifact_counts_as_captured_for_final_status` to `backend/tests/test_celery_tasks.py` which seeds a pre-existing road-facing artifact, runs `capture_dashcam`, and verifies the task result, `captured_streams` count, and final `IntegrationOperation` status.

### Testing
- Ran the focused dashcam task tests with `pytest backend/tests/test_celery_tasks.py -k "existing_artifact_counts_as_captured_for_final_status or both_streams_captured or both_streams_unavailable or one_stream_unavailable" -q` which returned `4 passed` and no failures. 
- The added regression test verifies the retry scenario where a pre-existing artifact is counted toward final status and the operation is marked `downloaded` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91c07a3a88321859a670d5e316873)