### PR TITLE
Load events and exports for incident list snapshot to fix readiness/completeness

### DIFF
--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -62,12 +62,14 @@ def list_incidents_endpoint(
     result = []
     for inc in incidents:
         artifacts = get_artifacts_by_incident(db, inc.incident_id)
+        events = get_events_by_incident(db, inc.incident_id)
+        exports = get_exports_by_incident(db, inc.incident_id)
         captured = sum(1 for a in artifacts if a.status == "captured")
         snapshot = build_case_snapshot(
             incident=inc,
             artifacts=artifacts,
-            events=[],
-            exports=[],
+            events=events,
+            exports=exports,
         )
         result.append(
             IncidentListItem(

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -508,6 +508,59 @@ class TestListIncidents:
         assert inc["evidence_total"] == 2
         assert "created_at_utc" in inc
 
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
+    def test_list_incidents_uses_events_and_exports_for_snapshot(
+        self, mock_begin_capture, client, db_session, auth_headers
+    ):
+        create_resp = client.post(
+            "/incidents/",
+            json={
+                "severity": "minor",
+                "adc_vehicle_id": "v1",
+                "samsara_vehicle_id": "s1",
+                "adc_driver_id": "d1",
+            },
+            headers=auth_headers,
+        )
+        incident_id = uuid.UUID(create_resp.json()["incident_id"])
+
+        db_session.add(
+            Artifact(
+                incident_id=incident_id,
+                artifact_type="dashcam_road",
+                status="captured",
+            )
+        )
+        db_session.add_all(
+            [
+                Event(
+                    incident_id=incident_id,
+                    event_type="timeline_validated",
+                    actor_type="system",
+                    actor_id="system",
+                ),
+                Event(
+                    incident_id=incident_id,
+                    event_type="export_completed",
+                    actor_type="system",
+                    actor_id="system",
+                ),
+                Export(
+                    incident_id=incident_id,
+                    status="ready",
+                ),
+            ]
+        )
+        db_session.commit()
+
+        resp = client.get("/incidents/", headers=auth_headers)
+        assert resp.status_code == 200
+
+        inc = [i for i in resp.json() if i["incident_id"] == str(incident_id)][0]
+        assert inc["completeness_percent"] == 100
+        assert inc["readiness_state"] == "ready_for_export"
+        assert inc["blocker_counts"] == {"critical": 0, "important": 0, "optional": 0}
+
 
 # ── POST /exports ────────────────────────────────────────────────────
 


### PR DESCRIPTION
### Motivation

- The incident list previously derived completeness/readiness with `events=[]` and `exports=[]`, causing false `timeline_validation_missing`/export blockers and mismatches with the detail endpoint.
- List-level readiness fields must reflect actual timeline and export data so UI and operators receive a consistent view.
- This change addresses the high-priority correctness issue flagged during review by ensuring snapshots include timeline and export data.

### Description

- Updated `backend/app/api/routes_incidents.py` to call `get_events_by_incident` and `get_exports_by_incident` and pass `events` and `exports` into `build_case_snapshot(...)` for each listed incident.
- Added a regression test `test_list_incidents_uses_events_and_exports_for_snapshot` in `backend/tests/test_api_endpoints.py` that creates timeline validation/export events and a ready `Export` and asserts the list endpoint reports `completeness_percent == 100`, `readiness_state == "ready_for_export"`, and zero blocker counts.
- The list endpoint continues to populate `completeness_percent`, `completeness_status`, `readiness_state`, and `blocker_counts` from the computed snapshot so list-level fields align with detail responses.

### Testing

- Ran `pytest -q backend/tests/test_api_endpoints.py::TestListIncidents::test_list_incidents_returns_evidence_counts backend/tests/test_api_endpoints.py::TestListIncidents::test_list_incidents_uses_events_and_exports_for_snapshot` and both tests passed.
- The change is narrowly scoped and covered by the new regression test validating snapshot derivation and readiness/blocker outcomes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91fc8c8dc8321a8a1745190eb4213)