### PR TITLE
Fix Twilio status webhook to return 403 on invalid signatures

### DIFF
--- a/backend/app/api/routes_integrations.py
+++ b/backend/app/api/routes_integrations.py
@@ -405,4 +405,6 @@ async def provider_twilio_status_webhook(request: Request, db: Session = Depends
         signature_valid=signature_valid,
         signature_error=signature_error,
     )
+    if result.status_code == 403:
+        return Response(status_code=403, content=result.body.get("detail", "Invalid Twilio signature"))
     return result.body

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -339,6 +339,19 @@ class TestIntegrationDiagnosticsRoutes:
         assert summary_resp.status_code == 200
         assert summary_resp.json()["retryable_failures"] == 1
 
+    @patch("app.api.routes_integrations.process_twilio_status_callback")
+    def test_provider_twilio_status_webhook_preserves_forbidden_status(
+        self, mock_process_status_callback, client
+    ):
+        mock_process_status_callback.return_value = MagicMock(
+            status_code=403, body={"detail": "Invalid Twilio signature"}
+        )
+
+        response = client.post("/provider-webhooks/twilio/status", data={"MessageSid": "SM123"})
+
+        assert response.status_code == 403
+        assert response.text == "Invalid Twilio signature"
+
     @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_get_incident_returns_created_at(
         self, mock_begin_capture, client, auth_headers


### PR DESCRIPTION
### Motivation
- Prevent the `/provider-webhooks/twilio/status` route from acknowledging invalid Twilio signatures as HTTP 200, which weakens webhook authentication and hides failed requests.
- Ensure the integration webhook route preserves the `status_code` returned by the shared handler so failures (403) are propagated to callers and monitoring.

### Description
- Updated `backend/app/api/routes_integrations.py` so `provider_twilio_status_webhook` returns a `Response` with `status_code=403` and the handler `detail` when `process_twilio_status_callback` yields a 403 result instead of returning the handler body directly.
- Added a regression test in `backend/tests/test_api_endpoints.py` that patches `process_twilio_status_callback` to return a 403 and asserts the integration route responds with status 403 and the expected error text.
- Committed the fix and test to ensure the behavior is enforced going forward.

### Testing
- Ran the focused test with `cd backend && pytest tests/test_api_endpoints.py -k provider_twilio_status_webhook_preserves_forbidden_status`, which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91d5ed2308321bf4c7de4368556e5)