### PR TITLE
fix(frontend): show only overdue tasks in overdue follow-up widget

### DIFF
--- a/frontend/app/dashboard/DashboardClient.tsx
+++ b/frontend/app/dashboard/DashboardClient.tsx
@@ -15,7 +15,6 @@ import {
   getIncidentAlerts,
   getIncidentQueue,
   getIncidentSummaryMetrics,
-  getMyOpenTasks,
   getOverdueTasks,
   patchIncidentOwner,
   patchIncidentStatus,
@@ -54,7 +53,6 @@ export default function DashboardClient() {
   const [metrics, setMetrics] = useState<CaseOpsSummaryMetrics | null>(null);
   const [alerts, setAlerts] = useState<CaseOpsAlerts | null>(null);
   const [overdueTasks, setOverdueTasks] = useState<CaseTaskWidgetItem[]>([]);
-  const [myOpenTasks, setMyOpenTasks] = useState<CaseTaskWidgetItem[]>([]);
   const [queueLoading, setQueueLoading] = useState(true);
   const [overviewLoading, setOverviewLoading] = useState(true);
   const [queueError, setQueueError] = useState("");
@@ -88,13 +86,11 @@ export default function DashboardClient() {
       getIncidentSummaryMetrics(),
       getIncidentAlerts(),
       getOverdueTasks({ limit: 20 }),
-      getMyOpenTasks({ limit: 20 }),
     ])
-      .then(([summary, alertPayload, overdue, mine]) => {
+      .then(([summary, alertPayload, overdue]) => {
         setMetrics(summary);
         setAlerts(alertPayload);
         setOverdueTasks(overdue.items);
-        setMyOpenTasks(mine.items);
         setOverviewError("");
       })
       .catch((err) =>
@@ -200,7 +196,7 @@ export default function DashboardClient() {
           <AlertsPanel alerts={alerts} loading={overviewLoading} error={overviewError} />
           <ExportReadyList items={exportReady} loading={queueLoading} />
           <OverdueFollowUpList
-            items={overdueTasks.length > 0 ? overdueTasks : myOpenTasks.filter((task) => task.status !== "completed")}
+            items={overdueTasks}
             loading={overviewLoading}
             error={overviewError}
           />


### PR DESCRIPTION
### Motivation

- Fix a P1 bug where the "Overdue follow-up list" could show non-overdue tasks because the dashboard fell back to the user's open tasks when no overdue items existed.
- Ensure the `OverdueFollowUpList` component only receives truly overdue items so it renders its empty state correctly and avoids misleading users.

### Description

- Removed the now-unused `getMyOpenTasks` import and the `myOpenTasks` state from `frontend/app/dashboard/DashboardClient.tsx`.
- Removed the `getMyOpenTasks` call from the overview `Promise.all` and removed setting `myOpenTasks` from the Promise resolution.
- Updated the `OverdueFollowUpList` usage to pass `items={overdueTasks}` (removed the fallback to non-overdue open tasks) so the component shows its native empty state when there are no overdue items.

### Testing

- Ran ESLint with `npm run lint -- app/dashboard/DashboardClient.tsx` and it passed after correcting the lint invocation path.
- Ran TypeScript checks with `npm run typecheck` (`tsc --noEmit`) and it passed.
- The change was committed and a follow-up PR was created titled `fix(frontend): show only overdue tasks in overdue follow-up widget`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e924b8ba508321a3f6ad60b4879542)