### PR TITLE
Gate /exports by readiness and avoid stale status overwrite on export completion

### DIFF
--- a/backend/app/api/routes_exports.py
+++ b/backend/app/api/routes_exports.py
@@ -35,6 +35,7 @@ from app.db.repo.exports import (
 from app.db.repo.artifacts import get_artifacts_by_incident
 from app.db.repo.events import create_event, get_events_by_incident
 from app.db.repo.incidents import get_incident
+from app.case_ops.service import build_case_snapshot
 from app.domain.system_event_types import SystemEventType
 from app.core.config import settings
 from app.tasks.export_tasks import build_export
@@ -133,6 +134,50 @@ def create_export_endpoint(
                     created_at_utc=prior.created_at_utc,
                 )
 
+    artifacts = get_artifacts_by_incident(db, body.incident_id)
+    events = get_events_by_incident(db, body.incident_id)
+    prior_exports = get_exports_by_incident(db, body.incident_id)
+    snapshot = build_case_snapshot(
+        incident=incident,
+        artifacts=artifacts,
+        events=events,
+        exports=prior_exports,
+    )
+    readiness_reasons = [
+        {
+            "code": blocker.code,
+            "message": blocker.message,
+            "severity": blocker.severity,
+            "blocks_readiness": blocker.blocks_readiness,
+        }
+        for blocker in snapshot.blockers.items
+    ]
+    readiness_snapshot = {
+        "state": snapshot.readiness.state,
+        "completeness_percent": snapshot.completeness.percent,
+        "completeness_status": snapshot.completeness.status,
+        "blocking_codes": snapshot.readiness.blocking_codes,
+        "reasons": readiness_reasons,
+        "captured_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    if snapshot.readiness.state == "not_ready":
+        increment(MetricNames.EXPORT_REQUEST_FAILURES)
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": "Case is not ready for export.",
+                "readiness_state": snapshot.readiness.state,
+                "reasons": readiness_reasons,
+            },
+        )
+    readiness_warning = None
+    if snapshot.readiness.state == "conditionally_ready":
+        readiness_warning = {
+            "code": "conditional_export_readiness",
+            "message": "Case is conditionally ready for export. Exporting may omit or flag unresolved evidence.",
+            "blocking_codes": snapshot.readiness.blocking_codes,
+        }
+
     export = create_export(
         db,
         incident_id=body.incident_id,
@@ -141,7 +186,11 @@ def create_export_endpoint(
         export_type=body.export_type,
         profile_id=str(body.options_json.get("profile_id") or get_default_packet_profile(body.export_type).profile_id),
         requested_by_user_id=current_user.id,
-        options_json=body.options_json,
+        options_json={
+            **(body.options_json or {}),
+            "readiness_snapshot": readiness_snapshot,
+            "readiness_warning": readiness_warning,
+        },
         progress_stage="request_accepted",
     )
 
@@ -156,6 +205,8 @@ def create_export_endpoint(
             "incident_id": str(body.incident_id),
             "export_type": body.export_type,
             "status": "requested",
+            "readiness_snapshot": readiness_snapshot,
+            "readiness_warning": readiness_warning,
             "actor": {"type": "user", "id": str(current_user.id)},
             "idempotency_key_hash": idempotency.hashed_key if idempotency else None,
         },

--- a/backend/app/tasks/export_tasks.py
+++ b/backend/app/tasks/export_tasks.py
@@ -368,12 +368,16 @@ def _upload_and_finalize(ctx: ExportRuntimeContext):
 def _sync_incident_case_status_after_export(ctx: ExportRuntimeContext):
     from app.db.repo.events import create_event
 
-    incident_row = ctx.incident_row
+    incident_model = type(ctx.incident_row) if ctx.incident_row is not None else None
+    if incident_model is None:
+        return
+    incident_row = ctx.db.get(incident_model, ctx.incident_uuid, populate_existing=True)
     if incident_row is None:
         return
     if str(incident_row.case_status) != "ready_for_export":
         return
 
+    ctx.incident_row = incident_row
     incident_row.case_status = "exported"
     incident_row.readiness_state = "exported"
     db_now = datetime.now(timezone.utc)

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -900,11 +900,17 @@ class TestListIncidents:
 
 class TestRequestExport:
     @patch("app.api.routes_exports.build_export")
+    @patch("app.api.routes_exports.build_case_snapshot")
     @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_request_export_returns_201(
-        self, mock_begin_capture, mock_gen, client, auth_headers
+        self, mock_begin_capture, mock_snapshot, mock_gen, client, auth_headers
     ):
         mock_gen.delay = MagicMock()
+        mock_snapshot.return_value = SimpleNamespace(
+            readiness=SimpleNamespace(state="ready_for_export", blocking_codes=[]),
+            completeness=SimpleNamespace(percent=100, status="complete"),
+            blockers=SimpleNamespace(items=[]),
+        )
 
         create_resp = client.post(
             "/incidents/",
@@ -932,11 +938,17 @@ class TestRequestExport:
         assert data["created_at_utc"] is not None
 
     @patch("app.api.routes_exports.build_export")
+    @patch("app.api.routes_exports.build_case_snapshot")
     @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
     def test_request_export_enqueues_task(
-        self, mock_begin_capture, mock_gen, client, auth_headers
+        self, mock_begin_capture, mock_snapshot, mock_gen, client, auth_headers
     ):
         mock_gen.delay = MagicMock()
+        mock_snapshot.return_value = SimpleNamespace(
+            readiness=SimpleNamespace(state="ready_for_export", blocking_codes=[]),
+            completeness=SimpleNamespace(percent=100, status="complete"),
+            blockers=SimpleNamespace(items=[]),
+        )
 
         create_resp = client.post(
             "/incidents/",
@@ -961,6 +973,93 @@ class TestRequestExport:
             export_id,
             {"attempt_number": 1, "trigger": "api"},
         )
+
+    @patch("app.api.routes_exports.build_export")
+    @patch("app.api.routes_exports.build_case_snapshot")
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
+    def test_request_export_blocks_not_ready(
+        self, mock_begin_capture, mock_snapshot, mock_gen, client, auth_headers
+    ):
+        mock_snapshot.return_value = SimpleNamespace(
+            readiness=SimpleNamespace(state="not_ready", blocking_codes=["evidence_capture_incomplete"]),
+            completeness=SimpleNamespace(percent=40, status="incomplete"),
+            blockers=SimpleNamespace(
+                items=[
+                    SimpleNamespace(
+                        code="evidence_capture_incomplete",
+                        message="Evidence capture incomplete.",
+                        severity="critical",
+                        blocks_readiness=True,
+                    )
+                ]
+            ),
+        )
+        create_resp = client.post(
+            "/incidents/",
+            json={
+                "severity": "minor",
+                "adc_vehicle_id": "v1",
+                "samsara_vehicle_id": "s1",
+                "adc_driver_id": "d1",
+            },
+            headers=auth_headers,
+        )
+        incident_id = create_resp.json()["incident_id"]
+        resp = client.post(
+            "/exports/",
+            json={"incident_id": incident_id, "export_type": "court_defense"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 409
+        payload = resp.json()["detail"]
+        assert payload["readiness_state"] == "not_ready"
+        assert payload["reasons"][0]["code"] == "evidence_capture_incomplete"
+        mock_gen.delay.assert_not_called()
+
+    @patch("app.api.routes_exports.build_export")
+    @patch("app.api.routes_exports.build_case_snapshot")
+    @patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
+    def test_request_export_persists_readiness_snapshot(
+        self, mock_begin_capture, mock_snapshot, mock_gen, client, db_session, auth_headers
+    ):
+        mock_gen.delay = MagicMock()
+        mock_snapshot.return_value = SimpleNamespace(
+            readiness=SimpleNamespace(state="conditionally_ready", blocking_codes=["driver_statement_missing"]),
+            completeness=SimpleNamespace(percent=88, status="mostly_complete"),
+            blockers=SimpleNamespace(
+                items=[
+                    SimpleNamespace(
+                        code="driver_statement_missing",
+                        message="Driver statement still pending.",
+                        severity="important",
+                        blocks_readiness=False,
+                    )
+                ]
+            ),
+        )
+        create_resp = client.post(
+            "/incidents/",
+            json={
+                "severity": "minor",
+                "adc_vehicle_id": "v1",
+                "samsara_vehicle_id": "s1",
+                "adc_driver_id": "d1",
+            },
+            headers=auth_headers,
+        )
+        incident_id = create_resp.json()["incident_id"]
+        resp = client.post(
+            "/exports/",
+            json={"incident_id": incident_id, "export_type": "court_defense"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 201
+        export = db_session.query(Export).filter(Export.incident_id == uuid.UUID(incident_id)).one()
+        readiness_snapshot = export.options_json.get("readiness_snapshot")
+        readiness_warning = export.options_json.get("readiness_warning")
+        assert readiness_snapshot["state"] == "conditionally_ready"
+        assert readiness_snapshot["blocking_codes"] == ["driver_statement_missing"]
+        assert readiness_warning["code"] == "conditional_export_readiness"
 
     def test_request_export_incident_not_found(self, client, auth_headers):
         fake_id = str(uuid.uuid4())

--- a/backend/tests/test_export_case_status_sync.py
+++ b/backend/tests/test_export_case_status_sync.py
@@ -73,3 +73,70 @@ def test_sync_incident_case_status_after_export_moves_ready_for_export_to_export
     assert status_event.event_type == "incident_status_changed"
     assert status_event.payload["from_case_status"] == "ready_for_export"
     assert status_event.payload["to_case_status"] == "exported"
+
+
+def test_sync_incident_case_status_after_export_does_not_override_newer_status():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    worker_session = Session()
+    updater_session = Session()
+
+    org = Org(name="Test Org")
+    worker_session.add(org)
+    worker_session.commit()
+    worker_session.refresh(org)
+
+    incident = Incident(
+        org_id=org.id,
+        case_status="ready_for_export",
+        readiness_state="ready_for_export",
+    )
+    worker_session.add(incident)
+    worker_session.commit()
+    worker_session.refresh(incident)
+
+    stale_incident = worker_session.get(Incident, incident.incident_id)
+    fresh_incident = updater_session.get(Incident, incident.incident_id)
+    fresh_incident.case_status = "closed"
+    fresh_incident.readiness_state = "closed"
+    updater_session.commit()
+
+    ctx = ExportRuntimeContext(
+        db=worker_session,
+        incident_uuid=incident.incident_id,
+        export_uuid=uuid.uuid4(),
+        incident_id=str(incident.incident_id),
+        export_id=str(uuid.uuid4()),
+        workflow_key="workflow",
+        org_id=str(org.id),
+        settings=SimpleNamespace(S3_BUCKET="bucket"),
+        system_event_type=SimpleNamespace(INCIDENT_STATUS_CHANGED="incident_status_changed"),
+        s3_key_builder=None,
+        s3=None,
+        export_row=SimpleNamespace(export_type="court_defense", options_json={}),
+        incident_row=stale_incident,
+        warnings=[],
+        missing_items=[],
+        artifacts=[],
+        events=[],
+        exportable_artifacts=[],
+        inventory_csv_bytes=b"",
+        coc_csv_bytes=b"",
+        appendix_csv_bytes=b"",
+        readme_content="",
+        zip_bytes=b"",
+        zip_key=None,
+    )
+
+    _sync_incident_case_status_after_export(ctx)
+    worker_session.commit()
+
+    persisted = updater_session.get(Incident, incident.incident_id)
+    assert persisted.case_status == "closed"
+    assert persisted.readiness_state == "closed"
+    assert updater_session.query(Event).filter(Event.incident_id == incident.incident_id).count() == 0


### PR DESCRIPTION
### Motivation
- Ensure the legacy active export-create path (`POST /exports/`) enforces the same readiness gating and persists the request-time readiness snapshot so the UI and audit trail remain consistent. 
- Prevent the export worker from overwriting newer incident status updates with stale in-memory incident data when finalizing an export.

### Description
- Added case snapshot evaluation to the legacy `create_export_endpoint` (`backend/app/api/routes_exports.py`) and reject requests with `409` when `snapshot.readiness.state == "not_ready"`, including readiness reasons in the response payload. 
- Persisted `readiness_snapshot` and optional `readiness_warning` into the new export row `options_json` and included them in the `EXPORT_REQUESTED` event payload for requests accepted via `POST /exports/`.
- Updated `_sync_incident_case_status_after_export` (`backend/app/tasks/export_tasks.py`) to reload the incident row from the DB using `ctx.db.get(..., populate_existing=True)` before checking/transiting status and to use the freshly loaded row to avoid clobbering newer concurrent updates.
- Expanded and added backend tests to cover the new behaviors: readiness blocking and snapshot persistence for the `/exports/` endpoint and a concurrency test ensuring the worker does not override a newer status commit made while the export task ran (`backend/tests/test_api_endpoints.py`, `backend/tests/test_export_case_status_sync.py`).

### Testing
- Ran the targeted pytest selection for the modified areas with `pytest -q backend/tests/test_api_endpoints.py::TestRequestExport::test_request_export_blocks_not_ready backend/tests/test_api_endpoints.py::TestRequestExport::test_request_export_persists_readiness_snapshot backend/tests/test_export_case_status_sync.py` and the tests passed (`4 passed`).
- Ran linting with `ruff check` against the changed files (`backend/app/api/routes_exports.py`, `backend/app/tasks/export_tasks.py`, and the related tests`) and checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e926191c78832190a0249ae44fd445)