### PR TITLE
Add frontend UI redesign tracker and release readiness gates

### DIFF
--- a/frontend/docs/ui-redesign-plan.md
+++ b/frontend/docs/ui-redesign-plan.md
@@ -1,0 +1,67 @@
+# UI Redesign Tracker
+
+This tracker maps the numbered redesign spec sections to implementation tickets, ownership, and acceptance gates.
+
+## In-scope goals
+
+1. **Premium hierarchy**: elevate visual hierarchy and polish so key workflows feel premium and trustworthy.
+2. **Scan speed**: reduce time-to-complete for scan-heavy flows and minimize friction.
+3. **Consistency**: unify layout, spacing, typography, states, and interaction patterns across pages/components.
+4. **Status/readiness clarity**: make status, blockers, and readiness states obvious at a glance with explicit next actions.
+
+## Non-goals
+
+1. **No backend/workflow contract changes**: redesign work must not require API schema changes or workflow contract rewrites.
+2. **No heavy decorative motion**: avoid non-functional animation patterns that add cognitive load or hurt performance.
+
+## Numbered spec section tracker
+
+> Replace ticket IDs and owner names as they are assigned. Keep this table as the single source of truth for redesign progress.
+
+| Spec section | Section focus | Implementation ticket(s) | Owner | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Section 1 | Information architecture + premium visual hierarchy baseline | FE-REDESIGN-001 | Design Systems Lead | Planned | Establish page-level hierarchy standards and token priorities. |
+| Section 2 | Global typography, spacing, and color token alignment | FE-REDESIGN-002 | Frontend Engineer (Design Systems) | Planned | Normalize typography/spacing scales and semantic color usage. |
+| Section 3 | Navigation and wayfinding consistency | FE-REDESIGN-003 | Frontend Engineer (App Shell) | Planned | Standardize global nav, breadcrumbs, and section headers. |
+| Section 4 | Card/list/table component consistency | FE-REDESIGN-004 | Frontend Engineer (UI Platform) | Planned | Align visual treatment and behavior of data presentation components. |
+| Section 5 | Form ergonomics and completion speed | FE-REDESIGN-005 | Frontend Engineer (Workflow UX) | Planned | Reduce friction in high-frequency form entry paths. |
+| Section 6 | Scan flow speed optimization | FE-REDESIGN-006 | Frontend Engineer (Capture Flow) | Planned | Prioritize scan-first interactions and shorter completion paths. |
+| Section 7 | Status badges, readiness indicators, and blockers | FE-REDESIGN-007 | Frontend Engineer (Case Readiness) | Planned | Ensure status/readiness labels are explicit and deterministic. |
+| Section 8 | Detail-view clarity for current state + next action | FE-REDESIGN-008 | Product Designer | Planned | Make “what happened / what to do next” unambiguous. |
+| Section 9 | Loading, empty, error, and retry states | FE-REDESIGN-009 | Frontend Engineer (UX Reliability) | Planned | Ensure consistent state handling and user guidance. |
+| Section 10 | Accessibility-first interaction pass | FE-REDESIGN-010 | Accessibility Champion | Planned | Keyboard/screen-reader/contrast checks integrated into component updates. |
+
+## Acceptance gates (Definition of Done)
+
+### Section 21 gate (MVP acceptance)
+
+The redesign cannot be marked done unless all Section 21 MVP-aligned checks are satisfied and evidenced.
+
+- [ ] MVP gate evidence attached for impacted routes/components.
+- [ ] Auth and route behavior remains compliant with existing Section 21 expectations.
+- [ ] Deployment progress/readiness state contracts remain stable and validated.
+- [ ] Required regression tests for redesign-touched surfaces are passing in CI.
+
+### Section 22 gate (production readiness criteria)
+
+The redesign cannot be merged to final release unless Section 22 production-readiness criteria are explicitly met.
+
+- [ ] Production readiness checks are complete for observability, supportability, and rollout safety.
+- [ ] Monitoring/alert assumptions for redesigned flows are verified unchanged or intentionally updated.
+- [ ] Rollback path and release communication notes are documented.
+- [ ] QA evidence package includes pass/fail outcomes and remediation for any exceptions.
+
+## Release readiness checklist (must-pass before final merge)
+
+- [ ] **Visual QA**: visual regression review complete; spacing, typography, and hierarchy match approved redesign specs.
+- [ ] **Functional QA**: all affected user journeys execute correctly with no workflow regressions.
+- [ ] **Responsive QA**: verified on supported breakpoints/devices, including edge-case viewport sizes.
+- [ ] **Accessibility QA**: keyboard navigation, focus order, labels, semantics, and contrast meet accessibility requirements.
+- [ ] **Performance sanity QA**: no significant rendering/perceived-performance degradation from redesign changes.
+- [ ] **Stakeholder sign-off**: Product, Design, Frontend, and QA owners have approved release readiness.
+
+## Update protocol
+
+- Update table status (`Planned`, `In Progress`, `Blocked`, `In Review`, `Done`) at least once per sprint.
+- Add links to implementation PRs and QA evidence in the **Notes** column as work lands.
+- Keep acceptance gates checked/unchecked in this file for auditability during release review.


### PR DESCRIPTION
### Motivation

- Provide a single-source-of-truth tracker in the frontend repository that maps each numbered redesign spec section to implementation tickets and owners to simplify coordination and auditability. 
- Capture the redesign boundaries and constraints so implementation stays within accepted scope (visual/UX surface work only) and avoids backend contract or heavy motion changes. 
- Make acceptance gates explicit by turning Section 21 and Section 22 criteria into concrete DoD gates and a required release checklist to ensure safe rollouts.

### Description

- Add `frontend/docs/ui-redesign-plan.md` containing in-scope goals (premium hierarchy, scan speed, consistency, status/readiness clarity) and explicit non-goals. 
- Include a numbered spec section tracker (Sections 1–10) that seeds ticket placeholders, owner roles, status columns, and notes for PR/QA links. 
- Add Definition-of-Done acceptance gates mapped to Section 21 (MVP acceptance) and Section 22 (production readiness) and a mandatory release readiness checklist covering visual, functional, responsive, accessibility, performance sanity, and stakeholder sign-off. 
- Add an update protocol requiring per-sprint status updates and links to implementation PRs and QA evidence.

### Testing

- Ran the frontend linter with `npm run lint` in `frontend`, which completed successfully. 
- Ran the frontend test suite with `npm test` in `frontend`, which ran 8 tests and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf1fd61e48321ab1a27a31f67eed4)