### PR TITLE
Follow-up: add Alembic migration for CaseNote note_type and tags_json

### DIFF
--- a/backend/app/db/migrations/versions/0019_add_case_note_type_and_tags.py
+++ b/backend/app/db/migrations/versions/0019_add_case_note_type_and_tags.py
@@ -1,0 +1,55 @@
+"""add case note type and tags columns
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-04-22
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0019"
+down_revision: Union[str, None] = "0018"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+case_note_type = sa.Enum("standard", "tagged", "decision", name="case_note_type")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    case_note_type.create(bind, checkfirst=True)
+
+    op.add_column(
+        "case_notes",
+        sa.Column("note_type", case_note_type, nullable=True, server_default="standard"),
+    )
+    op.add_column(
+        "case_notes",
+        sa.Column(
+            "tags_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+
+    op.execute("UPDATE case_notes SET note_type = 'standard' WHERE note_type IS NULL")
+    op.execute("UPDATE case_notes SET tags_json = '[]'::jsonb WHERE tags_json IS NULL")
+
+    op.alter_column("case_notes", "note_type", nullable=False)
+    op.alter_column("case_notes", "tags_json", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("case_notes", "tags_json")
+    op.drop_column("case_notes", "note_type")
+
+    bind = op.get_bind()
+    case_note_type.drop(bind, checkfirst=True)


### PR DESCRIPTION
### Motivation
- Fix a high-priority schema gap where `CaseNote` model additions (`note_type`, `tags_json`) were not represented in migrations, which would cause runtime DB column errors on environments already migrated to `0018`.
- Provide a safe rollout path that backfills defaults so existing rows remain valid before enforcing `NOT NULL` constraints.

### Description
- Add new Alembic revision `backend/app/db/migrations/versions/0019_add_case_note_type_and_tags.py` that creates enum `case_note_type` and adds `case_notes.note_type` and `case_notes.tags_json` columns with server defaults. 
- Migration backfills existing rows (`note_type = 'standard'`, `tags_json = []`), then alters both columns to `NOT NULL`, and includes a `downgrade` that drops the columns and enum cleanly.
- No application model or route changes were required beyond the schema migration in this follow-up.

### Testing
- Ran `ruff check app/ tests/` which completed successfully.
- Ran targeted tests with `pytest -q tests/test_notes_routes.py tests/test_case_ops_workspace_route.py` and observed all tests passed (`5 passed`, with unrelated deprecation warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9247b5b4c8321b42be4d4f561fc13)