### PR TITLE
Fix failed-transaction handling for async vehicle import jobs

### DIFF
--- a/backend/app/services/vehicle_import_service.py
+++ b/backend/app/services/vehicle_import_service.py
@@ -242,6 +242,7 @@ def run_vehicle_import_job(
         db.refresh(job)
         return job
     except Exception as exc:
+        db.rollback()
         job.status = "failed"
         job.error_message = str(exc)
         job.completed_at_utc = datetime.now(timezone.utc)


### PR DESCRIPTION
### Motivation
- Prevent `PendingRollbackError` when the main import `db.commit()` fails so background import jobs can still be marked failed and persist `error_message` and completion timestamps.

### Description
- Add an explicit `db.rollback()` at the start of the `except` block in `run_vehicle_import_job` in `backend/app/services/vehicle_import_service.py` so the session is reset before updating and committing the failed job state.

### Testing
- Ran `cd backend && pytest tests/test_api_endpoints.py -q -k import` which completed with `2 passed, 72 deselected` (3 warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92a0929488321ad78f1356c3e6309)