### PR TITLE
Enforce signature-first handling for Twilio webhooks and add DB migration

### DIFF
--- a/backend/app/db/migrations/versions/0018_add_provider_webhook_event_processing_fields.py
+++ b/backend/app/db/migrations/versions/0018_add_provider_webhook_event_processing_fields.py
@@ -1,0 +1,69 @@
+"""add provider webhook event processing fields
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-04-22
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0018"
+down_revision: Union[str, None] = "0017"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("provider_webhook_events", sa.Column("signature_valid", sa.Boolean(), nullable=True))
+    op.add_column("provider_webhook_events", sa.Column("idempotency_key", sa.Text(), nullable=True))
+    op.add_column("provider_webhook_events", sa.Column("processing_outcome", sa.Text(), nullable=True))
+    op.add_column(
+        "provider_webhook_events",
+        sa.Column("raw_payload", sa.Text(), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "provider_webhook_events",
+        sa.Column(
+            "error_details_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+
+    op.create_index(
+        "ix_provider_webhook_events_signature_valid",
+        "provider_webhook_events",
+        ["signature_valid"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_provider_webhook_events_idempotency_key",
+        "provider_webhook_events",
+        ["idempotency_key"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_provider_webhook_events_processing_outcome",
+        "provider_webhook_events",
+        ["processing_outcome"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_provider_webhook_events_processing_outcome", table_name="provider_webhook_events")
+    op.drop_index("ix_provider_webhook_events_idempotency_key", table_name="provider_webhook_events")
+    op.drop_index("ix_provider_webhook_events_signature_valid", table_name="provider_webhook_events")
+
+    op.drop_column("provider_webhook_events", "error_details_json")
+    op.drop_column("provider_webhook_events", "raw_payload")
+    op.drop_column("provider_webhook_events", "processing_outcome")
+    op.drop_column("provider_webhook_events", "idempotency_key")
+    op.drop_column("provider_webhook_events", "signature_valid")

--- a/backend/app/integrations/webhooks/handlers.py
+++ b/backend/app/integrations/webhooks/handlers.py
@@ -52,6 +52,25 @@ def process_twilio_status_callback(
         payload=payload,
     )
 
+    if not signature_valid:
+        create_provider_webhook_event(
+            db,
+            org_id=None,
+            provider="twilio",
+            domain="messaging",
+            event_type="status_callback",
+            status="failed",
+            external_reference=message_sid,
+            idempotency_key=idempotency_key,
+            signature_valid=False,
+            processing_outcome="invalid_signature",
+            raw_payload=raw_payload,
+            payload_json=payload,
+            error_message="twilio_signature_validation_failed",
+            error_details_json={"reason": signature_error or "invalid_signature"},
+        )
+        return WebhookResult(status_code=403, body={"detail": "Invalid Twilio signature"})
+
     existing = get_provider_webhook_event_by_idempotency_key(
         db,
         provider="twilio",
@@ -90,17 +109,6 @@ def process_twilio_status_callback(
         raw_payload=raw_payload,
         payload_json=payload,
     )
-
-    if not signature_valid:
-        update_provider_webhook_event(
-            db,
-            event,
-            status="failed",
-            processing_outcome="invalid_signature",
-            error_message="twilio_signature_validation_failed",
-            error_details_json={"reason": signature_error or "invalid_signature"},
-        )
-        return WebhookResult(status_code=403, body={"detail": "Invalid Twilio signature"})
 
     message_status = (payload.get("MessageStatus") or "").strip().lower()
     error_code = payload.get("ErrorCode") or None

--- a/backend/tests/test_twilio_routes.py
+++ b/backend/tests/test_twilio_routes.py
@@ -162,3 +162,53 @@ def test_twilio_status_callback_idempotency(monkeypatch, client, db_session):
     assert events[0].status == "processed"
     assert events[1].status == "ignored"
     assert events[1].processing_outcome == "duplicate"
+
+
+def test_twilio_status_callback_invalid_signature_is_not_short_circuited_by_duplicate(
+    monkeypatch, client, db_session
+):
+    monkeypatch.setattr(settings, "TWILIO_AUTH_TOKEN", "secret")
+    org = Org(name="Test Org")
+    db_session.add(org)
+    db_session.commit()
+
+    create_message_operation(
+        db_session,
+        org_id=org.id,
+        provider="twilio",
+        domain="messaging",
+        purpose="safety_manager_sms_notification",
+        to_e164="+15551234567",
+        status="sent",
+        provider_message_id="SM123",
+    )
+
+    params = {"MessageSid": "SM123", "MessageStatus": "delivered"}
+    url = f"{client.base_url}/twilio/status"
+    valid_signature = _build_twilio_signature("secret", url, params)
+
+    response_valid = client.post(
+        "/twilio/status",
+        data=params,
+        headers={"X-Twilio-Signature": valid_signature},
+    )
+    response_invalid = client.post(
+        "/twilio/status",
+        data=params,
+        headers={"X-Twilio-Signature": "invalid-signature"},
+    )
+
+    assert response_valid.status_code == 200
+    assert response_invalid.status_code == 403
+    assert "Invalid Twilio signature" in response_invalid.text
+
+    events = (
+        db_session.query(ProviderWebhookEvent)
+        .filter(ProviderWebhookEvent.event_type == "status_callback")
+        .order_by(ProviderWebhookEvent.received_at_utc.asc())
+        .all()
+    )
+    assert len(events) == 2
+    assert events[0].status == "processed"
+    assert events[1].status == "failed"
+    assert events[1].processing_outcome == "invalid_signature"


### PR DESCRIPTION
### Motivation

- Prevent invalid Twilio callbacks from being short-circuited by idempotency lookups so retries with different signature validity are handled correctly. 
- Ensure the database schema contains the new `ProviderWebhookEvent` columns that webhook handlers now read/write to avoid runtime missing-column errors.

### Description

- Validate Twilio signatures before performing idempotency duplicate checks in `process_twilio_status_callback` so invalid requests are persisted as failed and return `403` immediately. 
- Persist invalid-signature events with `processing_outcome="invalid_signature"` and `status="failed"` so audit and replay can observe signature validity. 
- Add Alembic migration `0018_add_provider_webhook_event_processing_fields.py` to add `signature_valid`, `idempotency_key`, `processing_outcome`, `raw_payload`, and `error_details_json` columns plus indexes. 
- Add a regression test in `backend/tests/test_twilio_routes.py` that verifies invalid-signature retries are not treated as duplicates and are persisted as failures.

### Testing

- Ran `cd backend && pytest tests/test_twilio_routes.py -q` and all Twilio route tests passed (`6 passed`).
- Ran `cd backend && pytest tests/test_migration_integrity.py -q` and the migration integrity check passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91c1bb4f48321b97e44d2bf09eaca)