### PR TITLE
Refactor main and admin layouts into dark-rail shell with contextual top bar

### DIFF
--- a/frontend/components/layout/AdminLayout.tsx
+++ b/frontend/components/layout/AdminLayout.tsx
@@ -7,12 +7,19 @@ import { logout } from "@/lib/api";
 import { useAuth } from "@/lib/useAuth";
 import { hasRoleCapability } from "@/lib/permissions";
 
-const NAV_ITEMS = [
-  { href: "/admin/driver-protocol", label: "Driver Protocol" },
-  { href: "/admin/driver-protocol/instructions", label: "Instructions" },
-  { href: "/admin/vehicles", label: "Vehicles" },
-  { href: "/admin/ops", label: "Ops Dashboard" },
-  { href: "/admin/ops/audit", label: "Audit Search" },
+interface NavItem {
+  href: string;
+  label: string;
+  group: "Operations" | "Deployment" | "Insights" | "Support" | "Admin";
+  hidden?: boolean;
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { href: "/admin/ops", label: "Ops Dashboard", group: "Operations" },
+  { href: "/admin/ops/audit", label: "Audit Search", group: "Insights" },
+  { href: "/admin/driver-protocol", label: "Driver Protocol", group: "Deployment" },
+  { href: "/admin/driver-protocol/instructions", label: "Instructions", group: "Support" },
+  { href: "/admin/vehicles", label: "Vehicles", group: "Deployment" },
 ];
 
 type AdminLayoutProps = {
@@ -20,61 +27,146 @@ type AdminLayoutProps = {
   children: ReactNode;
 };
 
+function toTitleCase(segment: string): string {
+  return segment
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
 export default function AdminLayout({ title, children }: AdminLayoutProps) {
   const { user, loading } = useAuth();
-  const pathname = usePathname();
+  const pathname = usePathname() ?? "/admin";
 
   if (loading) {
     return <div className="p-6 text-gray-500">Loading…</div>;
   }
 
   if (!user || !hasRoleCapability(user.role, "vehicle_qr:read")) {
-    return (
-      <div className="p-6 text-sm text-gray-500">
-        Admin access required.
-      </div>
-    );
+    return <div className="p-6 text-sm text-gray-500">Admin access required.</div>;
   }
 
+  const allItems: NavItem[] = [
+    ...NAV_ITEMS,
+    {
+      href: "/admin/plan-features",
+      label: "Plan & Features",
+      group: "Admin" as const,
+      hidden: !hasRoleCapability(user.role, "user_management:write"),
+    },
+  ].filter((item) => !item.hidden);
+
+  const groupedItems = allItems.reduce<Record<string, NavItem[]>>((acc, item) => {
+    acc[item.group] = [...(acc[item.group] ?? []), item];
+    return acc;
+  }, {});
+
+  const breadcrumbs = pathname
+    .split("/")
+    .filter(Boolean)
+    .map((segment, index, all) => {
+      const href = `/${all.slice(0, index + 1).join("/")}`;
+      return { href, label: toTitleCase(segment) };
+    });
+
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <header className="flex flex-wrap items-center justify-between gap-4 border-b bg-white px-6 py-4 dark:bg-gray-800">
-        <div>
-          <p className="text-xs uppercase tracking-wide text-gray-400">Admin</p>
-          <h1 className="text-lg font-semibold text-gray-900 dark:text-white">
-            {title}
-          </h1>
-        </div>
-        <button
-          onClick={logout}
-          className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400"
-        >
-          Sign out
-        </button>
-      </header>
+    <div className="min-h-screen bg-page text-text-primary">
+      <div className="flex min-h-screen">
+        <aside className="hidden w-72 shrink-0 flex-col border-r border-white/10 bg-[#0b1633] text-white lg:flex">
+          <div className="border-b border-white/10 px-5 py-5">
+            <Link href="/admin/ops" className="block">
+              <p className="text-xs uppercase tracking-[0.14em] text-slate-300/90">Tenant</p>
+              <p className="mt-1 text-sm font-semibold">ADC Operations Cloud</p>
+              <p className="mt-3 text-xs text-slate-300">{user.org_ids[0] ?? "Default Organization"}</p>
+            </Link>
+          </div>
 
-      <nav className="border-b bg-white px-6 py-3 dark:border-gray-700 dark:bg-gray-800">
-        <div className="flex flex-wrap gap-4 text-sm">
-          {NAV_ITEMS.map((item) => {
-            const isActive = pathname?.startsWith(item.href);
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                className={`rounded-full px-3 py-1 transition ${
-                  isActive
-                    ? "bg-blue-600 text-white"
-                    : "text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
-                }`}
-              >
-                {item.label}
-              </Link>
-            );
-          })}
-        </div>
-      </nav>
+          <nav className="flex-1 space-y-6 overflow-y-auto px-4 py-5">
+            {(["Operations", "Deployment", "Insights", "Support", "Admin"] as const).map((groupName) => {
+              const items = groupedItems[groupName] ?? [];
+              if (items.length === 0) return null;
 
-      <main className="mx-auto max-w-5xl p-6">{children}</main>
+              return (
+                <div key={groupName}>
+                  <p className="mb-2 px-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-400">
+                    {groupName}
+                  </p>
+                  <div className="space-y-1">
+                    {items.map((item) => {
+                      const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
+                      return (
+                        <Link
+                          key={item.href}
+                          href={item.href}
+                          className={`block rounded-md px-3 py-2 text-sm transition ${
+                            isActive
+                              ? "bg-accent/20 text-white ring-1 ring-accent/50"
+                              : "text-slate-200 hover:bg-white/10 hover:text-white"
+                          }`}
+                          aria-current={isActive ? "page" : undefined}
+                        >
+                          {item.label}
+                        </Link>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </nav>
+
+          <div className="border-t border-white/10 px-4 py-4">
+            <p className="text-xs text-slate-300">{user.email}</p>
+            <p className="mt-0.5 text-xs uppercase tracking-wide text-slate-400">Role: {user.role}</p>
+            <button onClick={logout} className="mt-3 text-sm font-medium text-accent-soft hover:text-white">
+              Sign out
+            </button>
+          </div>
+        </aside>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          <header className="border-b border-border-default bg-surface px-4 py-4 sm:px-6">
+            <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-3">
+              <div>
+                <div className="mb-1 flex flex-wrap items-center gap-1 text-xs text-text-muted">
+                  <Link href="/admin/ops" className="hover:text-text-primary">
+                    Admin
+                  </Link>
+                  {breadcrumbs.map((crumb, idx) => {
+                    const last = idx === breadcrumbs.length - 1;
+                    return (
+                      <span key={crumb.href} className="flex items-center gap-1">
+                        <span>/</span>
+                        {last ? (
+                          <span className="font-medium text-text-primary">{crumb.label}</span>
+                        ) : (
+                          <Link href={crumb.href} className="hover:text-text-primary">
+                            {crumb.label}
+                          </Link>
+                        )}
+                      </span>
+                    );
+                  })}
+                </div>
+                <h1 className="text-xl font-semibold text-text-primary">{title}</h1>
+              </div>
+
+              <div className="flex items-center gap-2 text-sm">
+                <Link
+                  href="/admin/ops/audit"
+                  className="rounded-md border border-border-default bg-surface px-3 py-1 text-text-secondary hover:bg-surface-muted"
+                >
+                  Audit Search
+                </Link>
+                <button onClick={logout} className="rounded-md px-3 py-1 text-text-secondary hover:bg-surface-muted">
+                  Sign out
+                </button>
+              </div>
+            </div>
+          </header>
+
+          <main className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-6">{children}</main>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/components/layout/MainLayout.tsx
+++ b/frontend/components/layout/MainLayout.tsx
@@ -21,7 +21,7 @@ interface NavItem {
 }
 
 interface NavGroup {
-  area: "Operations" | "Evidence" | "Exports" | "Administration";
+  area: "Operations" | "Deployment" | "Insights" | "Support" | "Admin";
   items: NavItem[];
 }
 
@@ -39,7 +39,10 @@ const SEGMENT_LABELS: Record<string, string> = {
   dashboard: "Dashboard",
   vehicles: "Vehicles",
   timeline: "Timeline",
+  onboarding: "Onboarding",
   "driver-protocol": "Driver Protocol",
+  "plan-features": "Plan & Features",
+  ops: "Ops",
 };
 
 function getDefaultLandingForRole(role: string): string {
@@ -67,6 +70,13 @@ function toTitleCase(segment: string): string {
   return segment
     .replace(/-/g, " ")
     .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function contentWidthClass(pathname: string): string {
+  if (pathname.startsWith("/admin")) return "max-w-5xl";
+  if (pathname.startsWith("/incidents/")) return "max-w-6xl";
+  if (pathname.startsWith("/dashboard") || pathname.startsWith("/incidents")) return "max-w-7xl";
+  return "max-w-6xl";
 }
 
 export default function MainLayout({ title, children }: MainLayoutProps) {
@@ -103,21 +113,32 @@ export default function MainLayout({ title, children }: MainLayoutProps) {
       area: "Operations",
       items: [
         { href: "/dashboard", label: "Dashboard" },
-        { href: "/onboarding", label: "Onboarding", hidden: !canViewOnboarding },
         { href: "/incidents", label: "Incidents", activePrefixes: ["/incidents"] },
         { href: "/timeline", label: "Timeline" },
+        { href: "/onboarding", label: "Onboarding", hidden: !canViewOnboarding },
       ],
     },
     {
-      area: "Evidence",
+      area: "Deployment",
       items: [{ href: "/vehicles", label: "Vehicles", hidden: !canManageQr }],
     },
     {
-      area: "Exports",
+      area: "Insights",
       items: [{ href: "/exports", label: "Exports", activePrefixes: ["/exports"] }],
     },
     {
-      area: "Administration",
+      area: "Support",
+      items: [
+        {
+          href: "/admin/ops",
+          label: "Ops Dashboard",
+          activePrefixes: ["/admin/ops"],
+          hidden: !hasRoleCapability(user.role, "vehicle_qr:read"),
+        },
+      ],
+    },
+    {
+      area: "Admin",
       items: [
         {
           href: "/admin/driver-protocol",
@@ -178,59 +199,39 @@ export default function MainLayout({ title, children }: MainLayoutProps) {
     })
     .filter((crumb) => crumb.href !== defaultLanding);
 
+  const visibleGroups = navGroups
+    .map((group) => ({ ...group, items: group.items.filter((item) => !item.hidden) }))
+    .filter((group) => group.items.length > 0);
+
   return (
     <div className="min-h-screen bg-page text-text-primary">
-      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border-default bg-shell px-6 py-4 text-text-inverse">
-        <div>
-          <Link href={defaultLanding} className="inline-block">
-            <h1 className="text-lg font-bold text-text-inverse hover:text-accent-soft">
-              {title ?? "ADC Dashboard"}
-            </h1>
-          </Link>
-        </div>
-
-        <div className="flex flex-wrap items-center gap-2 text-xs sm:text-sm">
-          {quickActions.map((action) => (
-            <Link
-              key={action.label}
-              href={action.href}
-              aria-label={action.ariaLabel}
-              className={action.className}
-            >
-              {action.label}
+      <div className="flex min-h-screen">
+        <aside className="hidden w-72 shrink-0 flex-col border-r border-white/10 bg-[#0b1633] text-text-inverse lg:flex">
+          <div className="border-b border-white/10 px-5 py-5">
+            <Link href={defaultLanding} className="block">
+              <p className="text-xs uppercase tracking-[0.14em] text-slate-300/90">Tenant</p>
+              <p className="mt-1 text-sm font-semibold text-white">ADC Operations Cloud</p>
+              <p className="mt-3 text-xs text-slate-300">{user.org_ids[0] ?? "Default Organization"}</p>
             </Link>
-          ))}
-          <button
-            onClick={logout}
-            className="ml-1 text-sm text-accent-soft hover:text-text-inverse"
-          >
-            Sign out
-          </button>
-        </div>
-      </header>
+          </div>
 
-      <nav className="space-y-3 border-b border-border-default bg-shell/95 px-6 py-3 text-text-inverse">
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-          {navGroups.map((group) => {
-            const visibleItems = group.items.filter((item) => !item.hidden);
-            if (visibleItems.length === 0) return null;
-
-            return (
+          <nav className="flex-1 space-y-6 overflow-y-auto px-4 py-5">
+            {visibleGroups.map((group) => (
               <div key={group.area}>
-                <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-accent-soft">
+                <p className="mb-2 px-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-400">
                   {group.area}
                 </p>
-                <div className="flex flex-wrap gap-2 text-sm">
-                  {visibleItems.map((item) => {
+                <div className="space-y-1">
+                  {group.items.map((item) => {
                     const isActive = routeIsActive(pathname, item.href, item.activePrefixes);
                     return (
                       <Link
                         key={item.href}
                         href={item.href}
-                        className={`rounded-full px-3 py-1 transition ${
+                        className={`block rounded-md px-3 py-2 text-sm transition ${
                           isActive
-                            ? "bg-accent text-text-inverse"
-                            : "text-accent-soft hover:bg-surface/10"
+                            ? "bg-accent/20 text-white ring-1 ring-accent/50"
+                            : "text-slate-200 hover:bg-white/10 hover:text-white"
                         }`}
                         aria-current={isActive ? "page" : undefined}
                       >
@@ -240,35 +241,65 @@ export default function MainLayout({ title, children }: MainLayoutProps) {
                   })}
                 </div>
               </div>
-            );
-          })}
-        </div>
+            ))}
+          </nav>
 
-        {breadcrumbs.length > 0 && (
-          <div className="flex flex-wrap items-center gap-1 text-xs text-accent-soft">
-            <Link href={defaultLanding} className="hover:text-text-inverse">
-              Home
-            </Link>
-            {breadcrumbs.map((crumb, idx) => {
-              const last = idx === breadcrumbs.length - 1;
-              return (
-                <span key={crumb.href} className="flex items-center gap-1">
-                  <span>/</span>
-                  {last ? (
-                    <span className="font-medium text-text-inverse">{crumb.label}</span>
-                  ) : (
-                    <Link href={crumb.href} className="hover:text-text-inverse">
-                      {crumb.label}
-                    </Link>
-                  )}
-                </span>
-              );
-            })}
+          <div className="border-t border-white/10 px-4 py-4">
+            <p className="text-xs text-slate-300">{user.email}</p>
+            <p className="mt-0.5 text-xs uppercase tracking-wide text-slate-400">Role: {user.role}</p>
+            <button onClick={logout} className="mt-3 text-sm font-medium text-accent-soft hover:text-white">
+              Sign out
+            </button>
           </div>
-        )}
-      </nav>
+        </aside>
 
-      <main className="mx-auto max-w-7xl p-6">{children}</main>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <header className="border-b border-border-default bg-surface px-4 py-4 sm:px-6">
+            <div className="mx-auto flex w-full max-w-7xl flex-wrap items-center justify-between gap-3">
+              <div className="min-w-0">
+                {breadcrumbs.length > 0 && (
+                  <div className="mb-1 flex flex-wrap items-center gap-1 text-xs text-text-muted">
+                    <Link href={defaultLanding} className="hover:text-text-primary">
+                      Home
+                    </Link>
+                    {breadcrumbs.map((crumb, idx) => {
+                      const last = idx === breadcrumbs.length - 1;
+                      return (
+                        <span key={crumb.href} className="flex items-center gap-1">
+                          <span>/</span>
+                          {last ? (
+                            <span className="font-medium text-text-primary">{crumb.label}</span>
+                          ) : (
+                            <Link href={crumb.href} className="hover:text-text-primary">
+                              {crumb.label}
+                            </Link>
+                          )}
+                        </span>
+                      );
+                    })}
+                  </div>
+                )}
+                <h1 className="truncate text-xl font-semibold text-text-primary">{title ?? "ADC Dashboard"}</h1>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2 text-xs sm:text-sm">
+                {quickActions.map((action) => (
+                  <Link
+                    key={action.label}
+                    href={action.href}
+                    aria-label={action.ariaLabel}
+                    className={action.className}
+                  >
+                    {action.label}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          </header>
+
+          <main className={`mx-auto w-full px-4 py-6 sm:px-6 ${contentWidthClass(pathname)}`}>{children}</main>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Align layouts with the UI design contract (dark shell + light content) and command-center app feel.  
- Replace the previous top-only nav with a persistent dark navy left rail to group related navigation areas for faster scanning.  
- Provide consistent page chrome (breadcrumbs, title, contextual actions) and standardized content width/padding across page types.  
- Preserve existing role/capability visibility and access gating to avoid changing authorization behavior.

### Description
- Updated `frontend/components/layout/MainLayout.tsx` to a two-column shell with a dark navy left navigation rail, grouped nav sections (Operations, Deployment, Insights, Support, Admin), tenant/org block, user footer, active-route highlighting, top breadcrumb/title bar, quick actions, and page-type `max-width` handling via `contentWidthClass`.  
- Updated `frontend/components/layout/AdminLayout.tsx` to the same left-rail + top-bar pattern, with grouped admin nav, breadcrumbs, tenant/org block, user footer, and Plan & Features shown conditionally based on role capability.  
- Preserved and reused existing permission checks (`hasRoleCapability`, onboarding/vehicle/export gating) and the `routeIsActive` logic for nested route highlighting.  
- Small data-source adjustment to read organization display from `user.org_ids[0]` where appropriate.

### Testing
- Ran linting with `npm run lint` in `frontend`, which completed successfully.  
- Ran unit/integration tests with `npm test` in `frontend`, which ran 8 tests and all passed.  
- Ran type checking with `npm run typecheck` (invokes `tsc --noEmit`) in `frontend`, which completed with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1ed982ac8321b9f2d28a64c43927)