### PR TITLE
Introduce semantic design tokens and refactor major page styling

### DIFF
--- a/frontend/app/exports/page.tsx
+++ b/frontend/app/exports/page.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/lib/api";
 import { getExportStatusBadgeClass, getExportStatusLabel } from "@/lib/exportStatus";
 import { safeOpenDownloadUrl } from "@/lib/safeUrl";
+import { designTokens } from "@/lib/design/tokens";
 
 interface ExportFilters {
   incident: string;
@@ -169,13 +170,13 @@ export default function ExportsPage() {
   }
 
   function renderManifest(items: ExportContentsItem[]) {
-    if (items.length === 0) return <p className="text-sm text-gray-500">None</p>;
+    if (items.length === 0) return <p className="text-sm text-text-muted">None</p>;
     return (
-      <ul className="space-y-1 text-sm text-gray-700 dark:text-gray-300">
+      <ul className="space-y-1 text-sm text-text-secondary">
         {items.map((item) => (
-          <li key={`${item.kind}-${item.path ?? item.item ?? ""}`} className="rounded border px-2 py-1 dark:border-gray-700">
+          <li key={`${item.kind}-${item.path ?? item.item ?? ""}`} className="rounded-md border border-border-subtle px-2 py-1">
             <p className="font-medium">{item.item ?? item.kind}</p>
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-text-muted">
               {item.reason ?? "—"} · {formatBytes(item.byte_size)}
             </p>
           </li>
@@ -187,8 +188,8 @@ export default function ExportsPage() {
   return (
     <MainLayout title="Exports">
       <div className="mb-4">
-        <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">Exports</h2>
-        <p className="text-sm text-gray-600 dark:text-gray-400">
+        <h2 className="text-2xl font-semibold text-text-primary">Exports</h2>
+        <p className="text-sm text-text-secondary">
           Export history with filters, package health, and detailed audit/download visibility.
         </p>
       </div>
@@ -198,26 +199,26 @@ export default function ExportsPage() {
         requiredPlan="Enterprise"
         reason="Export package comparison and anomaly scoring are available on Enterprise plans."
       >
-        <section className="mb-4 rounded-lg border bg-white p-3 shadow dark:border-gray-700 dark:bg-gray-800">
+        <section className="mb-4 rounded-lg border border-border-default bg-surface p-3 shadow-card">
           <h3 className="font-semibold">Compliance package compare</h3>
-          <p className="text-sm text-gray-600 dark:text-gray-300">
+          <p className="text-sm text-text-secondary">
             Compare two exports for missing evidence artifacts and timeline drift.
           </p>
-          <button type="button" disabled className="mt-3 rounded bg-gray-300 px-3 py-1 text-sm text-gray-700">
+          <button type="button" disabled className="mt-3 rounded-md bg-surface-muted px-3 py-1 text-sm text-text-secondary">
             Compare exports
           </button>
         </section>
       </FeatureGate>
 
-      <div className="mb-4 grid grid-cols-1 gap-3 rounded-lg border bg-white p-3 shadow dark:border-gray-700 dark:bg-gray-800 md:grid-cols-6">
+      <div className="mb-4 grid grid-cols-1 gap-3 rounded-lg border border-border-default bg-surface p-3 shadow-card md:grid-cols-6">
         <input
-          className="rounded border px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-900"
+          className={designTokens.control.input}
           placeholder="Incident"
           value={filters.incident}
           onChange={(e) => updateFilter("incident", e.target.value)}
         />
         <select
-          className="rounded border px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-900"
+          className={designTokens.control.input}
           value={filters.status}
           onChange={(e) => updateFilter("status", e.target.value as ExportFilters["status"])}
         >
@@ -228,7 +229,7 @@ export default function ExportsPage() {
           ))}
         </select>
         <select
-          className="rounded border px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-900"
+          className={designTokens.control.input}
           value={filters.exportType}
           onChange={(e) => updateFilter("exportType", e.target.value as ExportFilters["exportType"])}
         >
@@ -239,34 +240,34 @@ export default function ExportsPage() {
           ))}
         </select>
         <input
-          className="rounded border px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-900"
+          className={designTokens.control.input}
           placeholder="Requested by"
           value={filters.requestedBy}
           onChange={(e) => updateFilter("requestedBy", e.target.value)}
         />
         <input
-          className="rounded border px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-900"
+          className={designTokens.control.input}
           type="date"
           value={filters.createdFrom}
           onChange={(e) => updateFilter("createdFrom", e.target.value)}
         />
         <input
-          className="rounded border px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-900"
+          className={designTokens.control.input}
           type="date"
           value={filters.createdTo}
           onChange={(e) => updateFilter("createdTo", e.target.value)}
         />
       </div>
 
-      {loading && <p className="text-gray-500">Loading…</p>}
-      {error && <p className="mb-3 text-sm text-red-600">{error}</p>}
+      {loading && <p className="text-text-muted">Loading…</p>}
+      {error && <p className="mb-3 text-sm text-status-critical">{error}</p>}
 
-      {!loading && filteredExports.length === 0 && <p className="text-gray-500">No exports found.</p>}
+      {!loading && filteredExports.length === 0 && <p className="text-text-muted">No exports found.</p>}
 
       {!loading && filteredExports.length > 0 && (
-        <div className="overflow-hidden rounded-lg border bg-white shadow dark:border-gray-700 dark:bg-gray-800">
+        <div className="overflow-hidden rounded-lg border border-border-default bg-surface shadow-card">
           <table className="w-full text-left text-sm">
-            <thead className="bg-gray-50 dark:bg-gray-700">
+            <thead className="bg-surface-muted text-text-secondary">
               <tr>
                 <th className="px-4 py-3 font-medium">ID</th>
                 <th className="px-4 py-3 font-medium">Incident ID</th>
@@ -279,12 +280,12 @@ export default function ExportsPage() {
                 <th className="px-4 py-3 font-medium">Actions</th>
               </tr>
             </thead>
-            <tbody className="divide-y dark:divide-gray-700">
+            <tbody className="divide-y divide-border-subtle">
               {filteredExports.map((ex) => (
                 <tr key={ex.export_id}>
                   <td className="px-4 py-3 font-mono text-xs">{ex.export_id.slice(0, 8)}…</td>
                   <td className="px-4 py-3">
-                    <Link href={`/incidents/${ex.incident_id}`} className="text-blue-600 hover:underline dark:text-blue-400">
+                    <Link href={`/incidents/${ex.incident_id}`} className={designTokens.accent.text}>
                       {ex.incident_id.slice(0, 8)}…
                     </Link>
                   </td>
@@ -305,14 +306,14 @@ export default function ExportsPage() {
                     <div className="flex gap-2">
                       <button
                         onClick={() => openDetail(ex.export_id)}
-                        className="rounded bg-gray-700 px-2 py-1 text-xs text-white hover:bg-gray-800"
+                        className="rounded-md border border-border-default bg-surface-muted px-2 py-1 text-xs text-text-secondary hover:bg-surface-muted/80"
                       >
                         Details
                       </button>
                       {ex.status === "ready" && (
                         <button
                           onClick={() => handleDownload(ex.export_id)}
-                          className="rounded bg-green-600 px-2 py-1 text-xs text-white hover:bg-green-700"
+                          className="rounded-md bg-status-success px-2 py-1 text-xs text-text-inverse hover:bg-status-success/90"
                         >
                           Download
                         </button>
@@ -327,22 +328,22 @@ export default function ExportsPage() {
       )}
 
       {selectedExportId && (
-        <div className="fixed inset-0 z-40 flex justify-end bg-black/40">
-          <aside className="h-full w-full max-w-2xl overflow-y-auto bg-white p-4 shadow-xl dark:bg-gray-900">
+        <div className="fixed inset-0 z-40 flex justify-end bg-shell/40">
+          <aside className="h-full w-full max-w-2xl overflow-y-auto bg-surface-elevated p-4 shadow-panel">
             <div className="mb-4 flex items-center justify-between">
               <h3 className="text-lg font-semibold">Export Detail</h3>
               <button
-                className="rounded border px-2 py-1 text-sm dark:border-gray-700"
+                className="rounded-md border border-border-default px-2 py-1 text-sm text-text-secondary hover:bg-surface-muted"
                 onClick={() => setSelectedExportId(null)}
               >
                 Close
               </button>
             </div>
 
-            {detailLoading && <p className="text-gray-500">Loading detail…</p>}
+            {detailLoading && <p className="text-text-muted">Loading detail…</p>}
             {!detailLoading && detail && (
               <div className="space-y-4">
-                <section className="rounded border p-3 dark:border-gray-700">
+                <section className="rounded-lg border border-border-subtle p-3">
                   <h4 className="mb-2 font-medium">Metadata</h4>
                   <p>ID: {detail.export_id}</p>
                   <p>Incident: {detail.incident_id ?? "—"}</p>
@@ -352,14 +353,14 @@ export default function ExportsPage() {
                   <p>Completed: {formatDateTime(detail.completed_at_utc)}</p>
                 </section>
 
-                <section className="rounded border p-3 dark:border-gray-700">
+                <section className="rounded-lg border border-border-subtle p-3">
                   <h4 className="mb-2 font-medium">Request options</h4>
-                  <pre className="overflow-auto rounded bg-gray-100 p-2 text-xs dark:bg-gray-800">
+                  <pre className="overflow-auto rounded-md bg-surface-muted p-2 text-xs text-text-secondary">
                     {JSON.stringify(detail.options_json ?? {}, null, 2)}
                   </pre>
                 </section>
 
-                <section className="grid gap-3 rounded border p-3 dark:border-gray-700 md:grid-cols-3">
+                <section className="grid gap-3 rounded-lg border border-border-subtle p-3 md:grid-cols-3">
                   <div>
                     <h4 className="mb-2 font-medium">Included files</h4>
                     {renderManifest(included)}
@@ -374,7 +375,7 @@ export default function ExportsPage() {
                   </div>
                 </section>
 
-                <section className="rounded border p-3 dark:border-gray-700">
+                <section className="rounded-lg border border-border-subtle p-3">
                   <h4 className="mb-2 font-medium">Checksum + counts</h4>
                   <p>SHA256: {detail.package_sha256 ?? "—"}</p>
                   <p>Byte size: {formatBytes(detail.byte_size)}</p>
@@ -382,24 +383,24 @@ export default function ExportsPage() {
                   <p>Timeline events: {detail.timeline_event_count}</p>
                 </section>
 
-                <section className="rounded border p-3 dark:border-gray-700">
+                <section className="rounded-lg border border-border-subtle p-3">
                   <h4 className="mb-2 font-medium">Duration</h4>
                   <p>{formatDuration(detail.generation_duration_seconds)}</p>
                 </section>
 
-                <section className="rounded border p-3 dark:border-gray-700">
+                <section className="rounded-lg border border-border-subtle p-3">
                   <h4 className="mb-2 font-medium">Download audit history</h4>
                   {audit?.downloads.length ? (
-                    <ul className="space-y-1 text-sm">
+                    <ul className="space-y-1 text-sm text-text-secondary">
                       {audit.downloads.map((event, idx) => (
-                        <li key={`${event.occurred_at_utc}-${idx}`} className="rounded border px-2 py-1 dark:border-gray-700">
+                        <li key={`${event.occurred_at_utc}-${idx}`} className="rounded-md border border-border-subtle px-2 py-1">
                           <p>{formatDateTime(event.occurred_at_utc)}</p>
-                          <p className="text-xs text-gray-500">{event.actor_type}</p>
+                          <p className="text-xs text-text-muted">{event.actor_type}</p>
                         </li>
                       ))}
                     </ul>
                   ) : (
-                    <p className="text-sm text-gray-500">No download events.</p>
+                    <p className="text-sm text-text-muted">No download events.</p>
                   )}
                 </section>
               </div>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,13 +1,94 @@
 @import "tailwindcss";
 
 :root {
-  --background: #EBF2FA;
-  --foreground: #062040;
+  /* Shell / page / surface */
+  --shell: #0b1d33;
+  --page: #ebf2fa;
+  --surface: #ffffff;
+  --surface-muted: #f4f8fc;
+  --surface-elevated: #ffffff;
+
+  /* Border */
+  --border-default: #cdd7e6;
+  --border-subtle: #dbe4f0;
+  --border-strong: #9fb0c7;
+
+  /* Text */
+  --text-primary: #062040;
+  --text-secondary: #334b68;
+  --text-muted: #5c718c;
+  --text-inverse: #f7fbff;
+
+  /* Accent */
+  --accent: #1b6ef3;
+  --accent-strong: #1558c9;
+  --accent-soft: #dfeafe;
+
+  /* Status */
+  --status-success: #1f8a54;
+  --status-success-soft: #e8f7ef;
+  --status-warning: #a66405;
+  --status-warning-soft: #fff3de;
+  --status-critical: #b42318;
+  --status-critical-soft: #feeceb;
+  --status-info: #1f64d8;
+  --status-info-soft: #e8f0ff;
+
+  /* Radius */
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+
+  /* Shadow */
+  --shadow-card: 0 1px 2px rgba(6, 32, 64, 0.08), 0 6px 16px rgba(6, 32, 64, 0.08);
+  --shadow-card-hover: 0 2px 4px rgba(6, 32, 64, 0.1), 0 10px 24px rgba(6, 32, 64, 0.12);
+  --shadow-panel: -8px 0 20px rgba(6, 32, 64, 0.18);
+
+  --background: var(--page);
+  --foreground: var(--text-primary);
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+
+  --color-shell: var(--shell);
+  --color-page: var(--page);
+  --color-surface: var(--surface);
+  --color-surface-muted: var(--surface-muted);
+  --color-surface-elevated: var(--surface-elevated);
+
+  --color-border-default: var(--border-default);
+  --color-border-subtle: var(--border-subtle);
+  --color-border-strong: var(--border-strong);
+
+  --color-text-primary: var(--text-primary);
+  --color-text-secondary: var(--text-secondary);
+  --color-text-muted: var(--text-muted);
+  --color-text-inverse: var(--text-inverse);
+
+  --color-accent: var(--accent);
+  --color-accent-strong: var(--accent-strong);
+  --color-accent-soft: var(--accent-soft);
+
+  --color-status-success: var(--status-success);
+  --color-status-success-soft: var(--status-success-soft);
+  --color-status-warning: var(--status-warning);
+  --color-status-warning-soft: var(--status-warning-soft);
+  --color-status-critical: var(--status-critical);
+  --color-status-critical-soft: var(--status-critical-soft);
+  --color-status-info: var(--status-info);
+  --color-status-info-soft: var(--status-info-soft);
+
+  --radius-sm: var(--radius-sm);
+  --radius-md: var(--radius-md);
+  --radius-lg: var(--radius-lg);
+  --radius-xl: var(--radius-xl);
+
+  --shadow-card: var(--shadow-card);
+  --shadow-card-hover: var(--shadow-card-hover);
+  --shadow-panel: var(--shadow-panel);
 }
 
 body {

--- a/frontend/app/incidents/page.tsx
+++ b/frontend/app/incidents/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import MainLayout from "@/components/MainLayout";
 import DocumentationCenter from "@/components/commercial/DocumentationCenter";
 import { listIncidents, type Incident } from "@/lib/api";
+import { statusBadgeClass, type StatusTone, designTokens } from "@/lib/design/tokens";
 import { useAuth } from "@/lib/useAuth";
 
 /**
@@ -36,12 +37,10 @@ export default function IncidentsPage() {
     return "Ready for Export";
   }
 
-  function statusColor(s: string): string {
-    if (s === "evidence_capturing" || s === "open")
-      return "bg-yellow-100 text-yellow-800";
-    if (s === "ready" || s === "closed" || s === "export_ready")
-      return "bg-green-100 text-green-800";
-    return "bg-blue-100 text-blue-800";
+  function statusTone(s: string): StatusTone {
+    if (s === "evidence_capturing" || s === "open") return "warning";
+    if (s === "ready" || s === "closed" || s === "export_ready") return "success";
+    return "info";
   }
 
   function formatTime(iso?: string): string {
@@ -74,125 +73,81 @@ export default function IncidentsPage() {
     return true;
   });
 
+  const filterClass = (isActive: boolean, tone: StatusTone) => {
+    if (isActive) return `${statusBadgeClass(tone)} ring-1 ring-current`;
+    return `${statusBadgeClass(tone)} opacity-80 hover:opacity-100`;
+  };
+
   return (
     <MainLayout title="Incidents">
-      {/* Page header */}
       <div className="mb-4">
-        <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">Incidents</h2>
-        <p className="text-sm text-gray-600 dark:text-gray-400">
-          View and manage all recorded incidents.  Monitor evidence capture and export status.
+        <h2 className="text-2xl font-semibold text-text-primary">Incidents</h2>
+        <p className="text-sm text-text-secondary">
+          View and manage all recorded incidents. Monitor evidence capture and export status.
         </p>
         <div className="mt-3 flex flex-wrap items-center gap-2">
-          <button
-            onClick={() => setFilter("all")}
-            className={`rounded-full px-3 py-1 text-xs font-medium ${
-              filter === "all"
-                ? "bg-blue-600 text-white"
-                : "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300"
-            }`}
-          >
+          <button onClick={() => setFilter("all")} className={filterClass(filter === "all", "info")}>
             All ({incidents.length})
           </button>
           <button
             onClick={() => setFilter("waiting_driver")}
-            className={`rounded-full px-3 py-1 text-xs font-medium ${
-              filter === "waiting_driver"
-                ? "bg-yellow-500 text-white"
-                : "bg-yellow-100 text-yellow-800"
-            }`}
+            className={filterClass(filter === "waiting_driver", "warning")}
           >
             Waiting on driver ({waitingCount})
           </button>
-          <button
-            onClick={() => setFilter("ready")}
-            className={`rounded-full px-3 py-1 text-xs font-medium ${
-              filter === "ready"
-                ? "bg-green-600 text-white"
-                : "bg-green-100 text-green-800"
-            }`}
-          >
+          <button onClick={() => setFilter("ready")} className={filterClass(filter === "ready", "success")}>
             Driver action complete ({incidents.length - waitingCount})
           </button>
         </div>
       </div>
 
-      {/* Loading and error states */}
-      {(loading || authLoading) && <p className="text-gray-500">Loading…</p>}
-      {error && <p className="text-red-600">{error}</p>}
+      {(loading || authLoading) && <p className="text-text-muted">Loading…</p>}
+      {error && <p className="text-status-critical">{error}</p>}
 
-      {/* No incidents */}
-      {!loading && incidents.length === 0 && (
-        <p className="text-gray-500">No incidents found.</p>
-      )}
+      {!loading && incidents.length === 0 && <p className="text-text-muted">No incidents found.</p>}
       {!loading && incidents.length > 0 && visibleIncidents.length === 0 && (
-        <p className="text-gray-500">No incidents match the selected filter.</p>
+        <p className="text-text-muted">No incidents match the selected filter.</p>
       )}
 
-      {/* Incident table */}
       {!loading && visibleIncidents.length > 0 && (
-        <div className="overflow-hidden rounded-lg border bg-white shadow dark:border-gray-700 dark:bg-gray-800">
+        <div className={`${designTokens.surface.elevated} overflow-hidden`}>
           <table className="w-full text-left text-sm">
-            <thead className="bg-gray-50 dark:bg-gray-700">
+            <thead className="bg-surface-muted text-text-secondary">
               <tr>
-                <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">Incident ID</th>
-                <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">Created</th>
-                <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">Vehicle</th>
-                <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">Status</th>
-                <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">Evidence</th>
+                <th className="px-4 py-3 font-medium">Incident ID</th>
+                <th className="px-4 py-3 font-medium">Created</th>
+                <th className="px-4 py-3 font-medium">Vehicle</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 font-medium">Evidence</th>
               </tr>
             </thead>
-            <tbody className="divide-y dark:divide-gray-700">
+            <tbody className="divide-y divide-border-subtle">
               {visibleIncidents.map((inc) => {
                 const captured = inc.evidence_captured ?? 0;
                 const total = inc.evidence_total ?? 0;
                 const pct = total > 0 ? Math.round((captured / total) * 100) : 0;
                 const waitingOnDriver = isWaitingOnDriver(inc);
                 return (
-                  <tr
-                    key={inc.incident_id}
-                    className="hover:bg-gray-50 dark:hover:bg-gray-750"
-                  >
+                  <tr key={inc.incident_id} className="hover:bg-surface-muted/70">
                     <td className="px-4 py-3">
-                      <Link
-                        href={`/incidents/${inc.incident_id}`}
-                        className="font-mono text-blue-600 hover:underline dark:text-blue-400"
-                      >
+                      <Link href={`/incidents/${inc.incident_id}`} className={`font-mono ${designTokens.accent.text}`}>
                         {inc.incident_id.slice(0, 8)}…
                       </Link>
                     </td>
-                    <td className="px-4 py-3 text-gray-600 dark:text-gray-400">
-                      {formatTime(inc.created_at_utc)}
-                    </td>
-                    <td className="px-4 py-3 font-mono text-xs">
-                      {inc.adc_vehicle_id ?? "—"}
-                    </td>
+                    <td className="px-4 py-3 text-text-secondary">{formatTime(inc.created_at_utc)}</td>
+                    <td className="px-4 py-3 font-mono text-xs text-text-secondary">{inc.adc_vehicle_id ?? "—"}</td>
                     <td className="px-4 py-3">
                       <div className="flex flex-wrap items-center gap-1.5">
-                        <span
-                          className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${statusColor(
-                            inc.status
-                          )}`}
-                        >
-                          {friendlyStatus(inc.status)}
-                        </span>
-                        {waitingOnDriver && (
-                          <span className="inline-block rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800">
-                            Waiting on driver
-                          </span>
-                        )}
+                        <span className={statusBadgeClass(statusTone(inc.status))}>{friendlyStatus(inc.status)}</span>
+                        {waitingOnDriver && <span className={statusBadgeClass("warning")}>Waiting on driver</span>}
                       </div>
                     </td>
                     <td className="px-4 py-3">
                       <div className="flex items-center gap-2">
-                        <div className="h-2 w-20 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-600">
-                          <div
-                            className="h-full rounded-full bg-blue-500"
-                            style={{ width: `${pct}%` }}
-                          />
+                        <div className="h-2 w-20 overflow-hidden rounded-full bg-accent-soft">
+                          <div className="h-full rounded-full bg-accent" style={{ width: `${pct}%` }} />
                         </div>
-                        <span className="text-xs text-gray-500 dark:text-gray-400">
-                          {captured}/{total}
-                        </span>
+                        <span className="text-xs text-text-muted">{captured}/{total}</span>
                       </div>
                     </td>
                   </tr>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -24,9 +24,9 @@ export default function RootLayout({
           rel="stylesheet"
         />
       </head>
-      <body className="antialiased bg-[#EBF2FA]">
+      <body className="bg-page text-text-primary antialiased">
         {children}
-        <div className="fixed bottom-2 right-2 rounded bg-slate-900/85 px-2 py-1 text-xs text-white" aria-label="deploy-version">
+        <div className="fixed bottom-2 right-2 rounded-md bg-shell/90 px-2 py-1 text-xs text-text-inverse" aria-label="deploy-version">
           Deploy {deployVersion}
         </div>
       </body>

--- a/frontend/app/reports/page.tsx
+++ b/frontend/app/reports/page.tsx
@@ -5,7 +5,7 @@ export default function ReportsPage() {
   return (
     <MainLayout title="Commercial Reports">
       <div className="space-y-4">
-        <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">Commercial performance reports</h2>
+        <h2 className="text-2xl font-semibold text-text-primary">Commercial performance reports</h2>
         <CommercialSummaryCards
           items={[
             { label: "Active tenants", value: "48", detail: "+6 from last quarter" },

--- a/frontend/app/timeline/page.tsx
+++ b/frontend/app/timeline/page.tsx
@@ -4,6 +4,7 @@ import MainLayout from "@/components/MainLayout";
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { getIncident, listIncidents, type EventSummary } from "@/lib/api";
+import { designTokens } from "@/lib/design/tokens";
 
 const TIMELINE_POLL_MS = 10000;
 const MAX_EVENTS = 250;
@@ -112,10 +113,10 @@ export default function TimelinePage() {
     <MainLayout title="Live Timeline">
       <div className="mb-6 flex items-start justify-between gap-4">
         <div>
-          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">
+          <h2 className="text-2xl font-semibold text-text-primary">
             Live Timeline
           </h2>
-          <p className="text-sm text-gray-600 dark:text-gray-400">
+          <p className="text-sm text-text-secondary">
             Cross-incident event feed powered by existing event data. This view
             refreshes every {TIMELINE_POLL_MS / 1000}s while streaming support is
             planned next.
@@ -123,51 +124,51 @@ export default function TimelinePage() {
         </div>
         <Link
           href="/dashboard"
-          className="rounded border border-blue-600 px-3 py-2 text-xs font-medium text-blue-600 hover:bg-blue-50 dark:hover:bg-gray-700"
+          className="rounded-md border border-accent px-3 py-2 text-xs font-medium text-accent hover:bg-accent-soft"
         >
           Back to dashboard
         </Link>
       </div>
 
-      {error ? <p className="mb-4 text-sm text-red-600">{error}</p> : null}
+      {error ? <p className="mb-4 text-sm text-status-critical">{error}</p> : null}
 
       <div className="mb-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <div className="rounded border bg-white p-3 text-sm shadow dark:border-gray-700 dark:bg-gray-800">
-          <p className="text-gray-500">Events loaded</p>
-          <p className="text-xl font-bold text-blue-600 dark:text-blue-400">{events.length}</p>
+        <div className="rounded-lg border border-border-default bg-surface p-3 text-sm shadow-card">
+          <p className="text-text-muted">Events loaded</p>
+          <p className="text-xl font-bold text-accent">{events.length}</p>
         </div>
         {groupedCounts.map(([eventType, count]) => (
           <div
             key={eventType}
-            className="rounded border bg-white p-3 text-sm shadow dark:border-gray-700 dark:bg-gray-800"
+            className="rounded-lg border border-border-default bg-surface p-3 text-sm shadow-card"
           >
-            <p className="text-gray-500">{friendlyEventType(eventType)}</p>
-            <p className="text-xl font-bold text-blue-600 dark:text-blue-400">{count}</p>
+            <p className="text-text-muted">{friendlyEventType(eventType)}</p>
+            <p className="text-xl font-bold text-accent">{count}</p>
           </div>
         ))}
       </div>
 
       {loading ? (
-        <p className="text-gray-500">Loading…</p>
+        <p className="text-text-muted">Loading…</p>
       ) : events.length === 0 ? (
-        <div className="rounded border border-dashed p-8 text-center text-gray-400 dark:border-gray-700">
+        <div className="rounded-lg border border-dashed border-border-strong p-8 text-center text-text-muted">
           No incident events found yet.
         </div>
       ) : (
-        <ol className="relative border-l border-gray-200 dark:border-gray-600">
+        <ol className="relative border-l border-border-default">
           {events.map((event, index) => (
             <li key={`${event.incident_id}-${event.event_type}-${index}`} className="mb-5 ml-4">
-              <div className="absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full border border-white bg-blue-500 dark:border-gray-800" />
-              <time className="mb-1 block text-xs text-gray-400">
+              <div className="absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full border border-surface bg-accent" />
+              <time className="mb-1 block text-xs text-text-muted">
                 {formatTime(event.occurred_at_utc)}
               </time>
-              <p className="text-sm font-medium text-gray-900 dark:text-white">
+              <p className="text-sm font-medium text-text-primary">
                 {friendlyEventType(event.event_type)}
               </p>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
+              <p className="text-xs text-text-secondary">
                 Incident{" "}
                 <Link
-                  className="text-blue-600 hover:underline dark:text-blue-400"
+                  className={designTokens.accent.text}
                   href={`/incidents/${event.incident_id}`}
                 >
                   {event.incident_id.slice(0, 8)}…

--- a/frontend/components/MainLayout.tsx
+++ b/frontend/components/MainLayout.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import { logout } from "@/lib/api";
 import { useAuth } from "@/lib/useAuth";
 import { hasRoleCapability } from "@/lib/permissions";
+import { designTokens } from "@/lib/design/tokens";
 
 interface MainLayoutProps {
   title?: string;
@@ -73,18 +74,18 @@ export default function MainLayout({ title, children }: MainLayoutProps) {
   const pathname = usePathname() ?? "/";
 
   if (loading) {
-    return <div className="p-6 text-gray-500">Loading…</div>;
+    return <div className="p-6 text-text-muted">Loading…</div>;
   }
 
   if (!user) {
     return (
-      <div className="space-y-2 p-6 text-sm text-gray-500">
+      <div className="space-y-2 p-6 text-sm text-text-muted">
         <p>You must be logged in to view this page.</p>
         <div className="flex items-center gap-4">
-          <Link href="/login" className="font-medium text-blue-600 hover:underline dark:text-blue-400">
+          <Link href="/login" className={`font-medium ${designTokens.accent.text}`}>
             Sign in
           </Link>
-          <Link href="/" className="font-medium text-gray-600 hover:underline dark:text-gray-300">
+          <Link href="/" className="font-medium text-text-secondary hover:underline">
             Back to homepage
           </Link>
         </div>
@@ -146,21 +147,21 @@ export default function MainLayout({ title, children }: MainLayoutProps) {
       label: "+ Create Incident",
       ariaLabel: "Create a new incident",
       className:
-        "rounded border border-blue-200 px-3 py-1 font-medium text-blue-700 hover:bg-blue-50 dark:border-blue-700 dark:text-blue-300 dark:hover:bg-blue-950",
+        "rounded-md border border-accent/40 bg-accent-soft/30 px-3 py-1 font-medium text-accent hover:bg-accent-soft",
     },
     {
       href: "/incidents?filter=active",
       label: "Open Active Queue",
       ariaLabel: "Open active incident queue",
       className:
-        "rounded border border-amber-200 px-3 py-1 font-medium text-amber-700 hover:bg-amber-50 dark:border-amber-700 dark:text-amber-300 dark:hover:bg-amber-950",
+        "rounded-md border border-status-warning/35 bg-status-warning-soft/60 px-3 py-1 font-medium text-status-warning hover:bg-status-warning-soft",
     },
     {
       href: "/exports?intent=request",
       label: "Request Export",
       ariaLabel: "Open export request flow",
       className:
-        "rounded border border-emerald-200 px-3 py-1 font-medium text-emerald-700 hover:bg-emerald-50 dark:border-emerald-700 dark:text-emerald-300 dark:hover:bg-emerald-950",
+        "rounded-md border border-status-success/35 bg-status-success-soft/60 px-3 py-1 font-medium text-status-success hover:bg-status-success-soft",
     },
   ].filter((action) => (action.label === "Request Export" ? canManageExports : true));
 
@@ -178,11 +179,11 @@ export default function MainLayout({ title, children }: MainLayoutProps) {
     .filter((crumb) => crumb.href !== defaultLanding);
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <header className="flex flex-wrap items-center justify-between gap-3 border-b bg-white px-6 py-4 dark:bg-gray-800">
+    <div className="min-h-screen bg-page text-text-primary">
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border-default bg-shell px-6 py-4 text-text-inverse">
         <div>
           <Link href={defaultLanding} className="inline-block">
-            <h1 className="text-lg font-bold text-gray-900 hover:text-blue-700 dark:text-white dark:hover:text-blue-300">
+            <h1 className="text-lg font-bold text-text-inverse hover:text-accent-soft">
               {title ?? "ADC Dashboard"}
             </h1>
           </Link>
@@ -201,14 +202,14 @@ export default function MainLayout({ title, children }: MainLayoutProps) {
           ))}
           <button
             onClick={logout}
-            className="ml-1 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400"
+            className="ml-1 text-sm text-accent-soft hover:text-text-inverse"
           >
             Sign out
           </button>
         </div>
       </header>
 
-      <nav className="space-y-3 border-b bg-white px-6 py-3 dark:border-gray-700 dark:bg-gray-800">
+      <nav className="space-y-3 border-b border-border-default bg-shell/95 px-6 py-3 text-text-inverse">
         <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
           {navGroups.map((group) => {
             const visibleItems = group.items.filter((item) => !item.hidden);
@@ -216,7 +217,7 @@ export default function MainLayout({ title, children }: MainLayoutProps) {
 
             return (
               <div key={group.area}>
-                <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-accent-soft">
                   {group.area}
                 </p>
                 <div className="flex flex-wrap gap-2 text-sm">
@@ -228,8 +229,8 @@ export default function MainLayout({ title, children }: MainLayoutProps) {
                         href={item.href}
                         className={`rounded-full px-3 py-1 transition ${
                           isActive
-                            ? "bg-blue-600 text-white"
-                            : "text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+                            ? "bg-accent text-text-inverse"
+                            : "text-accent-soft hover:bg-surface/10"
                         }`}
                         aria-current={isActive ? "page" : undefined}
                       >
@@ -244,8 +245,8 @@ export default function MainLayout({ title, children }: MainLayoutProps) {
         </div>
 
         {breadcrumbs.length > 0 && (
-          <div className="flex flex-wrap items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
-            <Link href={defaultLanding} className="hover:text-gray-700 dark:hover:text-gray-200">
+          <div className="flex flex-wrap items-center gap-1 text-xs text-accent-soft">
+            <Link href={defaultLanding} className="hover:text-text-inverse">
               Home
             </Link>
             {breadcrumbs.map((crumb, idx) => {
@@ -254,9 +255,9 @@ export default function MainLayout({ title, children }: MainLayoutProps) {
                 <span key={crumb.href} className="flex items-center gap-1">
                   <span>/</span>
                   {last ? (
-                    <span className="font-medium text-gray-700 dark:text-gray-200">{crumb.label}</span>
+                    <span className="font-medium text-text-inverse">{crumb.label}</span>
                   ) : (
-                    <Link href={crumb.href} className="hover:text-gray-700 dark:hover:text-gray-200">
+                    <Link href={crumb.href} className="hover:text-text-inverse">
                       {crumb.label}
                     </Link>
                   )}

--- a/frontend/components/commercial/CommercialSummaryCards.tsx
+++ b/frontend/components/commercial/CommercialSummaryCards.tsx
@@ -1,3 +1,5 @@
+import { designTokens } from "@/lib/design/tokens";
+
 interface SummaryItem {
   label: string;
   value: string;
@@ -12,10 +14,10 @@ export default function CommercialSummaryCards({ items }: CommercialSummaryCards
   return (
     <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
       {items.map((item) => (
-        <article key={item.label} className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
-          <p className="text-xs uppercase tracking-wide text-gray-500">{item.label}</p>
-          <p className="mt-1 text-xl font-semibold text-gray-900 dark:text-white">{item.value}</p>
-          {item.detail ? <p className="mt-1 text-xs text-gray-600 dark:text-gray-300">{item.detail}</p> : null}
+        <article key={item.label} className={`${designTokens.surface.base} p-4`}>
+          <p className="text-xs uppercase tracking-wide text-text-muted">{item.label}</p>
+          <p className="mt-1 text-xl font-semibold text-text-primary">{item.value}</p>
+          {item.detail ? <p className="mt-1 text-xs text-text-secondary">{item.detail}</p> : null}
         </article>
       ))}
     </div>

--- a/frontend/components/commercial/DocumentationCenter.tsx
+++ b/frontend/components/commercial/DocumentationCenter.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { designTokens } from "@/lib/design/tokens";
 
 export interface DocumentationLink {
   title: string;
@@ -13,15 +14,15 @@ interface DocumentationCenterProps {
 
 export default function DocumentationCenter({ title = "Documentation center", docs }: DocumentationCenterProps) {
   return (
-    <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
-      <h3 className="text-base font-semibold text-gray-900 dark:text-white">{title}</h3>
+    <section className={`${designTokens.surface.base} p-4`}>
+      <h3 className="text-base font-semibold text-text-primary">{title}</h3>
       <ul className="mt-3 space-y-2">
         {docs.map((doc) => (
-          <li key={doc.href} className="rounded border p-3 dark:border-gray-700">
-            <Link href={doc.href} className="font-medium text-blue-600 hover:underline dark:text-blue-400">
+          <li key={doc.href} className="rounded-md border border-border-subtle p-3">
+            <Link href={doc.href} className={`font-medium ${designTokens.accent.text}`}>
               {doc.title}
             </Link>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">{doc.description}</p>
+            <p className="mt-1 text-sm text-text-secondary">{doc.description}</p>
           </li>
         ))}
       </ul>

--- a/frontend/components/commercial/FeatureGate.tsx
+++ b/frontend/components/commercial/FeatureGate.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { statusBadgeClass } from "@/lib/design/tokens";
 import PlanBadge from "./PlanBadge";
 
 interface FeatureGateProps {
@@ -20,14 +21,14 @@ export default function FeatureGate({
   if (mode === "hide") return null;
 
   return (
-    <div className="space-y-2 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900/50">
-      <div className="flex flex-wrap items-center gap-2 text-sm text-gray-700 dark:text-gray-200">
-        <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700">
+    <div className="space-y-2 rounded-lg border border-dashed border-border-strong bg-surface-muted p-4">
+      <div className="flex flex-wrap items-center gap-2 text-sm text-text-secondary">
+        <span className={`${statusBadgeClass("warning")} font-semibold`}>
           Locked
         </span>
         {requiredPlan ? <PlanBadge plan={requiredPlan} /> : null}
       </div>
-      <p className="text-sm text-gray-600 dark:text-gray-300">{reason}</p>
+      <p className="text-sm text-text-secondary">{reason}</p>
       <div
         className="pointer-events-none select-none rounded-md opacity-60"
         aria-disabled="true"

--- a/frontend/components/commercial/PlanBadge.tsx
+++ b/frontend/components/commercial/PlanBadge.tsx
@@ -3,9 +3,9 @@ interface PlanBadgeProps {
 }
 
 const PLAN_STYLES: Record<PlanBadgeProps["plan"], string> = {
-  Starter: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200",
-  Growth: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-200",
-  Enterprise: "bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-200",
+  Starter: "bg-surface text-text-secondary",
+  Growth: "bg-accent-soft text-accent",
+  Enterprise: "bg-status-info-soft text-status-info",
 };
 
 export default function PlanBadge({ plan }: PlanBadgeProps) {

--- a/frontend/lib/design/tokens.ts
+++ b/frontend/lib/design/tokens.ts
@@ -1,0 +1,60 @@
+export type StatusTone = "neutral" | "info" | "success" | "warning" | "critical";
+
+const statusBadgeClasses: Record<StatusTone, string> = {
+  neutral: "bg-surface-muted text-text-secondary",
+  info: "bg-status-info-soft text-status-info",
+  success: "bg-status-success-soft text-status-success",
+  warning: "bg-status-warning-soft text-status-warning",
+  critical: "bg-status-critical-soft text-status-critical",
+};
+
+export const designTokens = {
+  shell: "bg-shell text-text-inverse",
+  page: "bg-page text-text-primary",
+  surface: {
+    base: "rounded-lg border border-border-default bg-surface shadow-card",
+    subtle: "rounded-lg border border-border-subtle bg-surface-muted",
+    elevated: "rounded-lg border border-border-default bg-surface-elevated shadow-card",
+    panel: "bg-surface-elevated shadow-panel",
+  },
+  border: {
+    default: "border-border-default",
+    subtle: "border-border-subtle",
+    strong: "border-border-strong",
+  },
+  text: {
+    primary: "text-text-primary",
+    secondary: "text-text-secondary",
+    muted: "text-text-muted",
+    inverse: "text-text-inverse",
+  },
+  accent: {
+    solid: "bg-accent text-text-inverse hover:bg-accent-strong",
+    soft: "bg-accent-soft text-accent",
+    text: "text-accent hover:text-accent-strong",
+  },
+  radius: {
+    sm: "rounded-sm",
+    md: "rounded-md",
+    lg: "rounded-lg",
+    xl: "rounded-xl",
+  },
+  shadow: {
+    card: "shadow-card",
+    cardHover: "hover:shadow-card-hover",
+    panel: "shadow-panel",
+  },
+  status: {
+    badgeBase: "rounded-full px-2 py-0.5 text-xs font-medium",
+    badge: statusBadgeClasses,
+  },
+  control: {
+    input: "rounded-md border border-border-default bg-surface px-2 py-1 text-sm text-text-primary",
+    link: "text-accent hover:text-accent-strong hover:underline",
+    buttonSecondary: "rounded-md border border-border-default bg-surface px-2 py-1 text-xs text-text-secondary hover:bg-surface-muted",
+  },
+} as const;
+
+export function statusBadgeClass(tone: StatusTone): string {
+  return `${designTokens.status.badgeBase} ${designTokens.status.badge[tone]}`;
+}

--- a/frontend/lib/exportStatus.ts
+++ b/frontend/lib/exportStatus.ts
@@ -1,4 +1,5 @@
 import type { ExportStatus } from "@/lib/api";
+import { statusBadgeClass } from "@/lib/design/tokens";
 
 export const EXPORT_STATUS_LABELS: Record<ExportStatus, string> = {
   requested: "Requested",
@@ -14,7 +15,7 @@ export function getExportStatusLabel(status: ExportStatus): string {
 }
 
 export function getExportStatusBadgeClass(status: ExportStatus): string {
-  if (status === "ready") return "bg-green-100 text-green-800";
-  if (status === "failed" || status === "expired") return "bg-red-100 text-red-800";
-  return "bg-yellow-100 text-yellow-800";
+  if (status === "ready") return statusBadgeClass("success");
+  if (status === "failed" || status === "expired") return statusBadgeClass("critical");
+  return statusBadgeClass("warning");
 }


### PR DESCRIPTION
### Motivation
- Establish a single source of truth for colors, radii, and shadows so pages/components use semantic tokens instead of ad‑hoc hex values and Tailwind utility leakage. 
- Replace scattered hardcoded color usages (e.g. `#EBF2FA`, inline blues/greens/yellows) with named semantic roles (shell/page/surface/accent/status) to keep status meanings consistent and accessible. 
- Provide a typed token helper so React components can consume design tokens in a predictable, type-safe way. 

### Description
- Added semantic CSS variables and Tailwind theme mappings in `frontend/app/globals.css` for shell/page/surface, border, text, accent, status colors, radius scales (`--radius-sm…--radius-xl`) and shadows (`--shadow-card`, `--shadow-card-hover`, `--shadow-panel`). 
- Introduced `frontend/lib/design/tokens.ts` exporting a typed `StatusTone`, a `designTokens` helper object, and `statusBadgeClass()` for consistent badge classes. 
- Refactored major layout/pages to consume tokens instead of hardcoded classes, including `frontend/app/layout.tsx`, `frontend/components/MainLayout.tsx`, `frontend/app/incidents/page.tsx`, `frontend/app/exports/page.tsx`, `frontend/app/timeline/page.tsx`, and `frontend/app/reports/page.tsx`. 
- Updated shared commercial components to use tokens: `frontend/components/commercial/DocumentationCenter.tsx`, `frontend/components/commercial/CommercialSummaryCards.tsx`, `frontend/components/commercial/FeatureGate.tsx`, and `frontend/components/commercial/PlanBadge.tsx`. 
- Rewrote `frontend/lib/exportStatus.ts` to use the typed `statusBadgeClass()` helper so export status badges are semantic. 

### Testing
- Ran linting with `npm run lint` and the linter completed successfully. 
- Executed type checking with `npm run typecheck` (`tsc --noEmit`) and there were no type errors. 
- Ran the frontend unit tests with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecff95cd308321b138ba757d3c285b)