### PR TITLE
[Follow-up] Fix incident owner membership validation for incident org

### DIFF
--- a/backend/app/services/incident_ownership_service.py
+++ b/backend/app/services/incident_ownership_service.py
@@ -27,7 +27,10 @@ def patch_incident_owner(
         assert owner_user_id is not None
         is_user_in_org = (
             db.query(UserOrg)
-            .filter(UserOrg.user_id == owner_user_id, UserOrg.org_id.in_(org_ids))
+            .filter(
+                UserOrg.user_id == owner_user_id,
+                UserOrg.org_id == incident.org_id,
+            )
             .first()
             is not None
         )

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -715,6 +715,41 @@ class TestPatchIncidentOwner:
         assert response.status_code == 404
         assert response.json()["detail"] == "Owner user not found"
 
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
+    def test_patch_owner_rejects_owner_from_other_member_org(
+        self, mock_begin_capture, client, db_session, test_org, test_user, auth_headers
+    ):
+        incident_id = self._create_incident(client, auth_headers)
+
+        secondary_org = Org(name="Secondary Org")
+        secondary_owner = User(
+            email="secondary-owner@example.com",
+            password_hash=hash_password("testpass"),
+            role="safety_manager",
+        )
+        db_session.add_all([secondary_org, secondary_owner])
+        db_session.commit()
+        db_session.refresh(secondary_org)
+        db_session.refresh(secondary_owner)
+
+        # Multi-org actor can access both orgs, but assignment must remain scoped
+        # to the incident's org only.
+        db_session.add_all(
+            [
+                UserOrg(user_id=test_user.id, org_id=secondary_org.id),
+                UserOrg(user_id=secondary_owner.id, org_id=secondary_org.id),
+            ]
+        )
+        db_session.commit()
+
+        response = client.patch(
+            f"/incidents/{incident_id}/owner",
+            json={"operation": "assign", "owner_user_id": str(secondary_owner.id)},
+            headers=auth_headers,
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Owner user not found"
+
 
 # ── GET /incidents (list) ───────────────────────────────────────────
 


### PR DESCRIPTION
### Motivation
- Fix a high-priority tenant-scoping bug where a multi-org user could assign an owner from a different org to an incident, potentially leaking cross-tenant references.

### Description
- Validate candidate owner membership against the incident's `org_id` in `patch_incident_owner` instead of checking membership across the caller's `org_ids` (file: `backend/app/services/incident_ownership_service.py`).
- Add a regression API test `test_patch_owner_rejects_owner_from_other_member_org` that simulates a multi-org actor and asserts owner assignment is rejected when the owner is not in the incident's org (file: `backend/tests/test_api_endpoints.py`).
- Preserve existing assign/reassign/clear behavior and error semantics when ownership is invalid.

### Testing
- Ran `pytest tests/test_api_endpoints.py -k "patch_owner_enforces_org_isolation or patch_owner_rejects_owner_from_other_member_org" -q` and the targeted tests passed (2 passed, 63 deselected).
- Verified the new regression test exercises the multi-org actor path and returns `404 Owner user not found` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91fdfdd1c8321acbd228df84635cf)