### PR TITLE
[PR #206 Follow-up] Fix org role edit scope and add invite table migration

### DIFF
--- a/backend/app/api/routes_integrations.py
+++ b/backend/app/api/routes_integrations.py
@@ -66,6 +66,7 @@ router = APIRouter()
 
 _integration_admin = require_user_role("system_admin", "org_admin")
 _org_user_admin = require_user_role("system_admin", "org_admin")
+_org_user_role_editor = require_user_role("system_admin")
 
 
 def _first_org_id(context) -> uuid.UUID:
@@ -310,7 +311,7 @@ def patch_org_user_role(
     user_id: uuid.UUID,
     payload: OrgPatchUserRoleRequest,
     db: Session = Depends(get_db),
-    current_user: User = Depends(_org_user_admin),
+    current_user: User = Depends(_org_user_role_editor),
 ):
     context = build_user_auth_context(db, current_user)
     org_id = _first_org_id(context)

--- a/backend/app/db/migrations/versions/0021_add_org_user_invites_table.py
+++ b/backend/app/db/migrations/versions/0021_add_org_user_invites_table.py
@@ -1,0 +1,66 @@
+"""add org user invites table
+
+Revision ID: 0021_add_org_user_invites_table
+Revises: 0020_add_org_settings_and_onboarding_completion
+Create Date: 2026-04-22 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from typing import Union
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0021"
+down_revision: Union[str, None] = "0020"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "org_user_invites",
+        sa.Column("invite_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("email", sa.Text(), nullable=False),
+        sa.Column(
+            "role",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'safety_manager'"),
+        ),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column("invited_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "created_at_utc",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "last_sent_at_utc",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("deactivated_at_utc", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["invited_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("invite_id"),
+    )
+    op.create_index("ix_org_user_invites_org_id", "org_user_invites", ["org_id"])
+    op.create_index("ix_org_user_invites_email", "org_user_invites", ["email"])
+    op.create_index("ix_org_user_invites_status", "org_user_invites", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_org_user_invites_status", table_name="org_user_invites")
+    op.drop_index("ix_org_user_invites_email", table_name="org_user_invites")
+    op.drop_index("ix_org_user_invites_org_id", table_name="org_user_invites")
+    op.drop_table("org_user_invites")

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -525,6 +525,27 @@ class TestIntegrationDiagnosticsRoutes:
             headers=admin_headers,
             json={"role": "org_admin"},
         )
+        assert patch_role.status_code == 403
+
+        system_admin = User(
+            email="system-admin@example.com",
+            password_hash=hash_password("password123"),
+            role="system_admin",
+        )
+        db_session.add(system_admin)
+        db_session.commit()
+        db_session.refresh(system_admin)
+        db_session.add(UserOrg(user_id=system_admin.id, org_id=test_org.id))
+        db_session.commit()
+        system_admin_headers = {
+            "Authorization": f"Bearer {create_access_token({'sub': str(system_admin.id), 'role': 'system_admin'})}"
+        }
+
+        patch_role = client.patch(
+            f"/org/users/{test_user.id}/role",
+            headers=system_admin_headers,
+            json={"role": "org_admin"},
+        )
         assert patch_role.status_code == 200
         updated_user = next(
             item for item in patch_role.json()["users"] if item["user_id"] == str(test_user.id)


### PR DESCRIPTION
### Motivation
- Prevent cross-tenant privilege mutation by ensuring org-scoped role edits cannot modify the global `User.role` for accounts that belong to multiple orgs. 
- Ensure the new `OrgUserInvite` model is backed by a matching Alembic revision so APIs that query `org_user_invites` work in migrated environments.

### Description
- Introduced a dedicated `_org_user_role_editor = require_user_role("system_admin")` and switched `patch_org_user_role` to depend on it so only `system_admin` can change `User.role` via the org endpoint. 
- Added Alembic migration `0021_add_org_user_invites_table.py` that creates the `org_user_invites` table with the expected columns, server defaults, foreign keys, indexes (`org_id`, `email`, `status`), and a full `downgrade` path. 
- Updated API tests in `tests/test_api_endpoints.py` to assert that an `org_admin` receives `403` when calling `PATCH /org/users/{user_id}/role` and that a `system_admin` can perform the role update successfully.

### Testing
- Ran `ruff check app tests` which completed with all checks passing. 
- Ran `pytest -q tests/test_api_endpoints.py -k org_users_list_invite_patch_role_resend_deactivate` which passed for the targeted scenario. 
- Attempted `PYTHONPATH=. alembic upgrade head` in this environment which failed due to the local SQLite driver not supporting PostgreSQL `JSONB` column types present in earlier migrations, so full migration application could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92a01e4a0832193d416bd89246968)