### PR TITLE
Sort exports before deriving latest preflight state

### DIFF
--- a/frontend/components/IncidentDetailExportPanel.tsx
+++ b/frontend/components/IncidentDetailExportPanel.tsx
@@ -59,6 +59,24 @@ function formatWindow(start?: string | null, end?: string | null): string | null
   return `${startLabel} → ${endLabel}`;
 }
 
+function getExportSortTimestamp(item: ExportSummary): number {
+  const candidates = [
+    item.created_at_utc,
+    item.requested_at_utc,
+    item.updated_at_utc,
+  ];
+
+  for (const value of candidates) {
+    if (!value) continue;
+    const parsed = new Date(value).getTime();
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+
+  return 0;
+}
+
 export default function IncidentDetailExportPanel({
   incidentId,
   exports,
@@ -73,7 +91,11 @@ export default function IncidentDetailExportPanel({
   const [errorMessage, setErrorMessage] = useState("");
   const [readyExport, setReadyExport] = useState<ExportSummary | null>(null);
 
-  const recentExports = exports.slice(0, 5);
+  const sortedExports = useMemo(
+    () => [...exports].sort((a, b) => getExportSortTimestamp(b) - getExportSortTimestamp(a)),
+    [exports]
+  );
+  const recentExports = sortedExports.slice(0, 5);
   const latestExport = recentExports[0];
   const latestFailedExportId =
     activeExportId && (status === "failed" || status === "expired")


### PR DESCRIPTION
### Motivation
- Prevent preflight evidence statuses and warnings from being derived from an arbitrary historical export row when the backend `get_exports_by_incident` list is not ordered.

### Description
- Update `frontend/components/IncidentDetailExportPanel.tsx` to sort the incoming `exports` array by timestamp before selecting the most-recent export used for preflight UI and rollups.
- Add a new helper `getExportSortTimestamp` that prefers `created_at_utc`, then `requested_at_utc`, then `updated_at_utc` to produce a robust sort key for exports with missing/invalid timestamps.
- Replace the prior `exports.slice(0,5)` usage with a `useMemo`-backed `sortedExports` and derive `recentExports`/`latestExport` from that sorted list so preflight panels/readouts use the deterministic latest export.

### Testing
- Ran `cd frontend && npm run lint` and the lint job completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91d6574188321b082a3060b7dec57)