### PR TITLE
Refactor incident detail into primary workspace + sticky case-ops sidebar

### DIFF
--- a/frontend/app/incidents/[id]/IncidentDetailClient.tsx
+++ b/frontend/app/incidents/[id]/IncidentDetailClient.tsx
@@ -132,7 +132,7 @@ export default function IncidentDetailClient() {
   const acknowledged = Boolean(driverResponse.acknowledged_at_utc);
   const uploadsComplete = Boolean(driverResponse.uploads_complete);
   const waitingOnDriver = Boolean(driverResponse.awaiting_driver_action ?? (notificationSent && (!acknowledged || !uploadsComplete)));
-  const workspaceCaseStatus = workspace?.case_status ?? incident?.status ?? "new";
+  const workspaceCaseStatus = workspace?.case_status ?? "new";
   const workspaceReadiness = workspace?.readiness_state ?? incident?.readiness_state ?? "not_ready";
   const workspaceOwnerUserId = workspace?.owner?.user_id ?? null;
   const workspaceMissingItems = workspace?.missing_items ?? incident?.completeness_missing_items ?? [];

--- a/frontend/app/incidents/[id]/IncidentDetailClient.tsx
+++ b/frontend/app/incidents/[id]/IncidentDetailClient.tsx
@@ -2,30 +2,30 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
-import Link from "next/link";
 import {
   completeTask,
   createIncidentNote,
   createIncidentTask,
+  getDriverProtocolSettings,
   getIncident,
   getIncidentWorkspace,
-  getDriverProtocolSettings,
   listIncidentNotes,
   listIncidentTasks,
-  type IncidentDetail,
-  type IncidentNoteItem,
-  type IncidentTaskItem,
-  type CaseWorkspaceResponse,
-  type DriverProtocolSummary,
-  type DriverResponseSummary,
   patchIncidentOwner,
   patchIncidentStatus,
   toUserErrorMessage,
+  type CaseWorkspaceResponse,
+  type DriverProtocolSummary,
+  type DriverResponseSummary,
+  type IncidentDetail,
+  type IncidentNoteItem,
+  type IncidentTaskItem,
 } from "@/lib/api";
 import { useAuth } from "@/lib/useAuth";
 import EvidenceTable, { EVIDENCE_TYPES } from "@/components/EvidenceTable";
 import Timeline from "@/components/Timeline";
 import IncidentDetailExportPanel from "@/components/IncidentDetailExportPanel";
+import CaseHeroHeader from "@/components/case-ops/CaseHeroHeader";
 import CaseOwnerControl from "@/components/case-ops/CaseOwnerControl";
 import CaseStatusControl from "@/components/case-ops/CaseStatusControl";
 import CaseReadinessCard, { ExportReadinessBanner } from "@/components/case-ops/CaseReadinessCard";
@@ -34,6 +34,7 @@ import MissingItemsPanel from "@/components/case-ops/MissingItemsPanel";
 import CaseNotesPanel from "@/components/case-ops/CaseNotesPanel";
 import CaseTasksPanel from "@/components/case-ops/CaseTasksPanel";
 import TimelineFeed from "@/components/case-ops/TimelineFeed";
+import StickySidebar from "@/components/layout/StickySidebar";
 
 function formatTime(iso?: string | null): string {
   if (!iso) return "—";
@@ -55,68 +56,24 @@ export default function IncidentDetailClient() {
   const [incident, setIncident] = useState<IncidentDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [driverProtocolSettings, setDriverProtocolSettings] =
-    useState<DriverProtocolSummary | null>(null);
+  const [driverProtocolSettings, setDriverProtocolSettings] = useState<DriverProtocolSummary | null>(null);
   const [workspace, setWorkspace] = useState<CaseWorkspaceResponse | null>(null);
   const [notes, setNotes] = useState<IncidentNoteItem[]>([]);
   const [tasks, setTasks] = useState<IncidentTaskItem[]>([]);
 
   const artifactStatuses = useMemo(() => {
     if (!incident) return [];
-    const artifactMap = new Map(
-      incident.evidence_inventory.map((artifact) => [
-        artifact.artifact_type,
-        artifact,
-      ])
-    );
-    return EVIDENCE_TYPES.map(
-      ({ type }) => artifactMap.get(type)?.status ?? "pending"
-    );
+    const artifactMap = new Map(incident.evidence_inventory.map((artifact) => [artifact.artifact_type, artifact]));
+    return EVIDENCE_TYPES.map(({ type }) => artifactMap.get(type)?.status ?? "pending");
   }, [incident]);
 
-  const captured = artifactStatuses.filter((status) => status === "captured")
-    .length;
-  const unavailable = artifactStatuses.filter(
-    (status) => status === "unavailable"
-  ).length;
-  const pending = artifactStatuses.filter((status) => status === "pending")
-    .length;
+  const captured = artifactStatuses.filter((status) => status === "captured").length;
+  const unavailable = artifactStatuses.filter((status) => status === "unavailable").length;
+  const pending = artifactStatuses.filter((status) => status === "pending").length;
   const total = artifactStatuses.length || EVIDENCE_TYPES.length;
   const isCapturing = pending > 0;
   const refreshIntervalSeconds = REFRESH_INTERVAL_MS / 1000;
-  const timelineTypes = useMemo(
-    () => new Set((incident?.timeline ?? []).map((event) => event.event_type)),
-    [incident]
-  );
-  const lifecycleCoverage = useMemo(() => {
-    const hasCollected = [...timelineTypes].some(
-      (type) =>
-        type.includes("capture") ||
-        type.includes("collected") ||
-        type.includes("incident_started")
-    );
-    const hasValidated = [...timelineTypes].some(
-      (type) => type.includes("hash") || type.includes("validat")
-    );
-    const hasExported = [...timelineTypes].some((type) => type.includes("export"));
-    const hasDownloaded = [...timelineTypes].some((type) =>
-      type.includes("download")
-    );
-    return { hasCollected, hasValidated, hasExported, hasDownloaded };
-  }, [timelineTypes]);
-  const completenessPercent =
-    incident?.completeness_percent ?? Math.round((captured / total) * 100);
-  const continuityChecks = [
-    lifecycleCoverage.hasCollected,
-    lifecycleCoverage.hasValidated,
-    lifecycleCoverage.hasExported,
-  ].filter(Boolean).length;
-  const custodyContinuityLabel =
-    continuityChecks === 3
-      ? "Strong"
-      : continuityChecks === 2
-        ? "Partial"
-        : "Limited";
+  const completenessPercent = incident?.completeness_percent ?? Math.round((captured / total) * 100);
 
   const refreshIncident = useCallback(() => {
     return getIncident(id)
@@ -166,21 +123,15 @@ export default function IncidentDetailClient() {
   const captureSummary = isCapturing
     ? `Capture in progress (auto-refreshing every ${refreshIntervalSeconds} seconds).`
     : unavailable > 0
-      ? `Capture finished with ${unavailable} unavailable artifact${
-          unavailable === 1 ? "" : "s"
-        }.`
+      ? `Capture finished with ${unavailable} unavailable artifact${unavailable === 1 ? "" : "s"}.`
       : "Capture complete.";
 
   const driverResponse: DriverResponseSummary = incident?.driver_response ?? {};
-  const protocolSummary =
-    incident?.driver_protocol_summary ?? driverProtocolSettings;
+  const protocolSummary = incident?.driver_protocol_summary ?? driverProtocolSettings;
   const notificationSent = Boolean(driverResponse.notification_sent_at_utc);
   const acknowledged = Boolean(driverResponse.acknowledged_at_utc);
   const uploadsComplete = Boolean(driverResponse.uploads_complete);
-  const waitingOnDriver = Boolean(
-    driverResponse.awaiting_driver_action ??
-      (notificationSent && (!acknowledged || !uploadsComplete))
-  );
+  const waitingOnDriver = Boolean(driverResponse.awaiting_driver_action ?? (notificationSent && (!acknowledged || !uploadsComplete)));
   const workspaceCaseStatus = workspace?.case_status ?? incident?.status ?? "new";
   const workspaceReadiness = workspace?.readiness_state ?? incident?.readiness_state ?? "not_ready";
   const workspaceOwnerUserId = workspace?.owner?.user_id ?? null;
@@ -188,14 +139,14 @@ export default function IncidentDetailClient() {
   const workspaceEvidence = workspace?.evidence_summary;
   const workspaceActivity = workspace?.activity ?? [];
 
+  const nextAction = workspaceMissingItems.length > 0
+    ? `Collect ${workspaceMissingItems[0]} to unblock readiness.`
+    : tasks.find((task) => task.status === "open")?.title ?? "Review export readiness and generate packet.";
+
   const onAssignMe = useCallback(async () => {
     if (!user) return;
     const previous = workspace;
-    setWorkspace((current) =>
-      current
-        ? { ...current, owner: { user_id: user.user_id, email: user.email } }
-        : current
-    );
+    setWorkspace((current) => (current ? { ...current, owner: { user_id: user.user_id, email: user.email } } : current));
     try {
       await patchIncidentOwner(id, {
         operation: workspaceOwnerUserId ? "reassign" : "assign",
@@ -276,9 +227,7 @@ export default function IncidentDetailClient() {
 
   const onCompleteTask = useCallback(async (taskId: string) => {
     const previous = tasks;
-    setTasks((current) =>
-      current.map((task) => (task.task_id === taskId ? { ...task, status: "completed" } : task))
-    );
+    setTasks((current) => current.map((task) => (task.task_id === taskId ? { ...task, status: "completed" } : task)));
     try {
       await completeTask(taskId);
       await refreshWorkspacePanels();
@@ -305,220 +254,78 @@ export default function IncidentDetailClient() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      {/* Header */}
-      <header className="flex items-center justify-between border-b bg-white px-6 py-4 dark:bg-gray-800">
-        <div className="flex items-center gap-4">
-          <Link
-            href="/incidents"
-            className="text-sm text-blue-600 hover:underline dark:text-blue-400"
-          >
-            ← Incidents
-          </Link>
-          <h1 className="text-lg font-bold text-gray-900 dark:text-white">
-            Incident {incident.incident_id.slice(0, 8)}…
-          </h1>
-          <span className="text-xs text-gray-400">
-            {formatTime(incident.created_at_utc)}
-          </span>
-        </div>
-        <div className="flex flex-wrap items-center gap-2 text-xs">
-          <span className="rounded-full bg-green-100 px-2 py-0.5 font-medium text-green-800">
-            Captured {captured}/{total}
-          </span>
-          {pending > 0 && (
-            <span className="rounded-full bg-yellow-100 px-2 py-0.5 font-medium text-yellow-800">
-              Pending {pending}
-            </span>
-          )}
-          {unavailable > 0 && (
-            <span className="rounded-full bg-red-100 px-2 py-0.5 font-medium text-red-800">
-              Unavailable {unavailable}
-            </span>
-          )}
-        </div>
-      </header>
-
-      <main className="mx-auto max-w-6xl space-y-6 p-6">
-        <div className="rounded-lg border bg-white p-4 shadow dark:bg-gray-800">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
-            Defensibility Summary
-          </h2>
-          <div className="mt-3 grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-4">
-            <div className="rounded border bg-gray-50 p-3 dark:bg-gray-700">
-              <p className="text-xs text-gray-500">Artifact Completeness</p>
-              <p className="font-semibold text-gray-900 dark:text-white">
-                {captured}/{total} ({completenessPercent}%)
-              </p>
-            </div>
-            <div className="rounded border bg-gray-50 p-3 dark:bg-gray-700">
-              <p className="text-xs text-gray-500">Custody Continuity</p>
-              <p className="font-semibold text-gray-900 dark:text-white">
-                {custodyContinuityLabel}
-              </p>
-            </div>
-            <div className="rounded border bg-gray-50 p-3 dark:bg-gray-700">
-              <p className="text-xs text-gray-500">Unavailable Artifacts</p>
-              <p className="font-semibold text-gray-900 dark:text-white">
-                {unavailable}
-              </p>
-            </div>
-            <div className="rounded border bg-gray-50 p-3 dark:bg-gray-700">
-              <p className="text-xs text-gray-500">Readiness State</p>
-              <p className="font-semibold text-gray-900 capitalize dark:text-white">
-                {(incident.readiness_state ?? "not_ready").replaceAll("_", " ")}
-              </p>
-            </div>
-            <div className="rounded border bg-gray-50 p-3 dark:bg-gray-700">
-              <p className="text-xs text-gray-500">Lifecycle Coverage</p>
-              <p className="font-semibold text-gray-900 dark:text-white">
-                {lifecycleCoverage.hasCollected ? "✓C " : "•C "}
-                {lifecycleCoverage.hasValidated ? "✓V " : "•V "}
-                {lifecycleCoverage.hasExported ? "✓E " : "•E "}
-                {lifecycleCoverage.hasDownloaded ? "✓D" : "•D"}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div className="grid gap-4 lg:grid-cols-3">
-          <CaseOwnerControl
-            ownerUserId={workspaceOwnerUserId}
-            onAssignMe={onAssignMe}
-            onClearOwner={onClearOwner}
-          />
-          <CaseStatusControl caseStatus={workspaceCaseStatus} onChange={onCaseStatusChange} />
-          <CaseReadinessCard
-            readinessState={workspaceReadiness}
-            completenessPercent={workspace?.completeness.percent ?? completenessPercent}
-            blockersCount={(workspace?.blockers ?? []).length}
-          />
-        </div>
-
-        <ExportReadinessBanner
-          blockersCount={(workspace?.blockers ?? []).length}
-          readinessState={workspaceReadiness}
-          blockers={(workspace?.blockers ?? []) as Array<{ code?: string; message?: string; blocks_readiness?: boolean }>}
+    <div className="min-h-screen bg-gray-50">
+      <main className="mx-auto max-w-7xl space-y-6 p-6">
+        <CaseHeroHeader
+          incidentId={incident.incident_id}
+          createdAtLabel={formatTime(incident.created_at_utc)}
+          whatHappened={`Severity ${incident.severity ?? "unknown"} incident is currently ${workspaceCaseStatus.replaceAll("_", " ")}.`}
+          nextAction={nextAction}
+          captured={captured}
+          total={total}
+          pending={pending}
+          unavailable={unavailable}
         />
-        <EvidenceStatusPanel
-          captured={workspaceEvidence?.captured ?? captured}
-          pending={workspaceEvidence?.pending ?? pending}
-          unavailable={workspaceEvidence?.unavailable ?? unavailable}
-          total={workspaceEvidence?.total ?? total}
-        />
-        <MissingItemsPanel items={workspaceMissingItems} />
-        <div className="grid gap-4 lg:grid-cols-2">
-          <CaseNotesPanel notes={notes} onAddNote={onAddNote} />
-          <CaseTasksPanel tasks={tasks} onAddTask={onAddTask} onCompleteTask={onCompleteTask} />
-        </div>
-        <TimelineFeed items={workspaceActivity} />
 
-        {/* ── Panel A: Evidence Inventory ────────────────────────── */}
-        <div className="rounded-lg border bg-white p-6 shadow dark:bg-gray-800">
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-500">
-            A) Evidence Inventory
-          </h2>
-          <p className="mb-4 text-xs text-gray-500">{captureSummary}</p>
-          <EvidenceTable artifacts={incident.evidence_inventory} />
-        </div>
-
-        {/* ── Panel B: Timeline ──────────────────────────────────── */}
-        <div className="rounded-lg border bg-white p-6 shadow dark:bg-gray-800">
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-500">
-            B) Timeline
-          </h2>
-          <Timeline events={incident.timeline} />
-        </div>
-
-        {/* ── Panel C: Export Actions ────────────────────────────── */}
-        <div className="rounded-lg border bg-white p-6 shadow dark:bg-gray-800">
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-500">
-            C) Export Actions
-          </h2>
-          <IncidentDetailExportPanel
-            incidentId={id}
-            exports={incident.export_status}
-            artifacts={incident.evidence_inventory}
-            onExportsChanged={refreshIncident}
-          />
-        </div>
-
-        {/* ── Panel D: Driver Response ───────────────────────────── */}
-        <div className="rounded-lg border bg-white p-6 shadow dark:bg-gray-800">
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-500">
-            D) Driver response
-          </h2>
-          <div className="mb-4 flex flex-wrap gap-2">
-            <span
-              className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-                waitingOnDriver
-                  ? "bg-yellow-100 text-yellow-800"
-                  : "bg-green-100 text-green-800"
-              }`}
-            >
-              {waitingOnDriver
-                ? "Waiting on driver action"
-                : "Driver response complete"}
-            </span>
-          </div>
-          <ul className="space-y-3 text-sm text-gray-700 dark:text-gray-200">
-            <li className="flex items-center justify-between gap-2 rounded-md border px-3 py-2">
-              <span>Notification sent</span>
-              <span className={notificationSent ? "text-green-700" : "text-gray-500"}>
-                {notificationSent
-                  ? formatTime(driverResponse.notification_sent_at_utc)
-                  : "Pending"}
-              </span>
-            </li>
-            <li className="flex items-center justify-between gap-2 rounded-md border px-3 py-2">
-              <span>Acknowledged</span>
-              <span className={acknowledged ? "text-green-700" : "text-gray-500"}>
-                {acknowledged ? formatTime(driverResponse.acknowledged_at_utc) : "Pending"}
-              </span>
-            </li>
-            <li className="flex items-center justify-between gap-2 rounded-md border px-3 py-2">
-              <span>Uploads complete</span>
-              <span className={uploadsComplete ? "text-green-700" : "text-gray-500"}>
-                {uploadsComplete
-                  ? formatTime(driverResponse.uploads_completed_at_utc)
-                  : "Pending"}
-              </span>
-            </li>
-          </ul>
-
-          {protocolSummary && (
-            <div className="mt-6 rounded-md border bg-gray-50 p-4 dark:bg-gray-900/40">
-              <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">
-                Driver protocol configuration
-              </h3>
-              <dl className="mt-3 grid gap-2 text-sm sm:grid-cols-2">
-                <div>
-                  <dt className="text-gray-500">Instruction source</dt>
-                  <dd className="font-medium capitalize text-gray-800 dark:text-gray-200">
-                    {protocolSummary.instruction_source ?? "Default"}
-                  </dd>
-                </div>
-                <div>
-                  <dt className="text-gray-500">Acknowledgment required</dt>
-                  <dd className="font-medium text-gray-800 dark:text-gray-200">
-                    {protocolSummary.require_ack ? "Yes" : "No"}
-                  </dd>
-                </div>
-                <div>
-                  <dt className="text-gray-500">SMS notifications</dt>
-                  <dd className="font-medium text-gray-800 dark:text-gray-200">
-                    {protocolSummary.sms_enabled ? "Enabled" : "Disabled"}
-                  </dd>
-                </div>
-                <div>
-                  <dt className="text-gray-500">Voice notifications</dt>
-                  <dd className="font-medium text-gray-800 dark:text-gray-200">
-                    {protocolSummary.voice_enabled ? "Enabled" : "Disabled"}
-                  </dd>
-                </div>
-              </dl>
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
+          <section className="space-y-4">
+            <EvidenceStatusPanel
+              captured={workspaceEvidence?.captured ?? captured}
+              pending={workspaceEvidence?.pending ?? pending}
+              unavailable={workspaceEvidence?.unavailable ?? unavailable}
+              total={workspaceEvidence?.total ?? total}
+            />
+            <TimelineFeed items={workspaceActivity} />
+            <div className="grid gap-4 lg:grid-cols-2">
+              <CaseTasksPanel tasks={tasks} onAddTask={onAddTask} onCompleteTask={onCompleteTask} />
+              <CaseNotesPanel notes={notes} onAddNote={onAddNote} />
             </div>
-          )}
+
+            <div className="rounded-lg border bg-white p-6 shadow-sm">
+              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-600">Evidence inventory</h2>
+              <p className="mb-4 text-xs text-gray-500">{captureSummary}</p>
+              <EvidenceTable artifacts={incident.evidence_inventory} />
+            </div>
+
+            <div className="rounded-lg border bg-white p-6 shadow-sm">
+              <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-600">Full timeline</h2>
+              <Timeline events={incident.timeline} />
+            </div>
+
+            <IncidentDetailExportPanel
+              incidentId={id}
+              exports={incident.export_status}
+              artifacts={incident.evidence_inventory}
+              onExportsChanged={refreshIncident}
+            />
+          </section>
+
+          <StickySidebar className="space-y-4" topOffsetClassName="top-6">
+            <CaseOwnerControl ownerUserId={workspaceOwnerUserId} onAssignMe={onAssignMe} onClearOwner={onClearOwner} />
+            <CaseStatusControl caseStatus={workspaceCaseStatus} onChange={onCaseStatusChange} />
+            <CaseReadinessCard
+              readinessState={workspaceReadiness}
+              completenessPercent={workspace?.completeness.percent ?? completenessPercent}
+              blockersCount={(workspace?.blockers ?? []).length}
+            />
+            <MissingItemsPanel items={workspaceMissingItems} />
+            <ExportReadinessBanner
+              blockersCount={(workspace?.blockers ?? []).length}
+              readinessState={workspaceReadiness}
+              blockers={(workspace?.blockers ?? []) as Array<{ code?: string; message?: string; blocks_readiness?: boolean }>}
+            />
+            <section className="rounded-lg border bg-white p-4 shadow-sm">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-600">Driver response</h3>
+              <div className="mt-2 flex flex-wrap gap-2">
+                <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${waitingOnDriver ? "bg-yellow-100 text-yellow-800" : "bg-green-100 text-green-800"}`}>
+                  {waitingOnDriver ? "Waiting on driver action" : "Driver response complete"}
+                </span>
+              </div>
+              {protocolSummary ? (
+                <p className="mt-2 text-xs text-gray-500">Protocol: {protocolSummary.instruction_source ?? "default"}</p>
+              ) : null}
+            </section>
+          </StickySidebar>
         </div>
       </main>
     </div>

--- a/frontend/components/IncidentDetailExportPanel.tsx
+++ b/frontend/components/IncidentDetailExportPanel.tsx
@@ -1,1 +1,21 @@
-export { default } from "@/components/exports/IncidentDetailExportPanel";
+import ExportPanelCore from "@/components/exports/IncidentDetailExportPanel";
+import type { ArtifactSummary, ExportSummary } from "@/lib/api";
+
+interface IncidentDetailExportPanelProps {
+  incidentId: string;
+  exports: ExportSummary[];
+  artifacts: ArtifactSummary[];
+  onExportsChanged: () => Promise<void>;
+}
+
+export default function IncidentDetailExportPanel(props: IncidentDetailExportPanelProps) {
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-600">Export readiness & actions</h3>
+      <p className="mt-1 text-xs text-gray-500">Confirm readiness before creating and downloading export packets.</p>
+      <div className="mt-3">
+        <ExportPanelCore {...props} />
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/case-ops/CaseHeroHeader.tsx
+++ b/frontend/components/case-ops/CaseHeroHeader.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+
+interface CaseHeroHeaderProps {
+  incidentId: string;
+  createdAtLabel: string;
+  whatHappened: string;
+  nextAction: string;
+  captured: number;
+  total: number;
+  pending: number;
+  unavailable: number;
+}
+
+export default function CaseHeroHeader({
+  incidentId,
+  createdAtLabel,
+  whatHappened,
+  nextAction,
+  captured,
+  total,
+  pending,
+  unavailable,
+}: CaseHeroHeaderProps) {
+  return (
+    <header className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <Link href="/incidents" className="text-sm text-blue-600 hover:underline">
+            ← Back to incidents
+          </Link>
+          <h1 className="mt-1 text-2xl font-semibold text-gray-900">Case {incidentId.slice(0, 8)}…</h1>
+          <p className="mt-1 text-xs text-gray-500">Opened {createdAtLabel}</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <span className="rounded-full bg-green-100 px-2 py-1 font-medium text-green-800">Captured {captured}/{total}</span>
+          {pending > 0 ? <span className="rounded-full bg-yellow-100 px-2 py-1 font-medium text-yellow-800">Pending {pending}</span> : null}
+          {unavailable > 0 ? <span className="rounded-full bg-red-100 px-2 py-1 font-medium text-red-800">Unavailable {unavailable}</span> : null}
+        </div>
+      </div>
+      <div className="mt-4 grid gap-3 md:grid-cols-2">
+        <div className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">What happened</p>
+          <p className="mt-1 text-sm text-gray-800">{whatHappened}</p>
+        </div>
+        <div className="rounded-lg border border-blue-200 bg-blue-50 p-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Next action</p>
+          <p className="mt-1 text-sm font-medium text-blue-900">{nextAction}</p>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/frontend/components/case-ops/CaseNotesPanel.tsx
+++ b/frontend/components/case-ops/CaseNotesPanel.tsx
@@ -1,1 +1,44 @@
-export { default } from "@/components/support/CaseNotesPanel";
+"use client";
+
+import { useState, type FormEvent } from "react";
+import type { IncidentNoteItem } from "@/lib/api";
+
+interface CaseNotesPanelProps {
+  notes: IncidentNoteItem[];
+  onAddNote: (body: string) => Promise<void>;
+}
+
+export default function CaseNotesPanel({ notes, onAddNote }: CaseNotesPanelProps) {
+  const [body, setBody] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!body.trim()) return;
+    setBusy(true);
+    try {
+      await onAddNote(body.trim());
+      setBody("");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="rounded-lg border bg-white p-4 shadow-sm">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-600">Case notes</h3>
+      <form onSubmit={submit} className="mt-3 flex gap-2">
+        <input value={body} onChange={(e) => setBody(e.target.value)} placeholder="Add note for handoff or legal context" className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm" />
+        <button disabled={busy || !body.trim()} className="rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-60">Add</button>
+      </form>
+      <ul className="mt-3 space-y-2 text-sm">
+        {notes.map((note) => (
+          <li key={note.note_id} className="rounded-md border border-gray-200 p-2">
+            <p className="text-gray-800">{note.body}</p>
+          </li>
+        ))}
+        {notes.length === 0 ? <li className="text-gray-500">No notes yet.</li> : null}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/components/case-ops/CaseOwnerControl.tsx
+++ b/frontend/components/case-ops/CaseOwnerControl.tsx
@@ -21,27 +21,13 @@ export default function CaseOwnerControl({ ownerUserId, onAssignMe, onClearOwner
   };
 
   return (
-    <div className="rounded-md border bg-gray-50 p-3 dark:bg-gray-900/40">
-      <p className="text-xs text-gray-500">Case owner</p>
-      <p className="mt-1 font-mono text-xs text-gray-800 dark:text-gray-200">
-        {ownerUserId ? `${ownerUserId.slice(0, 8)}…` : "Unassigned"}
-      </p>
-      <div className="mt-2 flex gap-2">
-        <button
-          onClick={() => run(onAssignMe)}
-          disabled={busy}
-          className="rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-60"
-        >
-          Assign me
-        </button>
-        <button
-          onClick={() => run(onClearOwner)}
-          disabled={busy || !ownerUserId}
-          className="rounded border px-2 py-1 text-xs hover:bg-gray-100 disabled:opacity-60 dark:border-gray-600 dark:hover:bg-gray-700"
-        >
-          Clear
-        </button>
+    <section className="rounded-lg border bg-white p-4 shadow-sm">
+      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Owner</p>
+      <p className="mt-1 text-sm font-medium text-gray-900">{ownerUserId ? `${ownerUserId.slice(0, 8)}…` : "Unassigned"}</p>
+      <div className="mt-3 flex gap-2">
+        <button onClick={() => run(onAssignMe)} disabled={busy} className="rounded bg-blue-600 px-2.5 py-1.5 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-60">Assign me</button>
+        <button onClick={() => run(onClearOwner)} disabled={busy || !ownerUserId} className="rounded border border-gray-300 px-2.5 py-1.5 text-xs text-gray-700 hover:bg-gray-50 disabled:opacity-60">Clear</button>
       </div>
-    </div>
+    </section>
   );
 }

--- a/frontend/components/case-ops/CaseReadinessCard.tsx
+++ b/frontend/components/case-ops/CaseReadinessCard.tsx
@@ -10,59 +10,65 @@ interface ReadinessBlocker {
   blocks_readiness?: boolean;
 }
 
-export function ExportReadinessBanner({
-  blockersCount,
-  readinessState,
-  blockers = [],
-}: {
-  blockersCount: number;
-  readinessState: string;
-  blockers?: ReadinessBlocker[];
-}) {
+function readinessTone(state: string) {
+  if (state === "ready_for_export" || state === "exported") return "green";
+  if (state === "conditionally_ready") return "yellow";
+  return "red";
+}
+
+export function ExportReadinessBanner({ blockersCount, readinessState, blockers = [] }: { blockersCount: number; readinessState: string; blockers?: ReadinessBlocker[] }) {
   const topReasons = blockers
     .filter((blocker) => blocker.blocks_readiness !== false)
     .slice(0, 2)
     .map((blocker) => blocker.message || blocker.code || "Unspecified readiness blocker");
 
   if (readinessState === "ready_for_export" || readinessState === "exported" || blockersCount === 0) {
-    return <div className="rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-800">Export readiness: no blockers detected.</div>;
+    return <div className="rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-900">Ready for export: no blockers detected.</div>;
   }
 
   if (readinessState === "conditionally_ready") {
     return (
-      <div className="rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-sm text-yellow-800">
-        <p>Export readiness: conditionally ready. {blockersCount} blocker{blockersCount === 1 ? "" : "s"} may affect packet completeness.</p>
-        {topReasons.length > 0 && (
+      <div className="rounded-lg border border-yellow-200 bg-yellow-50 px-3 py-2 text-sm text-yellow-900">
+        <p>Conditionally ready: {blockersCount} blocker{blockersCount === 1 ? "" : "s"} still require review.</p>
+        {topReasons.length > 0 ? (
           <ul className="mt-1 list-disc pl-5 text-xs">
             {topReasons.map((reason) => (
               <li key={reason}>{reason}</li>
             ))}
           </ul>
-        )}
+        ) : null}
       </div>
     );
   }
 
   return (
-    <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">
-      <p>Export readiness: blocked. Resolve readiness blockers before requesting export.</p>
-      {topReasons.length > 0 && (
+    <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-900">
+      <p>Not ready for export: resolve blockers before packet generation.</p>
+      {topReasons.length > 0 ? (
         <ul className="mt-1 list-disc pl-5 text-xs">
           {topReasons.map((reason) => (
             <li key={reason}>{reason}</li>
           ))}
         </ul>
-      )}
+      ) : null}
     </div>
   );
 }
 
 export default function CaseReadinessCard({ readinessState, completenessPercent, blockersCount }: CaseReadinessCardProps) {
+  const tone = readinessTone(readinessState);
+  const cardClass =
+    tone === "green"
+      ? "border-green-200 bg-green-50"
+      : tone === "yellow"
+        ? "border-yellow-200 bg-yellow-50"
+        : "border-red-200 bg-red-50";
+
   return (
-    <div className="rounded-md border bg-gray-50 p-3 dark:bg-gray-900/40">
-      <p className="text-xs text-gray-500">Readiness</p>
-      <p className="mt-1 text-sm font-semibold capitalize text-gray-900 dark:text-white">{readinessState.replaceAll("_", " ")}</p>
-      <p className="text-xs text-gray-600 dark:text-gray-300">Completeness {completenessPercent}% · {blockersCount} blocker{blockersCount === 1 ? "" : "s"}</p>
-    </div>
+    <section className={`rounded-lg border p-4 ${cardClass}`}>
+      <p className="text-xs font-semibold uppercase tracking-wide text-gray-600">Ready</p>
+      <p className="mt-1 text-sm font-semibold capitalize text-gray-900">{readinessState.replaceAll("_", " ")}</p>
+      <p className="text-xs text-gray-700">Completeness {completenessPercent}% · {blockersCount} blocker{blockersCount === 1 ? "" : "s"}</p>
+    </section>
   );
 }

--- a/frontend/components/case-ops/CaseReadinessCard.tsx
+++ b/frontend/components/case-ops/CaseReadinessCard.tsx
@@ -11,7 +11,7 @@ interface ReadinessBlocker {
 }
 
 function readinessTone(state: string) {
-  if (state === "ready_for_export" || state === "exported") return "green";
+  if (state === "ready_for_export" || state === "exported" || state === "closed") return "green";
   if (state === "conditionally_ready") return "yellow";
   return "red";
 }
@@ -22,8 +22,12 @@ export function ExportReadinessBanner({ blockersCount, readinessState, blockers 
     .slice(0, 2)
     .map((blocker) => blocker.message || blocker.code || "Unspecified readiness blocker");
 
-  if (readinessState === "ready_for_export" || readinessState === "exported" || blockersCount === 0) {
+  if (readinessState === "ready_for_export" || readinessState === "exported" || readinessState === "closed") {
     return <div className="rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-900">Ready for export: no blockers detected.</div>;
+  }
+
+  if (readinessState === "conditionally_ready" && blockersCount === 0) {
+    return <div className="rounded-lg border border-yellow-200 bg-yellow-50 px-3 py-2 text-sm text-yellow-900">Conditionally ready: completeness is low but no active blockers detected.</div>;
   }
 
   if (readinessState === "conditionally_ready") {

--- a/frontend/components/case-ops/CaseStatusControl.tsx
+++ b/frontend/components/case-ops/CaseStatusControl.tsx
@@ -2,7 +2,16 @@
 
 import { useState } from "react";
 
-const CASE_STATUSES = ["new", "awaiting_evidence", "in_review", "ready_for_export", "escalated", "closed"] as const;
+const CASE_STATUSES = [
+  "new",
+  "awaiting_evidence",
+  "awaiting_follow_up",
+  "in_review",
+  "ready_for_export",
+  "exported",
+  "escalated",
+  "closed",
+] as const;
 
 interface CaseStatusControlProps {
   caseStatus: string;

--- a/frontend/components/case-ops/CaseStatusControl.tsx
+++ b/frontend/components/case-ops/CaseStatusControl.tsx
@@ -1,13 +1,8 @@
 "use client";
 
-const CASE_STATUSES = [
-  "new",
-  "awaiting_evidence",
-  "in_review",
-  "ready_for_export",
-  "escalated",
-  "closed",
-] as const;
+import { useState } from "react";
+
+const CASE_STATUSES = ["new", "awaiting_evidence", "in_review", "ready_for_export", "escalated", "closed"] as const;
 
 interface CaseStatusControlProps {
   caseStatus: string;
@@ -15,17 +10,27 @@ interface CaseStatusControlProps {
 }
 
 export default function CaseStatusControl({ caseStatus, onChange }: CaseStatusControlProps) {
+  const [busy, setBusy] = useState(false);
+
   return (
-    <label className="flex flex-col gap-1 rounded-md border bg-gray-50 p-3 text-xs dark:bg-gray-900/40">
-      <span className="text-gray-500">Case status</span>
+    <label className="flex flex-col gap-1 rounded-lg border bg-white p-4 text-xs shadow-sm">
+      <span className="font-semibold uppercase tracking-wide text-gray-500">Case status</span>
       <select
-        className="rounded border px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900"
+        className="rounded border border-gray-300 px-2 py-1.5 text-sm text-gray-900 disabled:opacity-60"
         value={caseStatus}
-        onChange={(e) => void onChange(e.target.value)}
+        disabled={busy}
+        onChange={async (e) => {
+          setBusy(true);
+          try {
+            await onChange(e.target.value);
+          } finally {
+            setBusy(false);
+          }
+        }}
       >
         {CASE_STATUSES.map((status) => (
           <option key={status} value={status}>
-            {status}
+            {status.replaceAll("_", " ")}
           </option>
         ))}
       </select>

--- a/frontend/components/case-ops/CaseTasksPanel.tsx
+++ b/frontend/components/case-ops/CaseTasksPanel.tsx
@@ -1,1 +1,49 @@
-export { default } from "@/components/support/CaseTasksPanel";
+"use client";
+
+import { useState, type FormEvent } from "react";
+import type { IncidentTaskItem } from "@/lib/api";
+
+interface CaseTasksPanelProps {
+  tasks: IncidentTaskItem[];
+  onAddTask: (title: string) => Promise<void>;
+  onCompleteTask: (taskId: string) => Promise<void>;
+}
+
+export default function CaseTasksPanel({ tasks, onAddTask, onCompleteTask }: CaseTasksPanelProps) {
+  const [title, setTitle] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    setBusy(true);
+    try {
+      await onAddTask(title.trim());
+      setTitle("");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="rounded-lg border bg-white p-4 shadow-sm">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-600">Next action tasks</h3>
+      <form onSubmit={submit} className="mt-3 flex gap-2">
+        <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Create next action" className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm" />
+        <button disabled={busy || !title.trim()} className="rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-60">Add</button>
+      </form>
+      <ul className="mt-3 space-y-2 text-sm">
+        {tasks.map((task) => (
+          <li key={task.task_id} className="flex items-center justify-between rounded-md border border-gray-200 p-2">
+            <div>
+              <p className="text-gray-800">{task.title}</p>
+              <p className="text-xs text-gray-500">{task.status} · {task.priority}</p>
+            </div>
+            <button disabled={task.status === "completed"} onClick={() => void onCompleteTask(task.task_id)} className="rounded border border-gray-300 px-2 py-1 text-xs hover:bg-gray-50 disabled:opacity-50">Complete</button>
+          </li>
+        ))}
+        {tasks.length === 0 ? <li className="text-gray-500">No tasks yet.</li> : null}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/components/case-ops/CaseTasksPanel.tsx
+++ b/frontend/components/case-ops/CaseTasksPanel.tsx
@@ -39,7 +39,16 @@ export default function CaseTasksPanel({ tasks, onAddTask, onCompleteTask }: Cas
               <p className="text-gray-800">{task.title}</p>
               <p className="text-xs text-gray-500">{task.status} · {task.priority}</p>
             </div>
-            <button disabled={task.status === "completed"} onClick={() => void onCompleteTask(task.task_id)} className="rounded border border-gray-300 px-2 py-1 text-xs hover:bg-gray-50 disabled:opacity-50">Complete</button>
+            <button
+              disabled={task.status !== "open"}
+              onClick={() => {
+                if (task.status !== "open") return;
+                void onCompleteTask(task.task_id);
+              }}
+              className="rounded border border-gray-300 px-2 py-1 text-xs hover:bg-gray-50 disabled:opacity-50"
+            >
+              Complete
+            </button>
           </li>
         ))}
         {tasks.length === 0 ? <li className="text-gray-500">No tasks yet.</li> : null}

--- a/frontend/components/case-ops/EvidenceStatusPanel.tsx
+++ b/frontend/components/case-ops/EvidenceStatusPanel.tsx
@@ -6,24 +6,27 @@ interface EvidenceStatusPanelProps {
 }
 
 export default function EvidenceStatusPanel({ captured, pending, unavailable, total }: EvidenceStatusPanelProps) {
+  const coverage = Math.round((captured / Math.max(total, 1)) * 100);
+
   return (
-    <div className="rounded-lg border bg-white p-4 shadow dark:bg-gray-800">
-      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Evidence status</h3>
+    <section className="rounded-lg border bg-white p-4 shadow-sm">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-600">Evidence captured / missing</h3>
+      <p className="mt-1 text-xs text-gray-500">Visibility into what is present and what blocks readiness.</p>
       <div className="mt-3 grid grid-cols-2 gap-2 text-sm sm:grid-cols-4">
         <Metric label="Captured" value={`${captured}/${total}`} />
         <Metric label="Pending" value={String(pending)} />
         <Metric label="Unavailable" value={String(unavailable)} />
-        <Metric label="Coverage" value={`${Math.round((captured / Math.max(total, 1)) * 100)}%`} />
+        <Metric label="Coverage" value={`${coverage}%`} />
       </div>
-    </div>
+    </section>
   );
 }
 
 function Metric({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded border bg-gray-50 p-2 dark:bg-gray-700">
+    <div className="rounded-md border border-gray-200 bg-gray-50 p-2">
       <p className="text-xs text-gray-500">{label}</p>
-      <p className="font-semibold text-gray-900 dark:text-white">{value}</p>
+      <p className="font-semibold text-gray-900">{value}</p>
     </div>
   );
 }

--- a/frontend/components/case-ops/MissingItemsPanel.tsx
+++ b/frontend/components/case-ops/MissingItemsPanel.tsx
@@ -1,1 +1,20 @@
-export { default } from "@/components/support/MissingItemsPanel";
+interface MissingItemsPanelProps {
+  items: string[];
+}
+
+export default function MissingItemsPanel({ items }: MissingItemsPanelProps) {
+  return (
+    <section className="rounded-lg border bg-white p-4 shadow-sm">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-600">Missing evidence</h3>
+      {items.length === 0 ? (
+        <p className="mt-2 text-sm text-green-700">No missing evidence items.</p>
+      ) : (
+        <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-gray-700">
+          {items.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/components/case-ops/TimelineFeed.tsx
+++ b/frontend/components/case-ops/TimelineFeed.tsx
@@ -11,19 +11,17 @@ function formatTime(iso?: string | null): string {
 
 export default function TimelineFeed({ items }: TimelineFeedProps) {
   return (
-    <div className="rounded-lg border bg-white p-4 shadow dark:bg-gray-800">
-      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Timeline feed</h3>
+    <section className="rounded-lg border bg-white p-4 shadow-sm">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-600">What happened timeline</h3>
       <ul className="mt-3 space-y-2 text-sm">
         {items.map((item, idx) => (
-          <li key={`${item.source}-${item.type}-${idx}`} className="rounded border p-2 dark:border-gray-700">
-            <p className="font-medium text-gray-800 dark:text-gray-200">
-              {item.source === "audit" ? "Ops" : "System"}: {item.type}
-            </p>
+          <li key={`${item.source}-${item.type}-${idx}`} className="rounded-md border border-gray-200 p-2">
+            <p className="font-medium text-gray-800">{item.source === "audit" ? "Ops" : "System"}: {item.type.replaceAll("_", " ")}</p>
             <p className="text-xs text-gray-500">{formatTime(item.occurred_at_utc)}</p>
           </li>
         ))}
-        {items.length === 0 && <li className="text-gray-500">No timeline activity.</li>}
+        {items.length === 0 ? <li className="text-gray-500">No timeline activity yet.</li> : null}
       </ul>
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
### Motivation
- Convert the incident detail page into an operator-focused case workspace that emphasizes "what happened / owner / missing / ready / next action" for fast triage and handoff.
- Surface high-level context and next action at the top of the page so operators can scan status in <5s and take the single clearest next move.
- Provide a sticky case-ops sidebar with owner, status, readiness, missing items and driver-response signals to keep operational controls visible while investigating evidence.

### Description
- Reworked `app/incidents/[id]/IncidentDetailClient.tsx` to a two-column layout with a primary investigation column and a sticky sidebar via `StickySidebar`, added a `nextAction` heuristic and moved panels into the specified priority order.
- Added `frontend/components/case-ops/CaseHeroHeader.tsx` to present incident summary, "What happened" and "Next action" blocks and capture chips.
- Implemented case-ops UI components: `CaseReadinessCard.tsx` (with `ExportReadinessBanner`), `EvidenceStatusPanel.tsx`, `MissingItemsPanel.tsx`, `CaseOwnerControl.tsx`, `CaseStatusControl.tsx`, `CaseNotesPanel.tsx`, `CaseTasksPanel.tsx`, and `TimelineFeed.tsx` to provide consistent operator-focused cards and controls.
- Created `frontend/components/IncidentDetailExportPanel.tsx` as a structured wrapper around the existing export core component to present export readiness and actions in the workspace.
- Small TypeScript & import adjustments to use API types (`IncidentDetail`, `CaseWorkspaceResponse`, etc.) and removed a non-existent `incident.description` reference by replacing it with a severity/status-derived headline.

### Testing
- Ran lint with `cd frontend && npm run lint` and there were no lint errors.
- Ran type checking with `cd frontend && npm run typecheck` which succeeded after the code update to remove the `description` reference.
- Ran the frontend unit tests with `cd frontend && npm run test` and all tests passed (`8` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed781601b48321ba47c4d1b9b1e56b)