### PR TITLE
Refactor dashboard command center with queue tabs, KPI cards, and right-rail triage stack

### DIFF
--- a/frontend/app/dashboard/DashboardClient.tsx
+++ b/frontend/app/dashboard/DashboardClient.tsx
@@ -47,6 +47,20 @@ const DEFAULT_FILTERS: IncidentFilters = {
   sort: "urgency",
 };
 
+const QUEUE_PAGE_SIZE = 50;
+const QUEUE_ALL_PAGE_SIZE = 500;
+
+function buildQueueParams(filters: IncidentFilters, includeStatus = true) {
+  return {
+    ...(includeStatus && filters.status ? { status: filters.status } : {}),
+    readiness_state: filters.readiness_state || undefined,
+    blockers: filters.blockers || undefined,
+    search: filters.search || undefined,
+    sort: filters.sort,
+    page: 1,
+  };
+}
+
 const TAB_TO_STATUS: Record<QueueTabKey, string> = {
   all: "",
   new: "new",
@@ -54,6 +68,9 @@ const TAB_TO_STATUS: Record<QueueTabKey, string> = {
   awaiting_evidence: "awaiting_evidence",
   ready_for_export: "ready_for_export",
   escalated: "escalated",
+  awaiting_follow_up: "awaiting_follow_up",
+  exported: "exported",
+  closed: "closed",
 };
 
 function getFirstPriority(queue: CaseOpsQueueItem[]) {
@@ -80,6 +97,7 @@ export default function DashboardClient() {
   });
 
   const [queue, setQueue] = useState<CaseOpsQueueItem[]>([]);
+  const [queueAll, setQueueAll] = useState<CaseOpsQueueItem[]>([]);
   const [metrics, setMetrics] = useState<CaseOpsSummaryMetrics | null>(null);
   const [alerts, setAlerts] = useState<CaseOpsAlerts | null>(null);
   const [overdueTasks, setOverdueTasks] = useState<CaseTaskWidgetItem[]>([]);
@@ -108,17 +126,13 @@ export default function DashboardClient() {
   useEffect(() => {
     if (!user) return;
 
-    getIncidentQueue({
-      status: filters.status || undefined,
-      readiness_state: filters.readiness_state || undefined,
-      blockers: filters.blockers || undefined,
-      search: filters.search || undefined,
-      sort: filters.sort,
-      page: 1,
-      page_size: 50,
-    })
-      .then((payload) => {
-        setQueue(payload.items);
+    Promise.all([
+      getIncidentQueue({ ...buildQueueParams(filters), page_size: QUEUE_PAGE_SIZE }),
+      getIncidentQueue({ ...buildQueueParams(filters, false), page_size: QUEUE_ALL_PAGE_SIZE }),
+    ])
+      .then(([filtered, unfiltered]) => {
+        setQueue(filtered.items);
+        setQueueAll(unfiltered.items);
         setQueueError("");
       })
       .catch((err) => setQueueError(toUserErrorMessage(err, "Failed to load queue")))
@@ -169,20 +183,23 @@ export default function DashboardClient() {
   }, [user]);
 
   const exportReady = useMemo(
-    () => queue.filter((item) => item.case_status === "ready_for_export"),
-    [queue]
+    () => queueAll.filter((item) => item.case_status === "ready_for_export"),
+    [queueAll]
   );
 
   const tabCounts = useMemo(() => {
     const counts: Record<QueueTabKey, number> = {
-      all: queue.length,
+      all: queueAll.length,
       new: 0,
       in_review: 0,
       awaiting_evidence: 0,
       ready_for_export: 0,
       escalated: 0,
+      awaiting_follow_up: 0,
+      exported: 0,
+      closed: 0,
     };
-    for (const item of queue) {
+    for (const item of queueAll) {
       if (item.case_status in counts) {
         counts[item.case_status as QueueTabKey] += 1;
       }
@@ -195,8 +212,11 @@ export default function DashboardClient() {
       { key: "awaiting_evidence" as const, label: "Awaiting Evidence", count: counts.awaiting_evidence },
       { key: "ready_for_export" as const, label: "Ready for Export", count: counts.ready_for_export },
       { key: "escalated" as const, label: "Escalated", count: counts.escalated },
+      { key: "awaiting_follow_up" as const, label: "Awaiting Follow-Up", count: counts.awaiting_follow_up },
+      { key: "exported" as const, label: "Exported", count: counts.exported },
+      { key: "closed" as const, label: "Closed", count: counts.closed },
     ];
-  }, [queue]);
+  }, [queueAll]);
 
   const firstPriority = useMemo(() => getFirstPriority(queue), [queue]);
   const integrationIssues = integrationValidationResults.filter(
@@ -222,17 +242,13 @@ export default function DashboardClient() {
 
   const refreshQueue = () => {
     setQueueLoading(true);
-    getIncidentQueue({
-      status: filters.status || undefined,
-      readiness_state: filters.readiness_state || undefined,
-      blockers: filters.blockers || undefined,
-      search: filters.search || undefined,
-      sort: filters.sort,
-      page: 1,
-      page_size: 50,
-    })
-      .then((payload) => {
-        setQueue(payload.items);
+    Promise.all([
+      getIncidentQueue({ ...buildQueueParams(filters), page_size: QUEUE_PAGE_SIZE }),
+      getIncidentQueue({ ...buildQueueParams(filters, false), page_size: QUEUE_ALL_PAGE_SIZE }),
+    ])
+      .then(([filtered, unfiltered]) => {
+        setQueue(filtered.items);
+        setQueueAll(unfiltered.items);
         setQueueError("");
       })
       .catch((err) => setQueueError(toUserErrorMessage(err, "Failed to reload queue")))

--- a/frontend/app/dashboard/DashboardClient.tsx
+++ b/frontend/app/dashboard/DashboardClient.tsx
@@ -8,9 +8,13 @@ import ExportReadyList from "@/components/case-ops/ExportReadyList";
 import IncidentFilterBar, {
   type IncidentFilters,
 } from "@/components/case-ops/IncidentFilterBar";
-import IncidentQueueTable from "@/components/case-ops/IncidentQueueTable";
+import IncidentQueueTable, {
+  type QueueTabKey,
+} from "@/components/case-ops/IncidentQueueTable";
 import IncidentSummaryCards from "@/components/case-ops/IncidentSummaryCards";
 import OverdueFollowUpList from "@/components/case-ops/OverdueFollowUpList";
+import SectionCard from "@/components/layout/SectionCard";
+import PageHeader from "@/components/layout/PageHeader";
 import OnboardingProgressDashboard from "@/components/onboarding/OnboardingProgressDashboard";
 import {
   getIntegrationValidationResults,
@@ -43,6 +47,23 @@ const DEFAULT_FILTERS: IncidentFilters = {
   sort: "urgency",
 };
 
+const TAB_TO_STATUS: Record<QueueTabKey, string> = {
+  all: "",
+  new: "new",
+  in_review: "in_review",
+  awaiting_evidence: "awaiting_evidence",
+  ready_for_export: "ready_for_export",
+  escalated: "escalated",
+};
+
+function getFirstPriority(queue: CaseOpsQueueItem[]) {
+  return (
+    queue.find((item) => item.case_status === "escalated" || item.blockers.critical > 0) ??
+    queue.find((item) => item.case_status === "new" || item.blockers.important > 0) ??
+    queue[0]
+  );
+}
+
 export default function DashboardClient() {
   const { user } = useAuth();
   const router = useRouter();
@@ -71,6 +92,11 @@ export default function DashboardClient() {
   const [onboarding, setOnboarding] = useState<OrgLaunchReadiness | null>(null);
   const [qrStats, setQrStats] = useState<VehicleQrStats | null>(null);
   const [integrationValidationResults, setIntegrationValidationResults] = useState<IntegrationValidationResult[]>([]);
+
+  const activeTab = (Object.keys(TAB_TO_STATUS).find(
+    (key) => TAB_TO_STATUS[key as QueueTabKey] === filters.status
+  ) as QueueTabKey | undefined) ?? "all";
+
   const resumeOnboardingHref = useMemo(() => {
     if (typeof window === "undefined") return "/onboarding";
     const persistedStep = window.localStorage.getItem(ONBOARDING_WIZARD_STORAGE_KEY);
@@ -147,6 +173,40 @@ export default function DashboardClient() {
     [queue]
   );
 
+  const tabCounts = useMemo(() => {
+    const counts: Record<QueueTabKey, number> = {
+      all: queue.length,
+      new: 0,
+      in_review: 0,
+      awaiting_evidence: 0,
+      ready_for_export: 0,
+      escalated: 0,
+    };
+    for (const item of queue) {
+      if (item.case_status in counts) {
+        counts[item.case_status as QueueTabKey] += 1;
+      }
+    }
+
+    return [
+      { key: "all" as const, label: "All", count: counts.all },
+      { key: "new" as const, label: "New", count: counts.new },
+      { key: "in_review" as const, label: "In Review", count: counts.in_review },
+      { key: "awaiting_evidence" as const, label: "Awaiting Evidence", count: counts.awaiting_evidence },
+      { key: "ready_for_export" as const, label: "Ready for Export", count: counts.ready_for_export },
+      { key: "escalated" as const, label: "Escalated", count: counts.escalated },
+    ];
+  }, [queue]);
+
+  const firstPriority = useMemo(() => getFirstPriority(queue), [queue]);
+  const integrationIssues = integrationValidationResults.filter(
+    (result) =>
+      result.credentialStatus !== "completed" ||
+      result.capabilityStatus !== "completed" ||
+      result.mappingStatus !== "completed"
+  );
+  const onboardingBlockers = onboarding?.blockers ?? [];
+
   const updateFilters = (next: IncidentFilters) => {
     setFilters(next);
     setQueueLoading(true);
@@ -209,22 +269,32 @@ export default function DashboardClient() {
   return (
     <MainLayout title="Command Center">
       <div className="space-y-4">
-        <header>
-          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">Incident Command Center</h2>
-          <p className="text-sm text-gray-600 dark:text-gray-400">
-            Work active incidents, manage ownership, and clear blockers fast.
-          </p>
-          <button
-            type="button"
-            onClick={() => router.push(resumeOnboardingHref)}
-            className="mt-3 rounded border border-blue-200 bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700 hover:bg-blue-100"
-          >
-            Resume onboarding wizard
-          </button>
-        </header>
+        <PageHeader
+          eyebrow="Case Operations"
+          title="Incident Command Center"
+          subtitle="Answer what's new, blocked, ready, and first priority in under 10 seconds."
+          actions={(
+            <button
+              type="button"
+              onClick={() => router.push(resumeOnboardingHref)}
+              className="rounded border border-status-info/40 bg-status-info-soft px-3 py-1.5 text-sm font-medium text-status-info hover:opacity-90"
+            >
+              Resume onboarding wizard
+            </button>
+          )}
+          meta={
+            firstPriority ? (
+              <span>
+                First priority: <strong>{firstPriority.incident_id.slice(0, 8)}…</strong> · {firstPriority.blockers.critical} critical blockers · owner {firstPriority.owner_user_id ? firstPriority.owner_user_id.slice(0, 8) : "unassigned"}
+              </span>
+            ) : (
+              "No active incidents in the current queue."
+            )
+          }
+        />
 
-        {overviewError ? <p className="text-sm text-red-600">{overviewError}</p> : null}
-        {actionError ? <p className="text-sm text-red-600">{actionError}</p> : null}
+        {overviewError ? <p className="text-sm text-status-critical">{overviewError}</p> : null}
+        {actionError ? <p className="text-sm text-status-critical">{actionError}</p> : null}
 
         <OnboardingProgressDashboard
           readiness={onboarding}
@@ -234,29 +304,79 @@ export default function DashboardClient() {
         />
 
         <IncidentSummaryCards metrics={metrics} loading={overviewLoading} />
-        <IncidentFilterBar
-          filters={filters}
-          onChange={updateFilters}
-          onReset={() => updateFilters(DEFAULT_FILTERS)}
-        />
 
-        <IncidentQueueTable
-          items={queue}
-          loading={queueLoading}
-          error={queueError}
-          onOpen={(incidentId) => router.push(`/incidents/${incidentId}`)}
-          onAssignMe={onAssignMe}
-          onCaseStatusChange={onCaseStatusChange}
-        />
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
+          <div className="space-y-4">
+            <IncidentFilterBar
+              filters={filters}
+              onChange={updateFilters}
+              onReset={() => updateFilters(DEFAULT_FILTERS)}
+            />
 
-        <div className="grid gap-4 lg:grid-cols-3">
-          <AlertsPanel alerts={alerts} loading={overviewLoading} error={overviewError} />
-          <ExportReadyList items={exportReady} loading={queueLoading} />
-          <OverdueFollowUpList
-            items={overdueTasks.length > 0 ? overdueTasks : myOpenTasks.filter((task) => task.status !== "completed")}
-            loading={overviewLoading}
-            error={overviewError}
-          />
+            <IncidentQueueTable
+              items={queue}
+              loading={queueLoading}
+              error={queueError}
+              tabs={tabCounts}
+              activeTab={activeTab}
+              onTabChange={(tab) => updateFilters({ ...filters, status: TAB_TO_STATUS[tab] })}
+              onOpen={(incidentId) => router.push(`/incidents/${incidentId}`)}
+              onAssignMe={onAssignMe}
+              onCaseStatusChange={onCaseStatusChange}
+            />
+          </div>
+
+          <aside className="space-y-4">
+            <AlertsPanel alerts={alerts} loading={overviewLoading} error={overviewError} />
+            <ExportReadyList items={exportReady} loading={queueLoading} />
+            <OverdueFollowUpList
+              items={overdueTasks.length > 0 ? overdueTasks : myOpenTasks.filter((task) => task.status !== "completed")}
+              loading={overviewLoading}
+              error={overviewError}
+            />
+
+            <SectionCard
+              title="Integration Issues"
+              tone="warning"
+              description="Integration failures that can block evidence capture."
+            >
+              {overviewLoading ? <p className="text-sm text-text-secondary">Loading integration validation…</p> : null}
+              {!overviewLoading && integrationIssues.length === 0 ? (
+                <p className="text-sm text-text-secondary">No active integration issues.</p>
+              ) : null}
+              {!overviewLoading && integrationIssues.length > 0 ? (
+                <ul className="space-y-2 text-sm">
+                  {integrationIssues.slice(0, 5).map((result) => (
+                    <li key={result.integration_id} className="rounded-md border border-border-subtle bg-surface-raised px-3 py-2">
+                      <p className="font-medium text-text-primary">{result.integration_id}</p>
+                      <p className="text-xs text-status-warning">{result.messages[0] ?? "Validation is incomplete."}</p>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </SectionCard>
+
+            <SectionCard
+              title="Onboarding Blockers"
+              tone="info"
+              description="Go-live dependencies not yet completed."
+            >
+              {overviewLoading ? <p className="text-sm text-text-secondary">Loading onboarding status…</p> : null}
+              {!overviewLoading && onboardingBlockers.length === 0 ? (
+                <p className="text-sm text-text-secondary">No onboarding blockers.</p>
+              ) : null}
+              {!overviewLoading && onboardingBlockers.length > 0 ? (
+                <ul className="space-y-2 text-sm">
+                  {onboardingBlockers.slice(0, 5).map((item) => (
+                    <li key={item.code} className="rounded-md border border-border-subtle bg-surface-raised px-3 py-2">
+                      <p className="font-medium text-text-primary">{item.title}</p>
+                      <p className="text-xs text-text-secondary">{item.detail}</p>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </SectionCard>
+          </aside>
         </div>
       </div>
     </MainLayout>

--- a/frontend/components/case-ops/AlertsPanel.tsx
+++ b/frontend/components/case-ops/AlertsPanel.tsx
@@ -1,1 +1,39 @@
-export { default } from "@/components/support/AlertsPanel";
+import SectionCard from "@/components/layout/SectionCard";
+import type { CaseOpsAlerts } from "@/lib/api";
+
+interface AlertsPanelProps {
+  alerts: CaseOpsAlerts | null;
+  loading: boolean;
+  error: string;
+}
+
+const ALERT_ROWS: Array<{ key: keyof CaseOpsAlerts; label: string }> = [
+  { key: "blocked", label: "Blocked incidents" },
+  { key: "overdue", label: "Overdue follow-ups" },
+  { key: "stalled", label: "Stalled incidents" },
+  { key: "unassigned", label: "Unassigned incidents" },
+  { key: "export_aging", label: "Export aging" },
+];
+
+export default function AlertsPanel({ alerts, loading, error }: AlertsPanelProps) {
+  return (
+    <SectionCard
+      title="Critical Alerts"
+      tone="critical"
+      description="See what is blocked or at immediate risk first."
+    >
+      {loading ? <p className="text-sm text-text-secondary">Loading alerts…</p> : null}
+      {error ? <p className="text-sm text-status-critical">{error}</p> : null}
+      {!loading && !error && alerts ? (
+        <ul className="space-y-2 text-sm">
+          {ALERT_ROWS.map((row) => (
+            <li key={row.key} className="flex items-center justify-between gap-3 rounded-md border border-border-subtle bg-surface-raised px-3 py-2">
+              <span className="text-text-secondary">{row.label}</span>
+              <span className="text-sm font-semibold text-text-primary">{alerts[row.key]}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </SectionCard>
+  );
+}

--- a/frontend/components/case-ops/ExportReadyList.tsx
+++ b/frontend/components/case-ops/ExportReadyList.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import SectionCard from "@/components/layout/SectionCard";
 import type { CaseOpsQueueItem } from "@/lib/api";
 
 interface ExportReadyListProps {
@@ -8,21 +9,29 @@ interface ExportReadyListProps {
 
 export default function ExportReadyList({ items, loading }: ExportReadyListProps) {
   return (
-    <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
-      <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Export-ready list</h3>
-      {loading && <p className="mt-2 text-sm text-gray-500">Loading export-ready incidents…</p>}
-      {!loading && items.length === 0 && <p className="mt-2 text-sm text-gray-500">No incidents are ready for export.</p>}
+    <SectionCard
+      title="Ready for Export"
+      tone="success"
+      description="Cases cleared for export once QA is complete."
+    >
+      {loading && <p className="text-sm text-text-secondary">Loading export-ready incidents…</p>}
+      {!loading && items.length === 0 && (
+        <p className="text-sm text-text-secondary">No incidents are ready for export.</p>
+      )}
       {!loading && items.length > 0 && (
-        <ul className="mt-2 space-y-2 text-sm">
-          {items.slice(0, 8).map((item) => (
-            <li key={item.incident_id}>
-              <Link href={`/incidents/${item.incident_id}`} className="text-blue-600 hover:underline dark:text-blue-400">
+        <ul className="space-y-2 text-sm">
+          {items.slice(0, 6).map((item) => (
+            <li key={item.incident_id} className="rounded-md border border-border-subtle bg-surface-raised px-3 py-2">
+              <Link href={`/incidents/${item.incident_id}`} className="font-medium text-status-success hover:underline">
                 {item.incident_id.slice(0, 8)}…
               </Link>
+              <p className="text-xs text-text-secondary">
+                Completeness {Math.round(item.completeness_percent)}% · Owner {item.owner_user_id ? item.owner_user_id.slice(0, 8) : "unassigned"}
+              </p>
             </li>
           ))}
         </ul>
       )}
-    </section>
+    </SectionCard>
   );
 }

--- a/frontend/components/case-ops/IncidentFilterBar.tsx
+++ b/frontend/components/case-ops/IncidentFilterBar.tsx
@@ -49,7 +49,9 @@ export default function IncidentFilterBar({
           <option value="awaiting_evidence">Awaiting evidence</option>
           <option value="in_review">In review</option>
           <option value="ready_for_export">Ready for export</option>
+          <option value="awaiting_follow_up">Awaiting follow-up</option>
           <option value="escalated">Escalated</option>
+          <option value="exported">Exported</option>
           <option value="closed">Closed</option>
         </select>
         <select

--- a/frontend/components/case-ops/IncidentFilterBar.tsx
+++ b/frontend/components/case-ops/IncidentFilterBar.tsx
@@ -20,18 +20,29 @@ export default function IncidentFilterBar({
   onReset,
 }: IncidentFilterBarProps) {
   return (
-    <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
-      <div className="grid gap-3 md:grid-cols-5">
+    <section className="rounded-lg border border-border-default bg-surface p-4 shadow-card">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-text-primary">Filter toolbar</h3>
+        <button
+          type="button"
+          onClick={onReset}
+          className="rounded border border-border-default px-3 py-1.5 text-sm font-medium text-text-secondary hover:bg-surface-raised"
+        >
+          Reset filters
+        </button>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
         <input
           value={filters.search}
           onChange={(e) => onChange({ ...filters, search: e.target.value })}
           placeholder="Search incident, vehicle, driver"
-          className="rounded border px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-900"
+          className="rounded border border-border-default bg-surface px-3 py-2 text-sm"
         />
         <select
           value={filters.status}
           onChange={(e) => onChange({ ...filters, status: e.target.value })}
-          className="rounded border px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-900"
+          className="rounded border border-border-default bg-surface px-3 py-2 text-sm"
         >
           <option value="">All statuses</option>
           <option value="new">New</option>
@@ -44,7 +55,7 @@ export default function IncidentFilterBar({
         <select
           value={filters.readiness_state}
           onChange={(e) => onChange({ ...filters, readiness_state: e.target.value })}
-          className="rounded border px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-900"
+          className="rounded border border-border-default bg-surface px-3 py-2 text-sm"
         >
           <option value="">Any readiness</option>
           <option value="ready">Ready</option>
@@ -54,30 +65,22 @@ export default function IncidentFilterBar({
         <select
           value={filters.blockers}
           onChange={(e) => onChange({ ...filters, blockers: e.target.value })}
-          className="rounded border px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-900"
+          className="rounded border border-border-default bg-surface px-3 py-2 text-sm"
         >
           <option value="">Any blockers</option>
           <option value="critical">Critical</option>
           <option value="important">Important</option>
           <option value="none">No blockers</option>
         </select>
-        <div className="flex gap-2">
-          <select
-            value={filters.sort}
-            onChange={(e) => onChange({ ...filters, sort: e.target.value as CaseOpsQueueSort })}
-            className="w-full rounded border px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-900"
-          >
-            <option value="urgency">Sort: Urgency</option>
-            <option value="newest">Sort: Newest</option>
-            <option value="readiness">Sort: Readiness</option>
-          </select>
-          <button
-            onClick={onReset}
-            className="rounded border px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
-          >
-            Reset
-          </button>
-        </div>
+        <select
+          value={filters.sort}
+          onChange={(e) => onChange({ ...filters, sort: e.target.value as CaseOpsQueueSort })}
+          className="rounded border border-border-default bg-surface px-3 py-2 text-sm"
+        >
+          <option value="urgency">Sort: Urgency</option>
+          <option value="newest">Sort: Newest</option>
+          <option value="readiness">Sort: Readiness</option>
+        </select>
       </div>
     </section>
   );

--- a/frontend/components/case-ops/IncidentQueueTable.tsx
+++ b/frontend/components/case-ops/IncidentQueueTable.tsx
@@ -43,7 +43,7 @@ function getUrgencyTone(item: CaseOpsQueueItem) {
     };
   }
 
-  if (item.case_status === "new" || item.blockers.important > 0 || item.readiness_state === "blocked") {
+  if (item.case_status === "new" || item.blockers.important > 0 || item.readiness_state === "not_ready") {
     return {
       row: "border-l-4 border-status-warning bg-status-warning-soft/40",
       badge: "bg-status-warning-soft text-status-warning",

--- a/frontend/components/case-ops/IncidentQueueTable.tsx
+++ b/frontend/components/case-ops/IncidentQueueTable.tsx
@@ -1,10 +1,21 @@
 import Link from "next/link";
 import type { CaseOpsQueueItem } from "@/lib/api";
 
+type QueueTabKey = "all" | "new" | "in_review" | "awaiting_evidence" | "ready_for_export" | "escalated";
+
+interface QueueTab {
+  key: QueueTabKey;
+  label: string;
+  count: number;
+}
+
 interface IncidentQueueTableProps {
   items: CaseOpsQueueItem[];
   loading: boolean;
   error: string;
+  tabs: QueueTab[];
+  activeTab: QueueTabKey;
+  onTabChange: (tab: QueueTabKey) => void;
   onOpen: (incidentId: string) => void;
   onAssignMe: (incidentId: string) => void;
   onCaseStatusChange: (incidentId: string, caseStatus: string) => void;
@@ -19,71 +30,136 @@ const STATUSES = [
   "closed",
 ];
 
+function statusLabel(value: string) {
+  return value.replaceAll("_", " ");
+}
+
+function getUrgencyTone(item: CaseOpsQueueItem) {
+  if (item.blockers.critical > 0 || item.case_status === "escalated") {
+    return {
+      row: "border-l-4 border-status-critical bg-status-critical-soft/40",
+      badge: "bg-status-critical-soft text-status-critical",
+      label: "First priority",
+    };
+  }
+
+  if (item.case_status === "new" || item.blockers.important > 0 || item.readiness_state === "blocked") {
+    return {
+      row: "border-l-4 border-status-warning bg-status-warning-soft/40",
+      badge: "bg-status-warning-soft text-status-warning",
+      label: "Needs attention",
+    };
+  }
+
+  return {
+    row: "border-l-4 border-transparent",
+    badge: "bg-status-success-soft text-status-success",
+    label: "On track",
+  };
+}
+
 export default function IncidentQueueTable({
   items,
   loading,
   error,
+  tabs,
+  activeTab,
+  onTabChange,
   onOpen,
   onAssignMe,
   onCaseStatusChange,
 }: IncidentQueueTableProps) {
-  if (loading) {
-    return <div className="rounded-lg border bg-white p-4 text-sm text-gray-500 shadow-sm dark:border-gray-700 dark:bg-gray-800">Loading incident queue…</div>;
-  }
-
-  if (error) {
-    return <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">{error}</div>;
-  }
-
-  if (items.length === 0) {
-    return <div className="rounded-lg border bg-white p-4 text-sm text-gray-500 shadow-sm dark:border-gray-700 dark:bg-gray-800">No incidents match current filters.</div>;
-  }
-
   return (
-    <div className="overflow-hidden rounded-lg border bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
-      <table className="w-full text-left text-sm">
-        <thead className="bg-gray-50 dark:bg-gray-700">
-          <tr>
-            <th className="px-3 py-2">Incident</th>
-            <th className="px-3 py-2">Status</th>
-            <th className="px-3 py-2">Readiness</th>
-            <th className="px-3 py-2">Owner</th>
-            <th className="px-3 py-2">Blockers</th>
-            <th className="px-3 py-2">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((item) => (
-            <tr key={item.incident_id} className="border-t dark:border-gray-700">
-              <td className="px-3 py-3 font-mono text-xs">
-                <Link href={`/incidents/${item.incident_id}`} className="text-blue-600 hover:underline dark:text-blue-400">
-                  {item.incident_id.slice(0, 8)}…
-                </Link>
-                <div className="text-gray-500">{item.adc_vehicle_id ?? "—"} / {item.adc_driver_id ?? "—"}</div>
-              </td>
-              <td className="px-3 py-3">{item.case_status}</td>
-              <td className="px-3 py-3">{item.readiness_state}</td>
-              <td className="px-3 py-3 font-mono text-xs">{item.owner_user_id ? item.owner_user_id.slice(0, 8) : "Unassigned"}</td>
-              <td className="px-3 py-3">{item.blockers.critical} critical · {item.blockers.important} important</td>
-              <td className="px-3 py-3">
-                <div className="flex flex-wrap gap-2">
-                  <button onClick={() => onOpen(item.incident_id)} className="rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-700">Open</button>
-                  <button onClick={() => onAssignMe(item.incident_id)} className="rounded border px-2 py-1 text-xs hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-700">Assign me</button>
-                  <select
-                    value={item.case_status}
-                    onChange={(e) => onCaseStatusChange(item.incident_id, e.target.value)}
-                    className="rounded border px-2 py-1 text-xs dark:border-gray-600 dark:bg-gray-900"
-                  >
-                    {STATUSES.map((status) => (
-                      <option key={status} value={status}>{status}</option>
-                    ))}
-                  </select>
-                </div>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <section className="rounded-lg border border-border-default bg-surface shadow-card">
+      <div className="border-b border-border-subtle px-4 py-3">
+        <div className="flex flex-wrap items-center gap-2">
+          {tabs.map((tab) => {
+            const active = tab.key === activeTab;
+            return (
+              <button
+                key={tab.key}
+                type="button"
+                onClick={() => onTabChange(tab.key)}
+                className={[
+                  "rounded-md px-3 py-1.5 text-sm font-medium transition",
+                  active
+                    ? "bg-status-info-soft text-status-info"
+                    : "border border-border-subtle text-text-secondary hover:bg-surface-raised",
+                ].join(" ")}
+              >
+                {tab.label} <span className="ml-1 text-xs">({tab.count})</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {loading ? <div className="p-4 text-sm text-text-secondary">Loading incident queue…</div> : null}
+      {error ? <div className="m-4 rounded-md border border-status-critical/40 bg-status-critical-soft px-3 py-2 text-sm text-status-critical">{error}</div> : null}
+      {!loading && !error && items.length === 0 ? (
+        <div className="p-4 text-sm text-text-secondary">No incidents match current filters.</div>
+      ) : null}
+
+      {!loading && !error && items.length > 0 ? (
+        <div className="max-h-[620px] overflow-auto">
+          <table className="w-full min-w-[980px] text-left text-sm">
+            <thead className="sticky top-0 z-10 bg-surface-raised">
+              <tr>
+                <th className="px-3 py-2">Priority</th>
+                <th className="px-3 py-2">Incident</th>
+                <th className="px-3 py-2">Status</th>
+                <th className="px-3 py-2">Readiness</th>
+                <th className="px-3 py-2">Owner</th>
+                <th className="px-3 py-2">Blockers</th>
+                <th className="px-3 py-2">Completeness</th>
+                <th className="px-3 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item) => {
+                const urgency = getUrgencyTone(item);
+                return (
+                  <tr key={item.incident_id} className={`border-t border-border-subtle ${urgency.row}`}>
+                    <td className="px-3 py-3">
+                      <span className={`inline-flex rounded-full px-2 py-1 text-xs font-medium ${urgency.badge}`}>
+                        {urgency.label}
+                      </span>
+                    </td>
+                    <td className="px-3 py-3 font-mono text-xs">
+                      <Link href={`/incidents/${item.incident_id}`} className="font-semibold text-status-info hover:underline">
+                        {item.incident_id.slice(0, 8)}…
+                      </Link>
+                      <div className="text-text-secondary">{item.adc_vehicle_id ?? "—"} / {item.adc_driver_id ?? "—"}</div>
+                    </td>
+                    <td className="px-3 py-3 capitalize text-text-primary">{statusLabel(item.case_status)}</td>
+                    <td className="px-3 py-3 capitalize text-text-primary">{statusLabel(item.readiness_state)}</td>
+                    <td className="px-3 py-3 font-mono text-xs text-text-primary">{item.owner_user_id ? item.owner_user_id.slice(0, 8) : "Unassigned"}</td>
+                    <td className="px-3 py-3 text-text-primary">{item.blockers.critical} critical · {item.blockers.important} important</td>
+                    <td className="px-3 py-3 text-text-primary">{Math.round(item.completeness_percent)}%</td>
+                    <td className="px-3 py-3">
+                      <div className="flex flex-wrap gap-2">
+                        <button type="button" onClick={() => onOpen(item.incident_id)} className="rounded bg-status-info px-2 py-1 text-xs font-medium text-white hover:opacity-90">Open</button>
+                        <button type="button" onClick={() => onAssignMe(item.incident_id)} className="rounded border border-border-default px-2 py-1 text-xs text-text-secondary hover:bg-surface-raised">Assign me</button>
+                        <select
+                          value={item.case_status}
+                          onChange={(e) => onCaseStatusChange(item.incident_id, e.target.value)}
+                          className="rounded border border-border-default bg-surface px-2 py-1 text-xs"
+                        >
+                          {STATUSES.map((status) => (
+                            <option key={status} value={status}>{statusLabel(status)}</option>
+                          ))}
+                        </select>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </section>
   );
 }
+
+export type { QueueTabKey };

--- a/frontend/components/case-ops/IncidentQueueTable.tsx
+++ b/frontend/components/case-ops/IncidentQueueTable.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { CaseOpsQueueItem } from "@/lib/api";
 
-type QueueTabKey = "all" | "new" | "in_review" | "awaiting_evidence" | "ready_for_export" | "escalated";
+type QueueTabKey = "all" | "new" | "in_review" | "awaiting_evidence" | "ready_for_export" | "escalated" | "awaiting_follow_up" | "exported" | "closed";
 
 interface QueueTab {
   key: QueueTabKey;
@@ -26,7 +26,9 @@ const STATUSES = [
   "awaiting_evidence",
   "in_review",
   "ready_for_export",
+  "awaiting_follow_up",
   "escalated",
+  "exported",
   "closed",
 ];
 

--- a/frontend/components/case-ops/IncidentQueueTable.tsx
+++ b/frontend/components/case-ops/IncidentQueueTable.tsx
@@ -95,7 +95,7 @@ export default function IncidentQueueTable({
       </div>
 
       {loading ? <div className="p-4 text-sm text-text-secondary">Loading incident queue…</div> : null}
-      {error ? <div className="m-4 rounded-md border border-status-critical/40 bg-status-critical-soft px-3 py-2 text-sm text-status-critical">{error}</div> : null}
+      {!loading && error ? <div className="m-4 rounded-md border border-status-critical/40 bg-status-critical-soft px-3 py-2 text-sm text-status-critical">{error}</div> : null}
       {!loading && !error && items.length === 0 ? (
         <div className="p-4 text-sm text-text-secondary">No incidents match current filters.</div>
       ) : null}

--- a/frontend/components/case-ops/IncidentSummaryCards.tsx
+++ b/frontend/components/case-ops/IncidentSummaryCards.tsx
@@ -1,1 +1,57 @@
-export { default } from "@/components/reports/IncidentSummaryCards";
+import MetricCard from "@/components/data-display/MetricCard";
+import type { CaseOpsSummaryMetrics } from "@/lib/api";
+
+interface IncidentSummaryCardsProps {
+  metrics: CaseOpsSummaryMetrics | null;
+  loading: boolean;
+}
+
+function valueOrLoading(value: number | undefined, loading: boolean) {
+  return loading ? "…" : value ?? 0;
+}
+
+export default function IncidentSummaryCards({
+  metrics,
+  loading,
+}: IncidentSummaryCardsProps) {
+  return (
+    <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+      <MetricCard
+        label="What's New"
+        value={valueOrLoading(metrics?.open_incidents, loading)}
+        tone="info"
+        helperText="Open incidents that need active attention now."
+      />
+      <MetricCard
+        label="Blocked"
+        value={valueOrLoading(metrics?.blocked_incidents, loading)}
+        tone="critical"
+        helperText="Cases currently blocked by missing evidence or dependencies."
+      />
+      <MetricCard
+        label="Ready for Export"
+        value={valueOrLoading(metrics?.export_aging_incidents, loading)}
+        tone="success"
+        helperText="Incidents ready or aging in export-ready state."
+      />
+      <MetricCard
+        label="Unassigned"
+        value={valueOrLoading(metrics?.unassigned_incidents, loading)}
+        tone="warning"
+        helperText="Incidents without clear ownership."
+      />
+      <MetricCard
+        label="Stalled"
+        value={valueOrLoading(metrics?.stalled_incidents, loading)}
+        tone="warning"
+        helperText="No recent movement and at risk of delay."
+      />
+      <MetricCard
+        label="Overdue Follow-Ups"
+        value={valueOrLoading(metrics?.overdue_tasks, loading)}
+        tone="critical"
+        helperText="Follow-up tasks past due and blocking readiness."
+      />
+    </section>
+  );
+}

--- a/frontend/components/case-ops/OverdueFollowUpList.tsx
+++ b/frontend/components/case-ops/OverdueFollowUpList.tsx
@@ -1,1 +1,49 @@
-export { default } from "@/components/reports/OverdueFollowUpList";
+import Link from "next/link";
+import SectionCard from "@/components/layout/SectionCard";
+import type { CaseTaskWidgetItem } from "@/lib/api";
+
+interface OverdueFollowUpListProps {
+  items: CaseTaskWidgetItem[];
+  loading: boolean;
+  error: string;
+}
+
+function formatDueDate(value?: string | null) {
+  if (!value) return "No due date";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "No due date" : date.toLocaleString();
+}
+
+export default function OverdueFollowUpList({
+  items,
+  loading,
+  error,
+}: OverdueFollowUpListProps) {
+  return (
+    <SectionCard
+      title="Overdue Follow-Ups"
+      tone="warning"
+      description="Tasks that are directly delaying case readiness."
+    >
+      {loading && <p className="text-sm text-text-secondary">Loading overdue follow-ups…</p>}
+      {error && <p className="text-sm text-status-critical">{error}</p>}
+      {!loading && !error && items.length === 0 && (
+        <p className="text-sm text-text-secondary">No overdue follow-up tasks.</p>
+      )}
+      {!loading && !error && items.length > 0 && (
+        <ul className="space-y-2 text-sm">
+          {items.slice(0, 6).map((task) => (
+            <li key={task.task_id} className="rounded-md border border-border-subtle bg-surface-raised px-3 py-2">
+              <Link href={`/incidents/${task.incident_id}`} className="font-medium text-status-warning hover:underline">
+                {task.title}
+              </Link>
+              <p className="text-xs text-text-secondary">
+                {task.priority} priority · due {formatDueDate(task.due_at_utc)}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </SectionCard>
+  );
+}


### PR DESCRIPTION
### Motivation
- Make the dashboard behave like an operational command center so operators can answer “what’s new / blocked / ready / first priority” in under 10 seconds by surfacing urgency, ownership, readiness, and blockers. 

### Description
- Reworked the dashboard layout to use a `PageHeader` (first-priority meta + resume onboarding action), moved KPI summary to `MetricCard`-based cards, and split main content into queue + right-rail sections.  
- Implemented queue tabs, a filter toolbar, a sticky table header, and urgency-emphasized rows/badges in the main queue; preserved actions (`Open`, `Assign me`, and status change).  
- Converted right-rail widgets to `SectionCard` stack and added panels for Critical Alerts, Ready for Export, Overdue Follow-Ups, Integration Issues, and Onboarding Blockers.  
- Updated and added the case-ops components: `frontend/app/dashboard/DashboardClient.tsx`, `frontend/components/case-ops/IncidentSummaryCards.tsx`, `frontend/components/case-ops/IncidentQueueTable.tsx`, `frontend/components/case-ops/IncidentFilterBar.tsx`, `frontend/components/case-ops/AlertsPanel.tsx`, `frontend/components/case-ops/ExportReadyList.tsx`, and `frontend/components/case-ops/OverdueFollowUpList.tsx` to implement the above changes. 

### Testing
- Ran lint in the frontend with `npm run lint` and it completed successfully.  
- Executed frontend unit tests with `npm run test` which ran 8 tests and all passed.  
- Ran TypeScript type checking with `npm run typecheck` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed20d776808321b010b6fb4f43d606)