### PR TITLE
Fix driver import global-phone matching, rollback on failure, and add migration

### DIFF
--- a/backend/app/db/migrations/versions/0021_add_driver_import_jobs_table.py
+++ b/backend/app/db/migrations/versions/0021_add_driver_import_jobs_table.py
@@ -1,0 +1,107 @@
+"""add driver import jobs table
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-04-22
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0021"
+down_revision: Union[str, None] = "0020"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+driver_import_job_status = sa.Enum(
+    "pending",
+    "running",
+    "succeeded",
+    "failed",
+    name="driver_import_job_status",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    driver_import_job_status.create(bind, checkfirst=True)
+
+    op.create_table(
+        "driver_import_jobs",
+        sa.Column("job_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column(
+            "status",
+            driver_import_job_status,
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("records_total", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "records_processed", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column("records_imported", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("records_updated", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("records_skipped", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("records_errored", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "warnings_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "outcomes_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "summary_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("started_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "completed_at_utc", postgresql.TIMESTAMP(timezone=True), nullable=True
+        ),
+        sa.Column(
+            "created_at_utc",
+            postgresql.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at_utc",
+            postgresql.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(["org_id"], ["orgs.id"]),
+        sa.PrimaryKeyConstraint("job_id"),
+    )
+
+    op.create_index(
+        "ix_driver_import_jobs_org_id", "driver_import_jobs", ["org_id"], unique=False
+    )
+    op.create_index(
+        "ix_driver_import_jobs_status", "driver_import_jobs", ["status"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_driver_import_jobs_status", table_name="driver_import_jobs")
+    op.drop_index("ix_driver_import_jobs_org_id", table_name="driver_import_jobs")
+    op.drop_table("driver_import_jobs")
+
+    bind = op.get_bind()
+    driver_import_job_status.drop(bind, checkfirst=True)

--- a/backend/app/services/driver_import_service.py
+++ b/backend/app/services/driver_import_service.py
@@ -169,8 +169,7 @@ def run_driver_import_job(
         }
 
         existing_by_phone = {
-            row.phone_e164: row
-            for row in db.query(Driver).filter(Driver.org_id == org_id).all()
+            row.phone_e164: row for row in db.query(Driver).all() if row.phone_e164
         }
         assigned_driver_ids = {
             str(row.driver_id)
@@ -276,6 +275,18 @@ def run_driver_import_job(
                 outcomes["imported"].append(phone_e164)
                 existing_by_phone[phone_e164] = existing
             else:
+                if existing.org_id != org_id:
+                    message = (
+                        f"{phone_e164}: already exists in another organization; skipped"
+                    )
+                    outcomes["errored"].append(message)
+                    outcomes["duplicate_warning"].append(message)
+                    outcomes["skipped"].append(message)
+                    summary["duplicate_warning_count"] += 1
+                    summary["needs_review_count"] += 1
+                    outcomes["needs_review"].append(message)
+                    warnings.append(f"Driver {message}.")
+                    continue
                 existing.display_name = display_name
                 existing.is_active = bool(staged["is_active"])
                 outcomes["updated"].append(phone_e164)
@@ -316,6 +327,7 @@ def run_driver_import_job(
         db.refresh(job)
         return job
     except Exception as exc:
+        db.rollback()
         job.status = "failed"
         job.error_message = str(exc)
         job.completed_at_utc = datetime.now(timezone.utc)

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -2272,6 +2272,60 @@ class TestDriverImportJobs:
         )
         assert resp.status_code == 404
 
+    def test_driver_import_handles_phone_owned_by_other_org(
+        self, client, db_session, test_org, auth_headers
+    ):
+        other_org = Org(name="Other Org")
+        db_session.add(other_org)
+        db_session.commit()
+        db_session.refresh(other_org)
+
+        db_session.add(
+            Driver(
+                org_id=other_org.id,
+                phone_e164="+15559990000",
+                display_name="Other Org Driver",
+                is_active=True,
+            )
+        )
+        db_session.commit()
+
+        csv_content = "firstName,lastName,mobile,status\nCross,Org,5559990000,active\n"
+        create_resp = client.post(
+            "/org/drivers/import",
+            headers=auth_headers,
+            json={
+                "provider": "samsara",
+                "csv_content": csv_content,
+                "header_mapping": {"phone": "mobile"},
+                "inactive_mobile_phones": [],
+            },
+        )
+        assert create_resp.status_code == 202
+        job_id = create_resp.json()["job_id"]
+
+        read_resp = client.get(
+            f"/org/drivers/import-jobs/{job_id}", headers=auth_headers
+        )
+        assert read_resp.status_code == 200
+        payload = read_resp.json()
+        assert payload["status"] == "failed"
+        assert payload["records_imported"] == 0
+        assert payload["records_updated"] == 0
+        assert payload["records_skipped"] == 1
+        assert payload["records_errored"] == 1
+        assert payload["summary"]["duplicate_warning_count"] == 1
+        assert payload["summary"]["needs_review_count"] == 1
+        assert any(
+            "already exists in another organization" in row
+            for row in payload["outcomes"]["errored"]
+        )
+
+        org_drivers = (
+            db_session.query(Driver).filter(Driver.org_id == test_org.id).count()
+        )
+        assert org_drivers == 0
+
 
 # ── Health check ────────────────────────────────────────────────────
 


### PR DESCRIPTION
### Motivation
- Prevent integrity errors and non-deterministic behavior when importing drivers because `drivers.phone_e164` is globally unique and rows from other orgs could cause inserts to fail. 
- Ensure the DB session is properly reset before persisting a failed job state so job status updates do not raise secondary errors. 
- Provide an Alembic migration so environments upgraded via migrations will have the `driver_import_jobs` table available for onboarding/readiness queries.

### Description
- Updated `run_driver_import_job` to preload existing drivers keyed by `phone_e164` globally by changing the query to load all drivers and index by `phone_e164`, and to deterministically skip rows whose `phone_e164` exists on a driver that belongs to a different org while recording an error/duplicate-warning/needs-review outcome. 
- Added `db.rollback()` in the `except` path of `run_driver_import_job` before setting `job.status`/`job.error_message` and committing to clear any failed transaction state. 
- Added an Alembic migration `backend/app/db/migrations/versions/0021_add_driver_import_jobs_table.py` to create the `driver_import_jobs` table and the associated `driver_import_job_status` enum and indexes. 
- Added a regression test in `backend/tests/test_api_endpoints.py` that verifies a CSV row whose phone is owned by another org is skipped/errored and does not create a driver in the importing org.

### Testing
- Ran lint/format checks with `ruff` on the modified files and confirmed all checks passed. 
- Executed targeted tests with `pytest tests/test_api_endpoints.py -k "DriverImportJobs" -v`, which resulted in `3 passed` tests and no failures. 
- Confirmed the new migration file `0021_add_driver_import_jobs_table.py` was added to `backend/app/db/migrations/versions` and is ready for Alembic upgrade.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92aaeb0008321a5fc4b973de626b9)