### PR TITLE
Preserve telematics terminal failure state and restore dashcam autoretry

### DIFF
--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -73,6 +73,7 @@ celery_app.conf.update(
     },
     task_annotations={
         "app.tasks.evidence_tasks.capture_dashcam": {
+            "autoretry_for": (Exception,),
             "max_retries": dashcam_retry_policy.max_retries,
             "retry_backoff": dashcam_retry_policy.base_delay_seconds,
             "retry_backoff_max": dashcam_retry_policy.backoff_cap_seconds,

--- a/backend/app/tasks/evidence_tasks.py
+++ b/backend/app/tasks/evidence_tasks.py
@@ -1145,6 +1145,7 @@ def capture_telematics_bundle(
                 message=f"Telematics capture task failed: {exc}",
             )
         if retry_class == "non_retryable_intervention_required":
+            admin_action = _admin_action_for_reason(reason_code)
             if "org_id" in locals():
                 mark_connection_intervention_required(
                     db,
@@ -1152,18 +1153,13 @@ def capture_telematics_bundle(
                     provider="samsara",
                     domain="telematics",
                     reason_code=reason_code,
-                    admin_action=_admin_action_for_reason(reason_code),
+                    admin_action=admin_action,
                     message=normalized_error.user_facing_message,
                 )
             increment(MetricNames.CELERY_TASK_FAILURES)
-            return {
-                "incident_id": incident_id,
-                "type": "telematics",
-                "status": "failed",
-                "reason_code": reason_code,
-                "action_required": _admin_action_for_reason(reason_code),
-                "idempotency_key": workflow_key,
-            }
+            raise RuntimeError(
+                f"Telematics capture requires admin intervention: {reason_code} ({admin_action})"
+            ) from exc
         policy = get_policy_for_capability("telematics")
         if self.request.retries < policy.max_retries:
             delay = compute_retry_delay_seconds(

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -136,6 +136,9 @@ class TestCeleryAppConfig:
         from app.tasks.celery_app import celery_app
 
         annotations = celery_app.conf.task_annotations
+        assert annotations["app.tasks.evidence_tasks.capture_dashcam"]["autoretry_for"] == (
+            Exception,
+        )
         assert annotations["app.tasks.evidence_tasks.capture_dashcam"]["retry_backoff"]
         assert annotations["app.tasks.export_tasks.build_export"]["retry_jitter"]
 
@@ -606,12 +609,12 @@ class TestCaptureTelematicsBundle:
 
         from app.tasks.evidence_tasks import capture_telematics_bundle
 
-        result = capture_telematics_bundle(
-            str(incident.incident_id),
-            "2024-01-01T00:00:00Z",
-            "2024-01-01T01:00:00Z",
-        )
-        assert result["action_required"] == "reauth_required"
+        with pytest.raises(RuntimeError, match="requires admin intervention"):
+            capture_telematics_bundle(
+                str(incident.incident_id),
+                "2024-01-01T00:00:00Z",
+                "2024-01-01T01:00:00Z",
+            )
 
         connection = (
             db_session.query(IntegrationConnection)


### PR DESCRIPTION
### Motivation

- Ensure intervention-required integration errors are recorded as task failures so Celery `task_failure` hooks and terminal/dead-letter handling run instead of being recorded as successes.  
- Restore the previous retry semantics for `capture_dashcam` so top-level exceptions trigger configured automatic retries.  

### Description

- In `backend/app/tasks/evidence_tasks.py` change the `non_retryable_intervention_required` path in `capture_telematics_bundle` to raise a `RuntimeError` after calling `mark_connection_intervention_required`, preserving failure semantics and metric increments.  
- In `backend/app/tasks/celery_app.py` re-added `"autoretry_for": (Exception,)` to the `capture_dashcam` task annotation so outer-path exceptions are retried according to the configured backoff and max retries.  
- Updated `backend/tests/test_celery_tasks.py` to assert the `capture_dashcam` annotation includes `autoretry_for` and to expect a `RuntimeError` from the telematics credential path while still verifying the integration connection is marked for admin action.  

### Testing

- Ran the focused test command `pytest -q backend/tests/test_celery_tasks.py::TestCeleryAppConfig::test_retry_annotations_defined backend/tests/test_celery_tasks.py::TestCaptureTelematicsBundle::test_credentials_invalid_marks_connection_for_reauth`.  
- Result: `2 passed` with a single Pydantic deprecation warning reported by the test run.  
- Unit tests updated to guard the restored `autoretry_for` behavior and the telematics intervention error path passed under the modified expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91fbf8fdc8321a1bfd20d0ee6b74f)