### PR TITLE
feat(frontend): add layout/data-display primitives and design-system demo page

### DIFF
--- a/frontend/app/demo/design-system/page.tsx
+++ b/frontend/app/demo/design-system/page.tsx
@@ -1,0 +1,135 @@
+import {
+  AvatarChip,
+  DataTableShell,
+  MetricCard,
+  ProgressRing,
+  ReadinessBadge,
+  SeverityBadge,
+  StatusChip,
+} from "@/components/data-display";
+import { PageHeader, RightRailPanel, SectionCard, StickySidebar } from "@/components/layout";
+import type { StatusTone } from "@/lib/design/tokens";
+
+const tones: StatusTone[] = ["neutral", "info", "success", "warning", "critical"];
+const sizes = ["sm", "md", "lg"] as const;
+const readinessStatuses = ["not_started", "in_progress", "ready", "blocked"] as const;
+const severities = ["low", "medium", "high", "critical"] as const;
+
+export default function DesignSystemDemoPage() {
+  return (
+    <main className="space-y-6 p-6">
+      <PageHeader
+        eyebrow="Design system"
+        title="Layout & data-display contracts"
+        subtitle="Demo states for tones, sizes, and status variants"
+        actions={<button className="rounded-md border border-border-default px-3 py-1 text-sm">Action</button>}
+        meta={<span>Updated for Sprint component build-out.</span>}
+      />
+
+      <div className="grid gap-4 lg:grid-cols-[1fr_300px]">
+        <div className="space-y-4">
+          <SectionCard title="MetricCard tones" description="Visual lock for all tones">
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              {tones.map((tone) => (
+                <MetricCard
+                  key={tone}
+                  label={`Tone: ${tone}`}
+                  value={tone === "critical" ? "3" : "42"}
+                  tone={tone}
+                  trend={{ label: "+6%", tone }}
+                  helperText="Compared to yesterday"
+                />
+              ))}
+            </div>
+          </SectionCard>
+
+          <SectionCard title="StatusChip sizes × tones" tone="info">
+            <div className="space-y-3">
+              {sizes.map((size) => (
+                <div key={size} className="flex flex-wrap gap-2">
+                  {tones.map((tone) => (
+                    <StatusChip key={`${size}-${tone}`} label={`${size} • ${tone}`} tone={tone} size={size} />
+                  ))}
+                </div>
+              ))}
+            </div>
+          </SectionCard>
+
+          <SectionCard title="Readiness + Severity badges" tone="warning">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-2">
+                {readinessStatuses.map((status) => (
+                  <div key={status} className="flex items-center justify-between">
+                    <span className="text-sm text-text-secondary">{status}</span>
+                    <ReadinessBadge status={status} />
+                  </div>
+                ))}
+              </div>
+              <div className="space-y-2">
+                {severities.map((severity) => (
+                  <div key={severity} className="flex items-center justify-between">
+                    <span className="text-sm text-text-secondary">{severity}</span>
+                    <SeverityBadge severity={severity} />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </SectionCard>
+
+          <SectionCard title="AvatarChip + ProgressRing" tone="success">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                {sizes.map((size) => (
+                  <AvatarChip key={size} name="Jordan Lee" subtitle={`${size} size`} size={size} />
+                ))}
+              </div>
+              <div className="flex flex-wrap items-center gap-4">
+                <ProgressRing value={18} tone="critical" size="sm" label="18%" />
+                <ProgressRing value={62} tone="warning" size="md" label="62%" />
+                <ProgressRing value={92} tone="success" size="lg" label="92%" />
+              </div>
+            </div>
+          </SectionCard>
+
+          <DataTableShell
+            title="DataTableShell state"
+            description="Normal and empty states"
+            actions={<button className="rounded-md border border-border-default px-2 py-1 text-xs">Refresh</button>}
+            columns={
+              <tr>
+                <th className="px-3 py-2">Case</th>
+                <th className="px-3 py-2">Owner</th>
+                <th className="px-3 py-2">Readiness</th>
+              </tr>
+            }
+          >
+            <tr>
+              <td className="px-3 py-2">INC-1022</td>
+              <td className="px-3 py-2">Jordan Lee</td>
+              <td className="px-3 py-2"><ReadinessBadge status="in_progress" /></td>
+            </tr>
+          </DataTableShell>
+
+          <DataTableShell
+            title="DataTableShell empty"
+            columns={
+              <tr>
+                <th className="px-3 py-2">Case</th>
+              </tr>
+            }
+            isEmpty
+            emptyState="No cases match current filters."
+          >
+            <tr />
+          </DataTableShell>
+        </div>
+
+        <StickySidebar>
+          <RightRailPanel title="Right rail panel" subtitle="Sticky support state">
+            <p className="text-sm text-text-secondary">Use this rail for owner, readiness, and next action context.</p>
+          </RightRailPanel>
+        </StickySidebar>
+      </div>
+    </main>
+  );
+}

--- a/frontend/components/data-display/AvatarChip.tsx
+++ b/frontend/components/data-display/AvatarChip.tsx
@@ -1,0 +1,48 @@
+import Image from "next/image";
+
+export type AvatarChipSize = "sm" | "md" | "lg";
+
+export interface AvatarChipProps {
+  name: string;
+  subtitle?: string;
+  src?: string;
+  size?: AvatarChipSize;
+  className?: string;
+}
+
+const AVATAR_SIZE: Record<AvatarChipSize, string> = {
+  sm: "h-7 w-7 text-[11px]",
+  md: "h-9 w-9 text-xs",
+  lg: "h-11 w-11 text-sm",
+};
+
+export default function AvatarChip({ name, subtitle, src, size = "md", className }: AvatarChipProps) {
+  const initials = name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+
+  return (
+    <div className={["inline-flex items-center gap-2 rounded-full border border-border-default bg-surface-muted px-2 py-1", className].filter(Boolean).join(" ")}>
+      {src ? (
+        <Image
+          src={src}
+          alt={name}
+          width={44}
+          height={44}
+          className={["rounded-full object-cover", AVATAR_SIZE[size]].join(" ")}
+        />
+      ) : (
+        <span className={["inline-flex items-center justify-center rounded-full bg-accent-soft font-semibold text-accent", AVATAR_SIZE[size]].join(" ")}>
+          {initials}
+        </span>
+      )}
+      <span className="leading-tight">
+        <span className="block text-sm font-medium text-text-primary">{name}</span>
+        {subtitle ? <span className="block text-xs text-text-secondary">{subtitle}</span> : null}
+      </span>
+    </div>
+  );
+}

--- a/frontend/components/data-display/DataTableShell.tsx
+++ b/frontend/components/data-display/DataTableShell.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+
+export interface DataTableShellProps {
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+  columns: ReactNode;
+  children: ReactNode;
+  footer?: ReactNode;
+  emptyState?: ReactNode;
+  isEmpty?: boolean;
+  className?: string;
+}
+
+export default function DataTableShell({
+  title,
+  description,
+  actions,
+  columns,
+  children,
+  footer,
+  emptyState,
+  isEmpty = false,
+  className,
+}: DataTableShellProps) {
+  return (
+    <section className={["rounded-lg border border-border-default bg-surface shadow-card", className].filter(Boolean).join(" ")}>
+      <header className="flex flex-wrap items-start justify-between gap-2 border-b border-border-subtle p-4">
+        <div>
+          <h3 className="text-base font-semibold text-text-primary">{title}</h3>
+          {description ? <p className="text-sm text-text-secondary">{description}</p> : null}
+        </div>
+        {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
+      </header>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-border-subtle text-sm">
+          <thead className="bg-surface-muted text-left text-text-secondary">{columns}</thead>
+          <tbody className="divide-y divide-border-subtle text-text-primary">{isEmpty ? null : children}</tbody>
+        </table>
+        {isEmpty ? <div className="p-6 text-sm text-text-secondary">{emptyState ?? "No records."}</div> : null}
+      </div>
+
+      {footer ? <footer className="border-t border-border-subtle p-3 text-xs text-text-secondary">{footer}</footer> : null}
+    </section>
+  );
+}

--- a/frontend/components/data-display/MetricCard.tsx
+++ b/frontend/components/data-display/MetricCard.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+import StatusChip, { type StatusChipSize } from "./StatusChip";
+import type { StatusTone } from "@/lib/design/tokens";
+
+export interface MetricCardProps {
+  label: string;
+  value: string | number;
+  helperText?: string;
+  tone?: StatusTone;
+  trend?: {
+    label: string;
+    tone?: StatusTone;
+    size?: StatusChipSize;
+  };
+  icon?: ReactNode;
+  className?: string;
+}
+
+export default function MetricCard({ label, value, helperText, tone = "neutral", trend, icon, className }: MetricCardProps) {
+  return (
+    <article className={["rounded-lg border border-border-default bg-surface p-4 shadow-card", className].filter(Boolean).join(" ")}>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-text-secondary">{label}</p>
+          <p className="mt-1 text-2xl font-semibold text-text-primary">{value}</p>
+        </div>
+        {icon ? <div className="text-text-secondary">{icon}</div> : null}
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <StatusChip label={tone} tone={tone} size="sm" />
+        {trend ? <StatusChip label={trend.label} tone={trend.tone ?? tone} size={trend.size ?? "sm"} /> : null}
+      </div>
+
+      {helperText ? <p className="mt-2 text-xs text-text-secondary">{helperText}</p> : null}
+    </article>
+  );
+}

--- a/frontend/components/data-display/ProgressRing.tsx
+++ b/frontend/components/data-display/ProgressRing.tsx
@@ -1,0 +1,68 @@
+export type ProgressRingSize = "sm" | "md" | "lg";
+
+export interface ProgressRingProps {
+  value: number;
+  max?: number;
+  label?: string;
+  size?: ProgressRingSize;
+  tone?: "neutral" | "success" | "warning" | "critical";
+  className?: string;
+}
+
+const SIZE: Record<ProgressRingSize, { box: number; stroke: number; text: string }> = {
+  sm: { box: 44, stroke: 4, text: "text-[10px]" },
+  md: { box: 60, stroke: 5, text: "text-xs" },
+  lg: { box: 76, stroke: 6, text: "text-sm" },
+};
+
+const TONE: Record<NonNullable<ProgressRingProps["tone"]>, string> = {
+  neutral: "stroke-text-secondary",
+  success: "stroke-status-success",
+  warning: "stroke-status-warning",
+  critical: "stroke-status-critical",
+};
+
+export default function ProgressRing({
+  value,
+  max = 100,
+  label,
+  size = "md",
+  tone = "neutral",
+  className,
+}: ProgressRingProps) {
+  const config = SIZE[size];
+  const radius = (config.box - config.stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const pct = Math.max(0, Math.min(100, Math.round((value / max) * 100)));
+  const dashOffset = circumference - (pct / 100) * circumference;
+
+  return (
+    <div className={["inline-flex flex-col items-center gap-1", className].filter(Boolean).join(" ")}>
+      <svg width={config.box} height={config.box} viewBox={`0 0 ${config.box} ${config.box}`} aria-label={label ?? `${pct}%`} role="img">
+        <circle
+          cx={config.box / 2}
+          cy={config.box / 2}
+          r={radius}
+          fill="none"
+          strokeWidth={config.stroke}
+          className="stroke-border-subtle"
+        />
+        <circle
+          cx={config.box / 2}
+          cy={config.box / 2}
+          r={radius}
+          fill="none"
+          strokeWidth={config.stroke}
+          className={["origin-center -rotate-90", TONE[tone]].join(" ")}
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+          strokeLinecap="round"
+        />
+        <text x="50%" y="50%" dominantBaseline="middle" textAnchor="middle" className={config.text}>
+          {pct}%
+        </text>
+      </svg>
+      {label ? <span className="text-xs text-text-secondary">{label}</span> : null}
+    </div>
+  );
+}

--- a/frontend/components/data-display/ReadinessBadge.tsx
+++ b/frontend/components/data-display/ReadinessBadge.tsx
@@ -1,0 +1,27 @@
+import StatusChip, { type StatusChipSize } from "./StatusChip";
+
+export type ReadinessStatus = "not_started" | "in_progress" | "ready" | "blocked";
+
+export interface ReadinessBadgeProps {
+  status: ReadinessStatus;
+  size?: StatusChipSize;
+  className?: string;
+}
+
+const LABELS: Record<ReadinessStatus, string> = {
+  not_started: "Not started",
+  in_progress: "In progress",
+  ready: "Ready",
+  blocked: "Blocked",
+};
+
+const TONES: Record<ReadinessStatus, "neutral" | "warning" | "success" | "critical"> = {
+  not_started: "neutral",
+  in_progress: "warning",
+  ready: "success",
+  blocked: "critical",
+};
+
+export default function ReadinessBadge({ status, size = "md", className }: ReadinessBadgeProps) {
+  return <StatusChip label={LABELS[status]} tone={TONES[status]} size={size} className={className} />;
+}

--- a/frontend/components/data-display/SeverityBadge.tsx
+++ b/frontend/components/data-display/SeverityBadge.tsx
@@ -1,0 +1,20 @@
+import StatusChip, { type StatusChipSize } from "./StatusChip";
+
+export type SeverityLevel = "low" | "medium" | "high" | "critical";
+
+export interface SeverityBadgeProps {
+  severity: SeverityLevel;
+  size?: StatusChipSize;
+  className?: string;
+}
+
+const TONES: Record<SeverityLevel, "neutral" | "info" | "warning" | "critical"> = {
+  low: "neutral",
+  medium: "info",
+  high: "warning",
+  critical: "critical",
+};
+
+export default function SeverityBadge({ severity, size = "md", className }: SeverityBadgeProps) {
+  return <StatusChip label={severity[0].toUpperCase() + severity.slice(1)} tone={TONES[severity]} size={size} className={className} />;
+}

--- a/frontend/components/data-display/StatusChip.tsx
+++ b/frontend/components/data-display/StatusChip.tsx
@@ -1,0 +1,20 @@
+import { statusBadgeClass, type StatusTone } from "@/lib/design/tokens";
+
+export type StatusChipSize = "sm" | "md" | "lg";
+
+export interface StatusChipProps {
+  label: string;
+  tone?: StatusTone;
+  size?: StatusChipSize;
+  className?: string;
+}
+
+const sizeClass: Record<StatusChipSize, string> = {
+  sm: "text-[11px] px-2 py-0.5",
+  md: "text-xs px-2.5 py-1",
+  lg: "text-sm px-3 py-1",
+};
+
+export default function StatusChip({ label, tone = "neutral", size = "md", className }: StatusChipProps) {
+  return <span className={[statusBadgeClass(tone), sizeClass[size], className].filter(Boolean).join(" ")}>{label}</span>;
+}

--- a/frontend/components/data-display/index.ts
+++ b/frontend/components/data-display/index.ts
@@ -1,3 +1,10 @@
 export { default as EvidenceTable } from "./EvidenceTable";
 export { EVIDENCE_TYPES } from "./EvidenceTable";
 export { default as Timeline } from "./Timeline";
+export { default as MetricCard } from "./MetricCard";
+export { default as StatusChip } from "./StatusChip";
+export { default as ReadinessBadge } from "./ReadinessBadge";
+export { default as SeverityBadge } from "./SeverityBadge";
+export { default as AvatarChip } from "./AvatarChip";
+export { default as ProgressRing } from "./ProgressRing";
+export { default as DataTableShell } from "./DataTableShell";

--- a/frontend/components/layout/PageHeader.tsx
+++ b/frontend/components/layout/PageHeader.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+export interface PageHeaderProps {
+  title: string;
+  subtitle?: string;
+  eyebrow?: string;
+  actions?: ReactNode;
+  meta?: ReactNode;
+  className?: string;
+}
+
+export default function PageHeader({ title, subtitle, eyebrow, actions, meta, className }: PageHeaderProps) {
+  return (
+    <header className={["rounded-lg border border-border-default bg-surface p-5 shadow-card", className].filter(Boolean).join(" ")}>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-1">
+          {eyebrow ? <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">{eyebrow}</p> : null}
+          <h1 className="text-2xl font-semibold text-text-primary">{title}</h1>
+          {subtitle ? <p className="text-sm text-text-secondary">{subtitle}</p> : null}
+        </div>
+        {actions ? <div className="flex shrink-0 items-center gap-2">{actions}</div> : null}
+      </div>
+      {meta ? <div className="mt-4 border-t border-border-subtle pt-3 text-xs text-text-secondary">{meta}</div> : null}
+    </header>
+  );
+}

--- a/frontend/components/layout/RightRailPanel.tsx
+++ b/frontend/components/layout/RightRailPanel.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+export interface RightRailPanelProps {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+}
+
+export default function RightRailPanel({ title, subtitle, children, actions, className }: RightRailPanelProps) {
+  return (
+    <section className={["rounded-lg border border-border-default bg-surface p-4 shadow-card", className].filter(Boolean).join(" ")}>
+      <div className="mb-3 flex items-start justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-text-secondary">{title}</h3>
+          {subtitle ? <p className="mt-1 text-xs text-text-muted">{subtitle}</p> : null}
+        </div>
+        {actions ? <div className="shrink-0">{actions}</div> : null}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/frontend/components/layout/SectionCard.tsx
+++ b/frontend/components/layout/SectionCard.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+
+export type SectionCardTone = "default" | "info" | "success" | "warning" | "critical";
+
+export interface SectionCardProps {
+  title: string;
+  description?: string;
+  tone?: SectionCardTone;
+  actions?: ReactNode;
+  children: ReactNode;
+  footer?: ReactNode;
+  className?: string;
+}
+
+const toneClass: Record<SectionCardTone, string> = {
+  default: "border-border-default bg-surface",
+  info: "border-status-info/30 bg-status-info-soft/50",
+  success: "border-status-success/30 bg-status-success-soft/50",
+  warning: "border-status-warning/30 bg-status-warning-soft/50",
+  critical: "border-status-critical/30 bg-status-critical-soft/50",
+};
+
+export default function SectionCard({
+  title,
+  description,
+  tone = "default",
+  actions,
+  children,
+  footer,
+  className,
+}: SectionCardProps) {
+  return (
+    <section className={["rounded-lg border p-4 shadow-card", toneClass[tone], className].filter(Boolean).join(" ")}>
+      <div className="mb-3 flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h2 className="text-base font-semibold text-text-primary">{title}</h2>
+          {description ? <p className="text-sm text-text-secondary">{description}</p> : null}
+        </div>
+        {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
+      </div>
+
+      <div>{children}</div>
+
+      {footer ? <div className="mt-4 border-t border-border-subtle pt-3 text-sm text-text-secondary">{footer}</div> : null}
+    </section>
+  );
+}

--- a/frontend/components/layout/StickySidebar.tsx
+++ b/frontend/components/layout/StickySidebar.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+
+export interface StickySidebarProps {
+  children: ReactNode;
+  topOffsetClassName?: string;
+  className?: string;
+}
+
+export default function StickySidebar({
+  children,
+  topOffsetClassName = "top-20",
+  className,
+}: StickySidebarProps) {
+  return <aside className={["sticky space-y-3", topOffsetClassName, className].filter(Boolean).join(" ")}>{children}</aside>;
+}

--- a/frontend/components/layout/index.ts
+++ b/frontend/components/layout/index.ts
@@ -1,2 +1,6 @@
 export { default as MainLayout } from "./MainLayout";
 export { default as AdminLayout } from "./AdminLayout";
+export { default as PageHeader } from "./PageHeader";
+export { default as SectionCard } from "./SectionCard";
+export { default as StickySidebar } from "./StickySidebar";
+export { default as RightRailPanel } from "./RightRailPanel";


### PR DESCRIPTION
### Motivation
- Implement the UI primitives required by the build spec so pages can consume consistent, typed layout and data-display components.
- Lock visual and semantic consistency for tones/sizes/statuses as required by the frontend design contract in `frontend/app/README.md`.
- Provide a local demo surface to exercise every tone/size/status permutation for visual regression and review work.

### Description
- Added layout primitives with explicit prop contracts: `PageHeader`, `SectionCard`, `StickySidebar`, and `RightRailPanel` in `frontend/components/layout` (and exported via `layout/index.ts`).
- Added data-display primitives with typed props: `MetricCard`, `StatusChip`, `ReadinessBadge`, `SeverityBadge`, `AvatarChip`, `ProgressRing`, and `DataTableShell` in `frontend/components/data-display` (and exported via `data-display/index.ts`).
- Added a demo route at `frontend/app/demo/design-system/page.tsx` that renders all tone/size/status variants plus normal/empty `DataTableShell` states to lock visuals.
- Small implementation detail: `AvatarChip` uses `next/image` for avatars and all components expose clear TypeScript interfaces matching the requested prop contracts.

### Testing
- Ran lint with `cd frontend && npm run lint` and it completed successfully.
- Ran unit tests with `cd frontend && npm test` and all tests passed (`8` tests, `0` failures).
- Ran type checking with `cd frontend && npm run typecheck` (`tsc --noEmit`) and it completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1cf96ca48321829b6fed83a74f70)