### PR TITLE
Follow-up: fix stuck-job/OTP metric correctness for PR #184

### DIFF
--- a/backend/app/db/repo/job_execution_meta.py
+++ b/backend/app/db/repo/job_execution_meta.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from app.core.metrics import MetricNames, increment
 from app.db.models import JobExecutionMeta
 from app.db.session import SessionLocal
 
@@ -167,8 +168,10 @@ def list_ops_jobs_with_db(
             if heartbeat.tzinfo is None:
                 heartbeat = heartbeat.replace(tzinfo=timezone.utc)
             if heartbeat < stale_threshold:
-                row.status = "stuck"
-                db.flush()
+                if row.status != "stuck":
+                    row.status = "stuck"
+                    increment(MetricNames.RETRY_SCHEDULER_STUCK_IN_PROGRESS)
+                    db.flush()
     return (
         db.query(JobExecutionMeta)
         .filter(JobExecutionMeta.status.in_(statuses | {"stuck"}))

--- a/backend/app/integrations/webhooks/handlers.py
+++ b/backend/app/integrations/webhooks/handlers.py
@@ -155,9 +155,10 @@ def process_twilio_status_callback(
         normalized_error_code=f"TWILIO_{error_code}" if error_code else None,
         details_json=payload,
     )
-    if mapped in {"failed", "undelivered"}:
+    is_otp_operation = operation.purpose in {"otp_request", "otp_verify"} or operation.domain == "auth"
+    if is_otp_operation and mapped in {"failed", "undelivered"}:
         increment(MetricNames.OTP_DELIVERY_FAILURE)
-    if mapped == "delivered":
+    if is_otp_operation and mapped == "delivered":
         increment(MetricNames.OTP_DELIVERY_SUCCESS)
     update_provider_webhook_event(
         db,

--- a/backend/app/jobs/tracking.py
+++ b/backend/app/jobs/tracking.py
@@ -38,7 +38,6 @@ def record_task_queued(
 
 
 def record_task_started(*, task_name: str, task_id: str, max_retries: int) -> None:
-    increment(MetricNames.RETRY_SCHEDULER_STUCK_IN_PROGRESS)
     upsert_job_execution_meta(
         task_id=task_id,
         task_name=task_name,

--- a/backend/tests/test_job_execution_meta_metrics.py
+++ b/backend/tests/test_job_execution_meta_metrics.py
@@ -1,0 +1,75 @@
+"""Tests for retry scheduler stuck metric emission."""
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db.models import Base, JobExecutionMeta
+from app.db.repo import job_execution_meta as job_execution_meta_repo
+from app.jobs import tracking
+
+
+def _build_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def test_record_task_started_does_not_emit_stuck_metric(monkeypatch):
+    calls: list[str] = []
+
+    def _capture(metric_name: str) -> None:
+        calls.append(metric_name)
+
+    monkeypatch.setattr(tracking, "increment", _capture)
+    monkeypatch.setattr(tracking, "upsert_job_execution_meta", lambda **_: None)
+
+    tracking.record_task_started(
+        task_name="app.tasks.evidence.capture",
+        task_id="task-123",
+        max_retries=3,
+    )
+
+    assert calls == []
+
+
+def test_list_ops_jobs_emits_stuck_metric_for_stale_running_tasks(monkeypatch):
+    db = _build_session()
+    try:
+        stale_heartbeat = datetime.now(timezone.utc) - timedelta(minutes=31)
+        row = JobExecutionMeta(
+            celery_task_id="task-456",
+            task_name="app.tasks.evidence.capture",
+            task_type="evidence_capture",
+            status="running",
+            retry_count=0,
+            last_heartbeat_at_utc=stale_heartbeat,
+            started_at_utc=stale_heartbeat,
+        )
+        db.add(row)
+        db.commit()
+
+        calls: list[str] = []
+
+        def _capture(metric_name: str) -> None:
+            calls.append(metric_name)
+
+        monkeypatch.setattr(job_execution_meta_repo, "increment", _capture)
+
+        results = job_execution_meta_repo.list_ops_jobs_with_db(
+            db=db,
+            statuses={"running", "retrying", "failed"},
+            stale_after_minutes=15,
+        )
+
+        assert any(item.status == "stuck" for item in results)
+        assert calls == ["retry.scheduler.stuck_in_progress"]
+    finally:
+        db.close()

--- a/backend/tests/test_twilio_routes.py
+++ b/backend/tests/test_twilio_routes.py
@@ -8,9 +8,11 @@ from sqlalchemy.pool import StaticPool
 
 from app.api.routes_twilio import VOICE_MESSAGE, _build_twilio_signature
 from app.core.config import settings
+from app.core.metrics import MetricNames
 from app.db.models import Base, MessageOperation, Org, ProviderWebhookEvent
 from app.db.repo.message_operations import create_message_operation
 from app.db.session import get_db
+from app.integrations.webhooks import handlers
 from app.main import app
 
 
@@ -162,3 +164,65 @@ def test_twilio_status_callback_idempotency(monkeypatch, client, db_session):
     assert events[0].status == "processed"
     assert events[1].status == "ignored"
     assert events[1].processing_outcome == "duplicate"
+
+
+def test_twilio_status_callback_otp_metrics_only_for_otp_operations(
+    monkeypatch, client, db_session
+):
+    monkeypatch.setattr(settings, "TWILIO_AUTH_TOKEN", "secret")
+    org = Org(name="Test Org")
+    db_session.add(org)
+    db_session.commit()
+
+    create_message_operation(
+        db_session,
+        org_id=org.id,
+        provider="twilio",
+        domain="messaging",
+        purpose="safety_manager_sms_notification",
+        to_e164="+15551234567",
+        status="sent",
+        provider_message_id="SM_NON_OTP",
+    )
+    create_message_operation(
+        db_session,
+        org_id=org.id,
+        provider="twilio",
+        domain="auth",
+        purpose="otp_request",
+        to_e164="+15557654321",
+        status="sent",
+        provider_message_id="SM_OTP",
+    )
+
+    emitted_metrics: list[str] = []
+
+    def _capture(metric_name: str) -> None:
+        emitted_metrics.append(metric_name)
+
+    monkeypatch.setattr(handlers, "increment", _capture)
+
+    non_otp_params = {"MessageSid": "SM_NON_OTP", "MessageStatus": "failed"}
+    non_otp_sig = _build_twilio_signature(
+        "secret", f"{client.base_url}/twilio/status", non_otp_params
+    )
+    otp_params = {"MessageSid": "SM_OTP", "MessageStatus": "delivered"}
+    otp_sig = _build_twilio_signature(
+        "secret", f"{client.base_url}/twilio/status", otp_params
+    )
+
+    non_otp_response = client.post(
+        "/twilio/status",
+        data=non_otp_params,
+        headers={"X-Twilio-Signature": non_otp_sig},
+    )
+    otp_response = client.post(
+        "/twilio/status",
+        data=otp_params,
+        headers={"X-Twilio-Signature": otp_sig},
+    )
+
+    assert non_otp_response.status_code == 200
+    assert otp_response.status_code == 200
+    assert MetricNames.OTP_DELIVERY_FAILURE not in emitted_metrics
+    assert emitted_metrics.count(MetricNames.OTP_DELIVERY_SUCCESS) == 1

--- a/infra/monitoring/alert-policies.yaml
+++ b/infra/monitoring/alert-policies.yaml
@@ -220,7 +220,7 @@ alert_policies:
     section_ref: "7.4"
     severity: critical
     condition: "stuck in-progress jobs > 25 for 15m"
-    expression: "max(job_execution_stuck_total{service='adc-worker',environment='prod'}) > 25"
+    expression: "max(retry_scheduler_stuck_in_progress_total{service='adc-worker',environment='prod'}) > 25"
     for: 15m
     routing:
       pager: primary


### PR DESCRIPTION
### Motivation
- Fix critical metric/alert mismatches introduced by the integration reliability changes so alerts can evaluate real conditions instead of emitting false positives. 
- Ensure the retry-scheduler "stuck" metric is only incremented when a job is actually classified as stale/stuck rather than on every task start. 
- Prevent non-OTP messaging traffic from inflating OTP delivery metrics which would otherwise trigger OTP delivery alerts.

### Description
- Update the alert expression in `infra/monitoring/alert-policies.yaml` to query `retry_scheduler_stuck_in_progress_total` instead of the non-existent `job_execution_stuck_total`. 
- Remove the premature `RETRY_SCHEDULER_STUCK_IN_PROGRESS` increment from `record_task_started` in `backend/app/jobs/tracking.py`. 
- Emit `RETRY_SCHEDULER_STUCK_IN_PROGRESS` only when a job is reclassified as `stuck` in `list_ops_jobs_with_db` inside `backend/app/db/repo/job_execution_meta.py`. 
- Gate OTP delivery metric updates in the Twilio status callback handler (`backend/app/integrations/webhooks/handlers.py`) so `OTP_DELIVERY_SUCCESS`/`OTP_DELIVERY_FAILURE` are only incremented for OTP-related operations (checked by `purpose` or `domain`).

### Testing
- Ran targeted unit tests with `cd backend && pytest tests/test_job_execution_meta_metrics.py tests/test_twilio_routes.py -q` and all tests passed (`8 passed`).
- Ran static checks with `cd backend && ruff check app/jobs/tracking.py app/db/repo/job_execution_meta.py app/integrations/webhooks/handlers.py tests/test_job_execution_meta_metrics.py tests/test_twilio_routes.py` and the linter checks passed.
- Added regression tests `backend/tests/test_job_execution_meta_metrics.py` and an OTP gating test in `backend/tests/test_twilio_routes.py` which were executed by the test run above and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91d7381ec83218eb204eb4c2826d0)