### PR TITLE
Follow-up: decouple incident detail load from workspace panel failures

### DIFF
--- a/frontend/app/incidents/[id]/IncidentDetailClient.tsx
+++ b/frontend/app/incidents/[id]/IncidentDetailClient.tsx
@@ -125,26 +125,27 @@ export default function IncidentDetailClient() {
   }, [id]);
 
   const refreshWorkspacePanels = useCallback(() => {
-    return Promise.all([
+    return Promise.allSettled([
       getIncidentWorkspace(id).then(setWorkspace),
       listIncidentNotes(id).then((res) => setNotes(res.items)),
       listIncidentTasks(id).then((res) => setTasks(res.items)),
-    ]).catch((err) => {
-      console.warn("Workspace refresh failed", err);
+    ]).then((results) => {
+      const failures = results.filter((result) => result.status === "rejected");
+      if (failures.length > 0) {
+        console.warn("Workspace refresh partially failed", failures);
+      }
     });
   }, [id]);
 
   useEffect(() => {
     if (!user) return;
-    Promise.all([
-      getIncident(id).then(setIncident),
-      getIncidentWorkspace(id).then(setWorkspace),
-      listIncidentNotes(id).then((res) => setNotes(res.items)),
-      listIncidentTasks(id).then((res) => setTasks(res.items)),
-    ])
+    getIncident(id)
+      .then(setIncident)
       .catch((err) => setError(toUserErrorMessage(err, "Failed to load incident")))
       .finally(() => setLoading(false));
-  }, [id, user]);
+
+    refreshWorkspacePanels();
+  }, [id, refreshWorkspacePanels, user]);
 
   useEffect(() => {
     if (!user) return;


### PR DESCRIPTION
### Motivation

- Prevent auxiliary workspace panel failures (workspace/notes/tasks) from causing the global "Failed to load incident" state when the core incident data is available.
- Make workspace panel fetches best-effort so the incident detail view remains usable during transient backend errors.
- Improve observability of partial panel failures with clear warning logging.

### Description

- Changed `refreshWorkspacePanels` to use `Promise.allSettled` and log any rejected panel fetches so successful responses still update UI while failures are isolated (file: `frontend/app/incidents/[id]/IncidentDetailClient.tsx`).
- Decoupled initial load so `getIncident(id)` is fetched independently and controls the global load/error state, while `refreshWorkspacePanels()` is invoked separately as a best-effort operation.
- Kept the existing `refreshIncident` behavior and the optimistic UI updates for workspace actions unchanged.

### Testing

- Ran `cd frontend && npm run typecheck`, which completed successfully with no TypeScript errors.
- Ran `cd frontend && npm run lint`, which completed successfully with no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e926128bac8321880b90164b7c29f3)