### PR TITLE
Fix legacy task status serialization for incident task responses

### DIFF
--- a/backend/app/api/routes/routes_tasks.py
+++ b/backend/app/api/routes/routes_tasks.py
@@ -314,9 +314,12 @@ def _apply_status(
 
 
 def _api_status(status: str | None) -> str:
-    if status == "canceled":
+    normalized_status = str(status or "open")
+    if normalized_status in {"completed", "cancelled"}:
+        return normalized_status
+    if normalized_status == "canceled":
         return "cancelled"
-    return str(status or "open")
+    return "open"
 
 
 def _to_task_item(task: CaseTask, *, now_utc: datetime) -> IncidentTaskItem:

--- a/backend/tests/test_tasks_routes.py
+++ b/backend/tests/test_tasks_routes.py
@@ -221,3 +221,33 @@ def test_task_patch_rejects_invalid_status_transition(
         headers=_auth_headers(user),
     )
     assert response.status_code == 409
+
+
+@pytest.mark.parametrize("legacy_status", ["in_progress", "blocked"])
+def test_task_list_maps_legacy_non_terminal_statuses_to_open(
+    client: TestClient,
+    db_session,
+    incident: Incident,
+    user: User,
+    legacy_status: str,
+):
+    task = CaseTask(
+        org_id=incident.org_id,
+        incident_id=incident.incident_id,
+        title="Legacy status task",
+        status=legacy_status,
+        priority="low",
+        due_at_utc=datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+    db_session.add(task)
+    db_session.commit()
+
+    response = client.get(
+        f"/incidents/{incident.incident_id}/tasks",
+        headers=_auth_headers(user),
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload["items"]) == 1
+    assert payload["items"][0]["status"] == "open"
+    assert payload["items"][0]["overdue"] is True


### PR DESCRIPTION
### Motivation
- The task list and item serialization could raise model validation errors and return 500s when DB rows used legacy/non-terminal statuses (e.g. `in_progress`, `blocked`) because `IncidentTaskItem.status` only accepts `open|completed|cancelled`.
- Normalize DB statuses to stable API values so legacy values are treated as active/open tasks and `canceled` vs `cancelled` are handled consistently.

### Description
- Updated `_api_status` in `backend/app/api/routes/routes_tasks.py` to normalize statuses so only terminal statuses pass through (`completed` -> `completed`, `canceled|cancelled` -> `cancelled`) and all other values map to `open`.
- Added a regression test `test_task_list_maps_legacy_non_terminal_statuses_to_open` in `backend/tests/test_tasks_routes.py` (parameterized for `in_progress` and `blocked`) to ensure legacy non-terminal statuses serialize as `open` and that `overdue` is computed correctly.

### Testing
- Ran `pytest backend/tests/test_tasks_routes.py -q` and the test suite passed without failures.
- The modified tests include creation/list/patch/complete/cancel flows and the new legacy-status mapping regression, and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e924835ce083218c20d4db2422b163)