### PR TITLE
Follow-up: lock safety_manager privileged status-transition contract

### DIFF
--- a/backend/tests/test_permissions_role_mapping.py
+++ b/backend/tests/test_permissions_role_mapping.py
@@ -17,3 +17,12 @@ def test_read_only_capabilities_are_read_only():
     assert Capability.EXPORT_READ in capabilities
     assert Capability.INCIDENT_WRITE not in capabilities
     assert Capability.EXPORT_WRITE not in capabilities
+
+
+def test_safety_manager_does_not_get_privileged_status_transition_capabilities():
+    capabilities = get_user_capabilities("safety_manager")
+    assert Capability.INCIDENT_READ in capabilities
+    assert Capability.INCIDENT_WRITE in capabilities
+    assert Capability.INCIDENT_CLOSE not in capabilities
+    assert Capability.INCIDENT_REOPEN not in capabilities
+    assert Capability.INCIDENT_ESCALATE not in capabilities


### PR DESCRIPTION
### Motivation

- Prevent a P1 regression where `safety_manager` could gain privileged incident status-transition capabilities and weaken least-privilege controls for `patch_incident_status`.

### Description

- Add a focused regression test `test_safety_manager_does_not_get_privileged_status_transition_capabilities` in `backend/tests/test_permissions_role_mapping.py` that asserts `safety_manager` retains `incident:read`/`incident:write` but does not have `incident:close`, `incident:reopen`, or `incident:escalate`.

### Testing

- Ran `cd backend && pytest tests/test_permissions_role_mapping.py tests/test_api_endpoints.py::TestPatchIncidentStatus::test_patch_incident_status_rejects_privileged_transition_without_permission -q` and observed `4 passed` (with unrelated deprecation warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9248ef21c8321b8a87d8485eb6317)