### PR TITLE
[PR #179 Follow-up] Prevent duplicate retry operations in safety-manager notifications

### DIFF
--- a/backend/app/tasks/notification_tasks.py
+++ b/backend/app/tasks/notification_tasks.py
@@ -157,29 +157,23 @@ def notify_safety_manager(self, incident_id: str):
         }
 
         if org.sms_enabled:
-            sms_operation = create_message_operation(
-                db,
-                org_id=incident.org_id,
-                incident_id=inc_uuid,
-                provider="twilio",
-                domain="messaging",
-                purpose="safety_manager_sms_notification",
-                to_e164=phone,
-                status="queued",
-                payload_json={"task": "notify_safety_manager"},
-            )
             sms_event_key = f"{workflow_key}:sms_sent"
             if _event_exists(
                 db, inc_uuid, SystemEventType.SAFETY_MANAGER_SMS_SENT, sms_event_key
             ):
                 result["sms_status"] = "already_sent"
-                update_message_operation_status(
-                    db,
-                    sms_operation,
-                    to_status="sent",
-                    details_json={"reason": "already_sent_event_exists"},
-                )
             else:
+                sms_operation = create_message_operation(
+                    db,
+                    org_id=incident.org_id,
+                    incident_id=inc_uuid,
+                    provider="twilio",
+                    domain="messaging",
+                    purpose="safety_manager_sms_notification",
+                    to_e164=phone,
+                    status="queued",
+                    payload_json={"task": "notify_safety_manager"},
+                )
                 try:
                     sms_sid = send_sms(phone, message)
                     result["sms_sid"] = sms_sid
@@ -226,29 +220,23 @@ def notify_safety_manager(self, incident_id: str):
                     errors.append(f"SMS failed: {normalized_error.operator_message}")
 
         if org.voice_enabled:
-            call_operation = create_message_operation(
-                db,
-                org_id=incident.org_id,
-                incident_id=inc_uuid,
-                provider="twilio",
-                domain="voice",
-                purpose="safety_manager_voice_notification",
-                to_e164=phone,
-                status="queued",
-                payload_json={"task": "notify_safety_manager"},
-            )
             call_event_key = f"{workflow_key}:call_placed"
             if _event_exists(
                 db, inc_uuid, SystemEventType.SAFETY_MANAGER_CALL_PLACED, call_event_key
             ):
                 result["call_status"] = "already_placed"
-                update_message_operation_status(
-                    db,
-                    call_operation,
-                    to_status="sent",
-                    details_json={"reason": "already_placed_event_exists"},
-                )
             else:
+                call_operation = create_message_operation(
+                    db,
+                    org_id=incident.org_id,
+                    incident_id=inc_uuid,
+                    provider="twilio",
+                    domain="voice",
+                    purpose="safety_manager_voice_notification",
+                    to_e164=phone,
+                    status="queued",
+                    payload_json={"task": "notify_safety_manager"},
+                )
                 try:
                     call_sid = place_call(phone, twiml)
                     result["call_sid"] = call_sid

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -16,7 +16,16 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from app.db.models import Artifact, Base, Event, Export, Incident, IntegrationOperation, Org
+from app.db.models import (
+    Artifact,
+    Base,
+    Event,
+    Export,
+    Incident,
+    IntegrationOperation,
+    MessageOperation,
+    Org,
+)
 from app.domain.system_event_types import SystemEventType
 from app.tasks.notification_tasks import notify_safety_manager
 
@@ -996,3 +1005,5 @@ class TestNotifySafetyManager:
         assert second["status"] == "skipped_duplicate"
         assert mock_send_sms.call_count == 1
         assert mock_place_call.call_count == 1
+        message_operations = db_session.query(MessageOperation).all()
+        assert len(message_operations) == 2


### PR DESCRIPTION
### Motivation
- Fix an idempotency bug where duplicate notification retries created new `message_operations` rows and were marked `sent` even when no Twilio send/place-call occurred, which skews messaging reliability rollups.

### Description
- In `backend/app/tasks/notification_tasks.py` moved `create_message_operation` for both SMS and voice to occur only after checking `_event_exists`, so operations are not created for already-emitted idempotent events.
- Removed the code path that updated a newly-created operation to `sent` when the event was already present, preventing false-positive operation state transitions.
- Added a regression assertion in `backend/tests/test_celery_tasks.py` to verify only two `MessageOperation` rows exist after two invocations of `notify_safety_manager` (one SMS + one voice).

### Testing
- Ran the notification task unit tests with `cd backend && pytest -q tests/test_celery_tasks.py::TestNotifySafetyManager` and they passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91c0ed260832194d8287dee40a58e)