### PR TITLE
Refactor onboarding launch readiness dashboard structure

### DIFF
--- a/frontend/components/onboarding/BlockersPanel.tsx
+++ b/frontend/components/onboarding/BlockersPanel.tsx
@@ -28,7 +28,8 @@ export default function BlockersPanel({
   emptyMessage = "No blockers detected.",
   maxItems = 4,
 }: BlockersPanelProps) {
-  const visible = blockers.slice(0, maxItems);
+  const safeMaxItems = Math.max(0, maxItems);
+  const visible = blockers.slice(0, safeMaxItems);
 
   return (
     <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">

--- a/frontend/components/onboarding/BlockersPanel.tsx
+++ b/frontend/components/onboarding/BlockersPanel.tsx
@@ -10,6 +10,9 @@ type Blocker = {
 type BlockersPanelProps = {
   blockers: Blocker[];
   reviewHref: string;
+  title?: string;
+  emptyMessage?: string;
+  maxItems?: number;
 };
 
 const SEVERITY_STYLES: Record<Blocker["severity"], string> = {
@@ -18,21 +21,29 @@ const SEVERITY_STYLES: Record<Blocker["severity"], string> = {
   info: "border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-900/30 dark:text-blue-200",
 };
 
-export default function BlockersPanel({ blockers, reviewHref }: BlockersPanelProps) {
+export default function BlockersPanel({
+  blockers,
+  reviewHref,
+  title = "Readiness blockers",
+  emptyMessage = "No blockers detected.",
+  maxItems = 4,
+}: BlockersPanelProps) {
+  const visible = blockers.slice(0, maxItems);
+
   return (
     <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
       <div className="mb-3 flex items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Blockers</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">{title}</h3>
         <Link href={reviewHref} className="text-xs font-medium text-blue-600 hover:underline">
-          Review blockers
+          Review all
         </Link>
       </div>
 
-      {blockers.length === 0 ? (
-        <p className="text-xs text-emerald-700 dark:text-emerald-300">No blockers detected.</p>
+      {visible.length === 0 ? (
+        <p className="text-xs text-emerald-700 dark:text-emerald-300">{emptyMessage}</p>
       ) : (
         <ul className="space-y-2">
-          {blockers.slice(0, 4).map((blocker) => (
+          {visible.map((blocker) => (
             <li key={blocker.code} className={`rounded-md border p-2 text-xs ${SEVERITY_STYLES[blocker.severity]}`}>
               <p className="font-semibold">{blocker.title}</p>
               <p className="mt-1">{blocker.detail}</p>

--- a/frontend/components/onboarding/LaunchReadinessBanner.tsx
+++ b/frontend/components/onboarding/LaunchReadinessBanner.tsx
@@ -1,13 +1,14 @@
 import Link from "next/link";
+import type { OnboardingReadinessStatus } from "@/lib/api";
 
 type LaunchReadinessBannerProps = {
-  status: "not_started" | "in_progress" | "blocked" | "pilot_ready" | "launch_ready";
+  status: OnboardingReadinessStatus;
   recommendation: string;
   blockersCount: number;
   blockersHref: string;
 };
 
-const STATUS_LABELS: Record<LaunchReadinessBannerProps["status"], string> = {
+const STATUS_LABELS: Record<OnboardingReadinessStatus, string> = {
   not_started: "Not started",
   in_progress: "In progress",
   blocked: "Blocked",
@@ -15,7 +16,7 @@ const STATUS_LABELS: Record<LaunchReadinessBannerProps["status"], string> = {
   launch_ready: "Launch ready",
 };
 
-const STATUS_STYLES: Record<LaunchReadinessBannerProps["status"], string> = {
+const STATUS_STYLES: Record<OnboardingReadinessStatus, string> = {
   not_started: "border-slate-300 bg-slate-50 text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200",
   in_progress: "border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-900/30 dark:text-blue-200",
   blocked: "border-red-300 bg-red-50 text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200",

--- a/frontend/components/onboarding/LaunchReadinessBanner.tsx
+++ b/frontend/components/onboarding/LaunchReadinessBanner.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 type LaunchReadinessBannerProps = {
   status: "not_started" | "in_progress" | "blocked" | "pilot_ready" | "launch_ready";
   recommendation: string;
+  blockersCount: number;
+  blockersHref: string;
 };
 
 const STATUS_LABELS: Record<LaunchReadinessBannerProps["status"], string> = {
@@ -21,24 +23,26 @@ const STATUS_STYLES: Record<LaunchReadinessBannerProps["status"], string> = {
   launch_ready: "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-200",
 };
 
-export default function LaunchReadinessBanner({ status, recommendation }: LaunchReadinessBannerProps) {
+export default function LaunchReadinessBanner({
+  status,
+  recommendation,
+  blockersCount,
+  blockersHref,
+}: LaunchReadinessBannerProps) {
   return (
     <section className={`rounded-lg border p-4 ${STATUS_STYLES[status]}`}>
-      <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <p className="text-xs uppercase tracking-wide">Overall status</p>
+          <p className="text-xs uppercase tracking-wide">Launch readiness status</p>
           <h3 className="text-lg font-semibold">{STATUS_LABELS[status]}</h3>
+          <p className="mt-1 text-sm">{recommendation}</p>
         </div>
-        <span className="rounded-full border border-current px-3 py-1 text-xs font-semibold">
-          Recommendation: {recommendation}
-        </span>
-      </div>
-      <div className="mt-3 flex flex-wrap gap-3 text-xs font-medium">
-        <Link href="/admin/driver-protocol" className="underline underline-offset-2">Continue setup</Link>
-        <Link href="/dashboard" className="underline underline-offset-2">Rerun validation</Link>
-        <Link href="/settings/integrations" className="underline underline-offset-2">Import data</Link>
-        <Link href="/settings/integrations" className="underline underline-offset-2">Invite users</Link>
-        <Link href="/incidents" className="underline underline-offset-2">Open test incident flow</Link>
+        <Link
+          href={blockersHref}
+          className="rounded-full border border-current px-3 py-1 text-xs font-semibold hover:bg-white/50 dark:hover:bg-black/20"
+        >
+          {blockersCount > 0 ? `Review ${blockersCount} blockers` : "Review readiness checks"}
+        </Link>
       </div>
     </section>
   );

--- a/frontend/components/onboarding/LaunchReadinessHero.tsx
+++ b/frontend/components/onboarding/LaunchReadinessHero.tsx
@@ -1,9 +1,10 @@
 import LaunchReadinessBanner from "./LaunchReadinessBanner";
 import ReadinessProgressBar from "./ReadinessProgressBar";
+import type { OnboardingReadinessStatus } from "@/lib/api";
 
 type LaunchReadinessHeroProps = {
   percent: number;
-  status: "not_started" | "in_progress" | "blocked" | "pilot_ready" | "launch_ready";
+  status: OnboardingReadinessStatus;
   recommendation: string;
   blockersCount: number;
   blockersHref: string;

--- a/frontend/components/onboarding/LaunchReadinessHero.tsx
+++ b/frontend/components/onboarding/LaunchReadinessHero.tsx
@@ -1,0 +1,34 @@
+import LaunchReadinessBanner from "./LaunchReadinessBanner";
+import ReadinessProgressBar from "./ReadinessProgressBar";
+
+type LaunchReadinessHeroProps = {
+  percent: number;
+  status: "not_started" | "in_progress" | "blocked" | "pilot_ready" | "launch_ready";
+  recommendation: string;
+  blockersCount: number;
+  blockersHref: string;
+};
+
+export default function LaunchReadinessHero({
+  percent,
+  status,
+  recommendation,
+  blockersCount,
+  blockersHref,
+}: LaunchReadinessHeroProps) {
+  return (
+    <section className="rounded-xl border border-blue-100 bg-white p-4 shadow-sm dark:border-blue-900/50 dark:bg-gray-800">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <ReadinessProgressBar label="Launch readiness" percent={percent} variant="ring" />
+        <div className="min-w-0 flex-1">
+          <LaunchReadinessBanner
+            status={status}
+            recommendation={recommendation}
+            blockersCount={blockersCount}
+            blockersHref={blockersHref}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/onboarding/OnboardingProgressDashboard.tsx
+++ b/frontend/components/onboarding/OnboardingProgressDashboard.tsx
@@ -100,7 +100,7 @@ export default function OnboardingProgressDashboard({
       title: "Data imports",
       href: "/settings/integrations",
       ctaLabel: "Import data",
-      completed: importSummary.total > 0 && importSummary.failed === 0,
+      completed: importSummary.total > 0 && importSummary.succeeded === importSummary.total,
       summary: `${importSummary.succeeded}/${importSummary.total} jobs succeeded${importSummary.failed ? ` · ${importSummary.failed} failed` : ""}`,
       missingCue: "Missing cue: resolve failed imports and rerun connector sync.",
     },

--- a/frontend/components/onboarding/OnboardingProgressDashboard.tsx
+++ b/frontend/components/onboarding/OnboardingProgressDashboard.tsx
@@ -74,12 +74,17 @@ export default function OnboardingProgressDashboard({
     };
   }, [validationResults]);
 
+  const protocolStep = useMemo(
+    () => readiness?.steps.find((step) => step.key === "driver_protocol"),
+    [readiness]
+  );
+
   const stepCards: StepCard[] = [
     {
       title: "Protocol setup",
       href: "/admin/driver-protocol",
       ctaLabel: "Continue setup",
-      completed: readiness?.steps.some((step) => step.status === "completed") ?? false,
+      completed: protocolStep?.status === "completed",
       summary: "Configuration defaults and policy controls are defined.",
       missingCue: "Missing cue: assign an owner and finish protocol defaults.",
     },

--- a/frontend/components/onboarding/OnboardingProgressDashboard.tsx
+++ b/frontend/components/onboarding/OnboardingProgressDashboard.tsx
@@ -133,7 +133,7 @@ export default function OnboardingProgressDashboard({
         status={readiness?.status ?? "not_started"}
         recommendation={toBadgeRecommendation(readiness)}
         blockersCount={blockers.length}
-        blockersHref="/dashboard?blockers=critical"
+        blockersHref={blockers.length > 0 ? "/dashboard?blockers=critical" : "/dashboard"}
       />
 
       <div className="grid gap-4 lg:grid-cols-3">

--- a/frontend/components/onboarding/OnboardingProgressDashboard.tsx
+++ b/frontend/components/onboarding/OnboardingProgressDashboard.tsx
@@ -1,9 +1,7 @@
 import { useMemo } from "react";
 import Link from "next/link";
 import BlockersPanel from "./BlockersPanel";
-import LaunchReadinessBanner from "./LaunchReadinessBanner";
-import OnboardingStepCard from "./OnboardingStepCard";
-import ReadinessProgressBar from "./ReadinessProgressBar";
+import LaunchReadinessHero from "./LaunchReadinessHero";
 import type {
   IntegrationValidationResult,
   OrgLaunchReadiness,
@@ -17,11 +15,14 @@ type OnboardingProgressDashboardProps = {
   loading: boolean;
 };
 
-function getStepStatus(score: number): "completed" | "in_progress" | "not_started" {
-  if (score >= 1) return "completed";
-  if (score > 0) return "in_progress";
-  return "not_started";
-}
+type StepCard = {
+  title: string;
+  href: string;
+  ctaLabel: string;
+  completed: boolean;
+  summary: string;
+  missingCue: string;
+};
 
 function formatDate(value?: string | null) {
   if (!value) return "—";
@@ -43,7 +44,11 @@ export default function OnboardingProgressDashboard({
   loading,
 }: OnboardingProgressDashboardProps) {
   const blockers = useMemo(
-    () => (readiness?.blockers ?? []).map((item) => ({ ...item, severity: item.severity === "error" ? "critical" : item.severity })),
+    () =>
+      (readiness?.blockers ?? []).map((item) => ({
+        ...item,
+        severity: item.severity === "error" ? "critical" : item.severity,
+      })),
     [readiness]
   );
 
@@ -69,86 +74,125 @@ export default function OnboardingProgressDashboard({
     };
   }, [validationResults]);
 
-  const latestValidationTime = readiness?.latest_export_validation?.validated_at_utc;
-
-  const setupScore = readiness
-    ? readiness.steps.length === 0
-      ? 0
-      : readiness.steps.filter((step) => step.status === "completed").length / readiness.steps.length
-    : 0;
+  const stepCards: StepCard[] = [
+    {
+      title: "Protocol setup",
+      href: "/admin/driver-protocol",
+      ctaLabel: "Continue setup",
+      completed: readiness?.steps.some((step) => step.status === "completed") ?? false,
+      summary: "Configuration defaults and policy controls are defined.",
+      missingCue: "Missing cue: assign an owner and finish protocol defaults.",
+    },
+    {
+      title: "Validation checks",
+      href: "/dashboard",
+      ctaLabel: "Rerun validation",
+      completed: readiness?.latest_export_validation?.status === "completed",
+      summary: `Latest validation: ${formatDate(readiness?.latest_export_validation?.validated_at_utc)}`,
+      missingCue: "Missing cue: run a fresh validation and clear failed checks.",
+    },
+    {
+      title: "Data imports",
+      href: "/settings/integrations",
+      ctaLabel: "Import data",
+      completed: importSummary.total > 0 && importSummary.failed === 0,
+      summary: `${importSummary.succeeded}/${importSummary.total} jobs succeeded${importSummary.failed ? ` · ${importSummary.failed} failed` : ""}`,
+      missingCue: "Missing cue: resolve failed imports and rerun connector sync.",
+    },
+    {
+      title: "QR coverage",
+      href: "/settings/integrations",
+      ctaLabel: "Distribute QR codes",
+      completed:
+        (qrStats?.required_vehicle_count ?? 0) > 0 &&
+        (qrStats?.distributed_count ?? 0) >= (qrStats?.required_vehicle_count ?? 0),
+      summary: `${qrStats?.distributed_count ?? 0}/${qrStats?.required_vehicle_count ?? 0} vehicles covered.`,
+      missingCue: "Missing cue: distribute codes to uncovered vehicles.",
+    },
+  ];
 
   return (
     <section className="space-y-4 rounded-xl border border-blue-100 bg-blue-50/40 p-4 dark:border-blue-900/40 dark:bg-blue-900/10">
       <div className="flex items-center justify-between gap-3">
         <div>
           <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Onboarding Progress Dashboard</h2>
-          <p className="text-sm text-gray-600 dark:text-gray-300">Track readiness, blockers, validation signals, and launch recommendations.</p>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            Track readiness, blockers, ownership, and the next best actions to reach go-live.
+          </p>
         </div>
         {loading ? <span className="text-xs text-gray-500">Refreshing…</span> : null}
       </div>
 
-      <LaunchReadinessBanner
+      <LaunchReadinessHero
+        percent={readiness?.percent_complete ?? 0}
         status={readiness?.status ?? "not_started"}
         recommendation={toBadgeRecommendation(readiness)}
+        blockersCount={blockers.length}
+        blockersHref="/dashboard?blockers=critical"
       />
 
       <div className="grid gap-4 lg:grid-cols-3">
-        <div className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800 lg:col-span-2">
-          <ReadinessProgressBar
-            label="Overall launch readiness"
-            percent={readiness?.percent_complete ?? 0}
-          />
-          <div className="mt-4 grid gap-3 sm:grid-cols-3">
-            <OnboardingStepCard
-              title="Setup"
-              description="Finish protocol configuration and defaults"
-              status={getStepStatus(setupScore)}
-              href="/admin/driver-protocol"
-              ctaLabel="Continue setup"
-            />
-            <OnboardingStepCard
-              title="Validation"
-              description={`Latest export validation: ${formatDate(latestValidationTime)}`}
-              status={readiness?.latest_export_validation?.status ?? "not_started"}
-              href="/dashboard"
-              ctaLabel="Rerun validation"
-            />
-            <OnboardingStepCard
-              title="Imports"
-              description={`${importSummary.succeeded}/${importSummary.total} jobs succeeded${importSummary.failed ? ` · ${importSummary.failed} failed` : ""}`}
-              status={importSummary.total === 0 ? "not_started" : importSummary.failed > 0 ? "in_progress" : "completed"}
-              href="/settings/integrations"
-              ctaLabel="Import data"
-            />
-          </div>
-
-          <div className="mt-4 grid gap-3 text-xs text-gray-700 dark:text-gray-200 sm:grid-cols-3">
-            <div className="rounded-md border bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900">
-              <p className="text-[11px] uppercase text-gray-500">Integration health</p>
-              <p className="mt-1 text-base font-semibold">{integrationHealth.passed}/{integrationHealth.total}</p>
-              <p className="text-[11px] text-gray-500">validations passing</p>
+        <div className="space-y-4 lg:col-span-2">
+          <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <div className="mb-3 flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Readiness steps</h3>
+              <span className="text-xs text-gray-500">Completion + missing item cues</span>
             </div>
-            <div className="rounded-md border bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900">
-              <p className="text-[11px] uppercase text-gray-500">QR coverage</p>
-              <p className="mt-1 text-base font-semibold">
-                {qrStats?.distributed_count ?? 0}/{qrStats?.required_vehicle_count ?? 0}
-              </p>
-              <p className="text-[11px] text-gray-500">distributed vehicles</p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {stepCards.map((step) => (
+                <article key={step.title} className="rounded-md border border-gray-200 p-3 dark:border-gray-700">
+                  <div className="flex items-center justify-between gap-2">
+                    <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100">{step.title}</h4>
+                    <span
+                      className={`rounded-full px-2 py-1 text-[11px] font-semibold ${
+                        step.completed
+                          ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+                          : "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
+                      }`}
+                    >
+                      {step.completed ? "Completed" : "Needs action"}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-xs text-gray-600 dark:text-gray-300">{step.summary}</p>
+                  {!step.completed ? (
+                    <p className="mt-2 text-xs text-amber-700 dark:text-amber-300">{step.missingCue}</p>
+                  ) : null}
+                  <Link href={step.href} className="mt-3 inline-flex text-xs font-medium text-blue-600 hover:underline">
+                    {step.ctaLabel}
+                  </Link>
+                </article>
+              ))}
             </div>
-            <div className="rounded-md border bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900">
-              <p className="text-[11px] uppercase text-gray-500">Recent validations</p>
-              <p className="mt-1 text-base font-semibold">{validationResults.length}</p>
-              <p className="text-[11px] text-gray-500">latest integration checks</p>
-            </div>
-          </div>
-
-          <div className="mt-4 flex flex-wrap gap-3 text-xs font-medium text-blue-700 dark:text-blue-300">
-            <Link href="/settings/integrations" className="hover:underline">Invite users</Link>
-            <Link href="/incidents" className="hover:underline">Open test incident flow</Link>
-          </div>
+          </section>
         </div>
 
-        <BlockersPanel blockers={blockers} reviewHref="/dashboard?blockers=critical" />
+        <aside className="space-y-4">
+          <BlockersPanel blockers={blockers} reviewHref="/dashboard?blockers=critical" />
+
+          <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Validation + imports</h3>
+            <ul className="mt-3 space-y-2 text-xs text-gray-700 dark:text-gray-200">
+              <li className="rounded-md border border-gray-200 bg-gray-50 p-2 dark:border-gray-700 dark:bg-gray-900">
+                Integration validations passing: <span className="font-semibold">{integrationHealth.passed}/{integrationHealth.total}</span>
+              </li>
+              <li className="rounded-md border border-gray-200 bg-gray-50 p-2 dark:border-gray-700 dark:bg-gray-900">
+                Import jobs: <span className="font-semibold">{importSummary.succeeded}/{importSummary.total}</span>
+              </li>
+              <li className="rounded-md border border-gray-200 bg-gray-50 p-2 dark:border-gray-700 dark:bg-gray-900">
+                Latest checks recorded: <span className="font-semibold">{validationResults.length}</span>
+              </li>
+            </ul>
+          </section>
+
+          <section className="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Help + next actions</h3>
+            <div className="mt-3 flex flex-col gap-2 text-xs font-medium text-blue-700 dark:text-blue-300">
+              <Link href="/settings/integrations" className="hover:underline">Invite users</Link>
+              <Link href="/incidents" className="hover:underline">Run a test incident flow</Link>
+              <Link href="/dashboard" className="hover:underline">Review export readiness</Link>
+            </div>
+          </section>
+        </aside>
       </div>
     </section>
   );

--- a/frontend/components/onboarding/ReadinessProgressBar.tsx
+++ b/frontend/components/onboarding/ReadinessProgressBar.tsx
@@ -1,10 +1,58 @@
 type ReadinessProgressBarProps = {
   percent: number;
   label: string;
+  variant?: "bar" | "ring";
+  size?: number;
 };
 
-export default function ReadinessProgressBar({ percent, label }: ReadinessProgressBarProps) {
-  const boundedPercent = Math.max(0, Math.min(100, percent));
+export default function ReadinessProgressBar({
+  percent,
+  label,
+  variant = "bar",
+  size = 112,
+}: ReadinessProgressBarProps) {
+  const boundedPercent = Math.max(0, Math.min(100, Math.round(percent)));
+
+  if (variant === "ring") {
+    const strokeWidth = 10;
+    const radius = (size - strokeWidth) / 2;
+    const circumference = 2 * Math.PI * radius;
+    const dashOffset = circumference * (1 - boundedPercent / 100);
+
+    return (
+      <div className="inline-flex flex-col items-center gap-2" role="img" aria-label={`${label}: ${boundedPercent}%`}>
+        <div className="relative" style={{ width: size, height: size }}>
+          <svg className="-rotate-90" width={size} height={size}>
+            <circle
+              cx={size / 2}
+              cy={size / 2}
+              r={radius}
+              stroke="currentColor"
+              strokeWidth={strokeWidth}
+              className="text-slate-200 dark:text-slate-700"
+              fill="none"
+            />
+            <circle
+              cx={size / 2}
+              cy={size / 2}
+              r={radius}
+              stroke="currentColor"
+              strokeWidth={strokeWidth}
+              strokeLinecap="round"
+              strokeDasharray={circumference}
+              strokeDashoffset={dashOffset}
+              className="text-blue-600 dark:text-blue-400"
+              fill="none"
+            />
+          </svg>
+          <div className="absolute inset-0 flex items-center justify-center">
+            <span className="text-xl font-semibold text-gray-900 dark:text-gray-100">{boundedPercent}%</span>
+          </div>
+        </div>
+        <p className="text-xs font-medium text-gray-600 dark:text-gray-300">{label}</p>
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/frontend/components/onboarding/ReadinessProgressBar.tsx
+++ b/frontend/components/onboarding/ReadinessProgressBar.tsx
@@ -15,7 +15,7 @@ export default function ReadinessProgressBar({
 
   if (variant === "ring") {
     const strokeWidth = 10;
-    const radius = (size - strokeWidth) / 2;
+    const radius = Math.max(0, (size - strokeWidth) / 2);
     const circumference = 2 * Math.PI * radius;
     const dashOffset = circumference * (1 - boundedPercent / 100);
 

--- a/frontend/components/onboarding/ReadinessProgressBar.tsx
+++ b/frontend/components/onboarding/ReadinessProgressBar.tsx
@@ -11,7 +11,8 @@ export default function ReadinessProgressBar({
   variant = "bar",
   size = 112,
 }: ReadinessProgressBarProps) {
-  const boundedPercent = Math.max(0, Math.min(100, Math.round(percent)));
+  const safePercent = Number.isFinite(percent) ? percent : 0;
+  const boundedPercent = Math.max(0, Math.min(100, Math.round(safePercent)));
 
   if (variant === "ring") {
     const strokeWidth = 10;
@@ -20,9 +21,16 @@ export default function ReadinessProgressBar({
     const dashOffset = circumference * (1 - boundedPercent / 100);
 
     return (
-      <div className="inline-flex flex-col items-center gap-2" role="img" aria-label={`${label}: ${boundedPercent}%`}>
+      <div
+        className="inline-flex flex-col items-center gap-2"
+        role="progressbar"
+        aria-valuenow={boundedPercent}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={label}
+      >
         <div className="relative" style={{ width: size, height: size }}>
-          <svg className="-rotate-90" width={size} height={size}>
+          <svg className="-rotate-90" width={size} height={size} aria-hidden="true">
             <circle
               cx={size / 2}
               cy={size / 2}
@@ -45,11 +53,11 @@ export default function ReadinessProgressBar({
               fill="none"
             />
           </svg>
-          <div className="absolute inset-0 flex items-center justify-center">
+          <div className="absolute inset-0 flex items-center justify-center" aria-hidden="true">
             <span className="text-xl font-semibold text-gray-900 dark:text-gray-100">{boundedPercent}%</span>
           </div>
         </div>
-        <p className="text-xs font-medium text-gray-600 dark:text-gray-300">{label}</p>
+        <p className="text-xs font-medium text-gray-600 dark:text-gray-300" aria-hidden="true">{label}</p>
       </div>
     );
   }


### PR DESCRIPTION
### Motivation
- Make the onboarding surface more readiness-focused and scannable with a clear hero band and a main + right-rail layout so operators can see status, blockers, and the next action at a glance.
- Surface missing-item cues and per-step completion state to reduce ambiguity about what is blocking go-live.
- Provide a compact, reusable readiness band (ring + status) with a direct blockers CTA to speed remediation workflows.

### Description
- Reworked `OnboardingProgressDashboard` to a main-and-rail layout and replaced the previous step/cards layout with an explicit step grid that shows completion state and missing-item cues (`frontend/components/onboarding/OnboardingProgressDashboard.tsx`).
- Added `LaunchReadinessHero` which composes a readiness progress ring and an enhanced status banner with a blockers CTA (`frontend/components/onboarding/LaunchReadinessHero.tsx`).
- Refactored `LaunchReadinessBanner` to include recommendation text and blockers count/href props for a focused review CTA (`frontend/components/onboarding/LaunchReadinessBanner.tsx`).
- Extended `BlockersPanel` to be reusable in the rail with configurable title, empty message, and `maxItems` behavior while preserving severity styling (`frontend/components/onboarding/BlockersPanel.tsx`).
- Enhanced `ReadinessProgressBar` to support both `bar` and `ring` variants with bounded percentage handling and accessible labeling (`frontend/components/onboarding/ReadinessProgressBar.tsx`).

### Testing
- Ran frontend linter with `npm run lint` and it completed successfully.
- Ran TypeScript checks with `npm run typecheck` and no type errors were reported.
- Ran frontend unit tests with `npm test` and the test suite passed (8/8 tests OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3468516083219800697f060f4b54)