### PR TITLE
Fix onboarding readiness: exclude inactive vehicle assignments and scope protocol to org instruction_source

### DIFF
--- a/backend/app/onboarding/service.py
+++ b/backend/app/onboarding/service.py
@@ -89,7 +89,10 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
 
     vehicles_total = (
         db.query(func.count(distinct(DriverVehicleAssignment.adc_vehicle_id)))
-        .filter(DriverVehicleAssignment.org_id == org_id)
+        .filter(
+            DriverVehicleAssignment.org_id == org_id,
+            DriverVehicleAssignment.unassigned_at_utc.is_(None),
+        )
         .scalar()
         or 0
     )
@@ -102,7 +105,10 @@ def collect_onboarding_signals(db: Session, *, org_id: uuid.UUID) -> OnboardingS
 
     instruction_set = (
         db.query(DriverInstructionSet)
-        .filter(DriverInstructionSet.org_id == org_id)
+        .filter(
+            DriverInstructionSet.org_id == org_id,
+            DriverInstructionSet.scope == org.instruction_source,
+        )
         .order_by(DriverInstructionSet.created_at_utc.desc())
         .first()
     )


### PR DESCRIPTION
### Motivation
- Onboarding readiness could be falsely blocked because `vehicles_total` included historical/unassigned vehicle assignments instead of only active assignments. 
- Protocol readiness could flip incorrectly because the instruction-set lookup chose the newest set regardless of the org's active `instruction_source` scope.

### Description
- Restrict vehicle counts in `backend/app/onboarding/service.py` to active assignments by adding `DriverVehicleAssignment.unassigned_at_utc.is_(None)` to the `vehicles_total` query. 
- Constrain the instruction-set lookup in `backend/app/onboarding/service.py` to the org's active scope by adding `DriverInstructionSet.scope == org.instruction_source` to the query. 
- Changes are limited to signal collection logic and do not alter downstream readiness composition logic.

### Testing
- Ran the onboarding unit tests with `cd backend && pytest tests/test_onboarding_service.py -v`, which completed with `3 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9262618488321987f4d71cee929ad)