### PR TITLE
Refactor reports/help/trust pages into operational UX surfaces

### DIFF
--- a/frontend/app/help/page.tsx
+++ b/frontend/app/help/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import MainLayout from "@/components/MainLayout";
 import HelpArticleCard, { type HelpArticle } from "@/components/support/HelpArticleCard";
 
@@ -74,6 +74,36 @@ const RELATED_TOPICS = ["Trust Center", "Deployment coverage", "Integration heal
 export default function HelpPage() {
   const [activeCategory, setActiveCategory] = useState<HelpCategoryKey>("getting_started");
   const articles = ARTICLE_MAP[activeCategory];
+  const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+
+  function setTabRef(key: HelpCategoryKey) {
+    return (el: HTMLButtonElement | null) => {
+      tabRefs.current[key] = el;
+    };
+  }
+
+  function handleTabKeyDown(event: React.KeyboardEvent, currentKey: HelpCategoryKey) {
+    const keys = CATEGORY_TABS.map((t) => t.key);
+    const currentIndex = keys.indexOf(currentKey);
+    let nextIndex: number | null = null;
+
+    if (event.key === "ArrowRight") {
+      nextIndex = (currentIndex + 1) % keys.length;
+    } else if (event.key === "ArrowLeft") {
+      nextIndex = (currentIndex - 1 + keys.length) % keys.length;
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = keys.length - 1;
+    }
+
+    if (nextIndex !== null) {
+      event.preventDefault();
+      const nextKey = keys[nextIndex];
+      setActiveCategory(nextKey);
+      tabRefs.current[nextKey]?.focus();
+    }
+  }
 
   return (
     <MainLayout title="Help Center">
@@ -84,14 +114,21 @@ export default function HelpPage() {
             <p className="mt-1 text-sm text-text-secondary">
               Find focused guidance by workflow stage, then take the clearest next action.
             </p>
-            <div className="mt-3 flex flex-wrap gap-2">
+            <div role="tablist" aria-label="Help categories" className="mt-3 flex flex-wrap gap-2">
               {CATEGORY_TABS.map((tab) => {
                 const active = activeCategory === tab.key;
                 return (
                   <button
                     key={tab.key}
+                    id={`help-tab-${tab.key}`}
+                    role="tab"
                     type="button"
+                    aria-selected={active}
+                    aria-controls={`help-panel-${tab.key}`}
+                    tabIndex={active ? 0 : -1}
+                    ref={setTabRef(tab.key)}
                     onClick={() => setActiveCategory(tab.key)}
+                    onKeyDown={(e) => handleTabKeyDown(e, tab.key)}
                     className={[
                       "rounded-md px-3 py-1.5 text-sm font-medium transition",
                       active
@@ -106,7 +143,13 @@ export default function HelpPage() {
             </div>
           </article>
 
-          <div className="space-y-3">
+          <div
+            id={`help-panel-${activeCategory}`}
+            role="tabpanel"
+            aria-labelledby={`help-tab-${activeCategory}`}
+            tabIndex={0}
+            className="space-y-3 focus:outline-none"
+          >
             {articles.map((article) => (
               <HelpArticleCard key={article.href} article={article} />
             ))}

--- a/frontend/app/help/page.tsx
+++ b/frontend/app/help/page.tsx
@@ -147,8 +147,7 @@ export default function HelpPage() {
             id={`help-panel-${activeCategory}`}
             role="tabpanel"
             aria-labelledby={`help-tab-${activeCategory}`}
-            tabIndex={0}
-            className="space-y-3 focus:outline-none"
+            className="space-y-3"
           >
             {articles.map((article) => (
               <HelpArticleCard key={article.href} article={article} />

--- a/frontend/app/help/page.tsx
+++ b/frontend/app/help/page.tsx
@@ -1,24 +1,141 @@
+"use client";
+
+import { useState } from "react";
 import MainLayout from "@/components/MainLayout";
-import DocumentationCenter from "@/components/commercial/DocumentationCenter";
-import RelatedDocsPanel from "@/components/commercial/RelatedDocsPanel";
+import HelpArticleCard, { type HelpArticle } from "@/components/support/HelpArticleCard";
+
+type HelpCategoryKey = "getting_started" | "incident_ops" | "exports";
+
+const CATEGORY_TABS: Array<{ key: HelpCategoryKey; label: string }> = [
+  { key: "getting_started", label: "Getting started" },
+  { key: "incident_ops", label: "Incident operations" },
+  { key: "exports", label: "Exports & readiness" },
+];
+
+const ARTICLE_MAP: Record<HelpCategoryKey, HelpArticle[]> = {
+  getting_started: [
+    {
+      title: "Launch checklist for new operators",
+      href: "/onboarding",
+      description: "Walk through ownership, evidence capture setup, and first-response workflows before go-live.",
+      readTime: "6 min read",
+      audience: "Ops leads",
+    },
+    {
+      title: "Configure team roles and assignment rules",
+      href: "/settings/integrations",
+      description: "Set owner routing so every incident gets a clear accountable responder.",
+      readTime: "5 min read",
+      audience: "Admins",
+    },
+  ],
+  incident_ops: [
+    {
+      title: "Triage queue best practices",
+      href: "/incidents",
+      description: "Prioritize incident attention and reduce unresolved blocker carry-over between shifts.",
+      readTime: "7 min read",
+      audience: "Dispatch",
+    },
+    {
+      title: "How to chase missing evidence quickly",
+      href: "/timeline",
+      description: "Use timeline checkpoints to detect capture gaps and trigger next actions within SLA windows.",
+      readTime: "4 min read",
+      audience: "Investigators",
+    },
+  ],
+  exports: [
+    {
+      title: "Export readiness playbook",
+      href: "/exports",
+      description: "Validate package completeness, resolve blockers, and prepare legal-ready deliverables.",
+      readTime: "8 min read",
+      audience: "Compliance",
+    },
+    {
+      title: "When to escalate blocked export cases",
+      href: "/trust",
+      description: "Identify policy-based blockers and collect evidence required for trust and audit teams.",
+      readTime: "5 min read",
+      audience: "Legal ops",
+    },
+  ],
+};
+
+const FEATURED_ARTICLES = [
+  "What changed in readiness scoring this month",
+  "Incident owner handoff template",
+  "Evidence retention FAQ",
+];
+
+const RELATED_TOPICS = ["Trust Center", "Deployment coverage", "Integration health", "Admin ops runbooks"];
 
 export default function HelpPage() {
-  const docs = [
-    { title: "Onboarding setup guide", href: "/onboarding", description: "Step-by-step launch checklist and blockers." },
-    { title: "Incident operations", href: "/incidents", description: "Queue management, response tracking, and evidence coverage." },
-    { title: "Export package details", href: "/exports", description: "Audit history, package manifests, and legal-ready delivery." },
-  ];
+  const [activeCategory, setActiveCategory] = useState<HelpCategoryKey>("getting_started");
+  const articles = ARTICLE_MAP[activeCategory];
 
   return (
     <MainLayout title="Help Center">
       <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
-        <DocumentationCenter docs={docs} />
-        <RelatedDocsPanel
-          docs={[
-            { title: "Trust center", href: "/trust", description: "Security and compliance posture details." },
-            { title: "Deployment coverage", href: "/deployment", description: "Market expansion and rollout readiness." },
-          ]}
-        />
+        <section className="space-y-4">
+          <article className="rounded-lg border border-border-default bg-surface p-4 shadow-card">
+            <h2 className="text-xl font-semibold text-text-primary">Operator help center</h2>
+            <p className="mt-1 text-sm text-text-secondary">
+              Find focused guidance by workflow stage, then take the clearest next action.
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {CATEGORY_TABS.map((tab) => {
+                const active = activeCategory === tab.key;
+                return (
+                  <button
+                    key={tab.key}
+                    type="button"
+                    onClick={() => setActiveCategory(tab.key)}
+                    className={[
+                      "rounded-md px-3 py-1.5 text-sm font-medium transition",
+                      active
+                        ? "bg-status-info-soft text-status-info"
+                        : "border border-border-subtle text-text-secondary hover:bg-surface-raised",
+                    ].join(" ")}
+                  >
+                    {tab.label}
+                  </button>
+                );
+              })}
+            </div>
+          </article>
+
+          <div className="space-y-3">
+            {articles.map((article) => (
+              <HelpArticleCard key={article.title} article={article} />
+            ))}
+          </div>
+        </section>
+
+        <aside className="space-y-4">
+          <section className="rounded-lg border border-border-subtle bg-surface p-4 shadow-card">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-text-muted">Featured</h3>
+            <ul className="mt-3 space-y-2 text-sm text-text-secondary">
+              {FEATURED_ARTICLES.map((item) => (
+                <li key={item} className="rounded-md border border-border-subtle bg-surface-raised px-3 py-2">
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="rounded-lg border border-border-subtle bg-surface p-4 shadow-card">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-text-muted">Related topics</h3>
+            <ul className="mt-3 space-y-2 text-sm text-text-secondary">
+              {RELATED_TOPICS.map((item) => (
+                <li key={item} className="rounded-md border border-border-subtle px-3 py-2">
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </section>
+        </aside>
       </div>
     </MainLayout>
   );

--- a/frontend/app/help/page.tsx
+++ b/frontend/app/help/page.tsx
@@ -108,7 +108,7 @@ export default function HelpPage() {
 
           <div className="space-y-3">
             {articles.map((article) => (
-              <HelpArticleCard key={article.title} article={article} />
+              <HelpArticleCard key={article.href} article={article} />
             ))}
           </div>
         </section>

--- a/frontend/app/reports/page.tsx
+++ b/frontend/app/reports/page.tsx
@@ -105,6 +105,12 @@ export default function ReportsPage() {
   const activeReport = REPORT_DATA[activeTab];
   const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
 
+  function setTabRef(key: ReportTabKey) {
+    return (el: HTMLButtonElement | null) => {
+      tabRefs.current[key] = el;
+    };
+  }
+
   const maxTrendValue = useMemo(
     () => Math.max(...activeReport.trend.map((point) => point.value), 1),
     [activeReport.trend],
@@ -151,7 +157,7 @@ export default function ReportsPage() {
                   aria-selected={active}
                   aria-controls={`report-panel-${tab.key}`}
                   tabIndex={active ? 0 : -1}
-                  ref={(el) => { tabRefs.current[tab.key] = el; }}
+                  ref={setTabRef(tab.key)}
                   onClick={() => setActiveTab(tab.key)}
                   onKeyDown={(e) => handleTabKeyDown(e, tab.key)}
                   className={[

--- a/frontend/app/reports/page.tsx
+++ b/frontend/app/reports/page.tsx
@@ -30,7 +30,7 @@ const REPORT_DATA: Record<
   ReportTabKey,
   {
     subtitle: string;
-    cards: Array<{ label: string; value: string; detail: string; tone?: "success" | "warning" | "critical" }>;
+    cards: Array<{ id: string; label: string; value: string; detail: string; tone?: "success" | "warning" | "critical" }>;
     trend: TrendPoint[];
     rows: ReportRow[];
   }
@@ -38,10 +38,10 @@ const REPORT_DATA: Record<
   attention: {
     subtitle: "Track where operators should focus first, which queues are blocked, and what can wait.",
     cards: [
-      { label: "Needs action now", value: "28", detail: "+5 since yesterday", tone: "critical" },
-      { label: "Unassigned incidents", value: "9", detail: "Owner reassignment pending", tone: "warning" },
-      { label: "Awaiting driver response", value: "14", detail: "Median wait: 3.1h" },
-      { label: "Resolved today", value: "31", detail: "Outpaced intake by 12%", tone: "success" },
+      { id: "attention-needs-action", label: "Needs action now", value: "28", detail: "+5 since yesterday", tone: "critical" },
+      { id: "attention-unassigned", label: "Unassigned incidents", value: "9", detail: "Owner reassignment pending", tone: "warning" },
+      { id: "attention-awaiting", label: "Awaiting driver response", value: "14", detail: "Median wait: 3.1h" },
+      { id: "attention-resolved", label: "Resolved today", value: "31", detail: "Outpaced intake by 12%", tone: "success" },
     ],
     trend: [
       { label: "Mon", value: 18 },
@@ -59,10 +59,10 @@ const REPORT_DATA: Record<
   readiness: {
     subtitle: "Show what is export-ready, what is blocked, and exactly where evidence is incomplete.",
     cards: [
-      { label: "Ready for export", value: "64%", detail: "+4 points week-over-week", tone: "success" },
-      { label: "Blocked by missing media", value: "12", detail: "Mostly witness uploads", tone: "critical" },
-      { label: "Conditionally ready", value: "17", detail: "Require owner sign-off", tone: "warning" },
-      { label: "Avg readiness time", value: "19.4h", detail: "From incident open to ready" },
+      { id: "readiness-ready", label: "Ready for export", value: "64%", detail: "+4 points week-over-week", tone: "success" },
+      { id: "readiness-blocked", label: "Blocked by missing media", value: "12", detail: "Mostly witness uploads", tone: "critical" },
+      { id: "readiness-conditional", label: "Conditionally ready", value: "17", detail: "Require owner sign-off", tone: "warning" },
+      { id: "readiness-avg-time", label: "Avg readiness time", value: "19.4h", detail: "From incident open to ready" },
     ],
     trend: [
       { label: "Mon", value: 52 },
@@ -80,10 +80,10 @@ const REPORT_DATA: Record<
   sla: {
     subtitle: "Monitor response performance and identify queues at risk of breaching support commitments.",
     cards: [
-      { label: "SLA attainment", value: "98.9%", detail: "30-day rolling window", tone: "success" },
-      { label: "At-risk queues", value: "3", detail: "2 due to staffing gaps", tone: "warning" },
-      { label: "SLA breaches", value: "2", detail: "Both recovered under 1 hour", tone: "critical" },
-      { label: "Median first response", value: "11m", detail: "Down from 14m last week" },
+      { id: "sla-attainment", label: "SLA attainment", value: "98.9%", detail: "30-day rolling window", tone: "success" },
+      { id: "sla-at-risk", label: "At-risk queues", value: "3", detail: "2 due to staffing gaps", tone: "warning" },
+      { id: "sla-breaches", label: "SLA breaches", value: "2", detail: "Both recovered under 1 hour", tone: "critical" },
+      { id: "sla-first-response", label: "Median first response", value: "11m", detail: "Down from 14m last week" },
     ],
     trend: [
       { label: "Mon", value: 97 },

--- a/frontend/app/reports/page.tsx
+++ b/frontend/app/reports/page.tsx
@@ -1,19 +1,196 @@
+"use client";
+
+import { useMemo, useState } from "react";
 import MainLayout from "@/components/MainLayout";
-import CommercialSummaryCards from "@/components/commercial/CommercialSummaryCards";
+import ReportSummaryCards from "@/components/reports/ReportSummaryCards";
+
+type ReportTabKey = "attention" | "readiness" | "sla";
+
+interface TrendPoint {
+  label: string;
+  value: number;
+}
+
+interface ReportRow {
+  queue: string;
+  owner: string;
+  unresolved: number;
+  blocked: number;
+  ready: number;
+  nextAction: string;
+}
+
+const REPORT_TABS: Array<{ key: ReportTabKey; label: string }> = [
+  { key: "attention", label: "Incident attention" },
+  { key: "readiness", label: "Export readiness" },
+  { key: "sla", label: "Support SLA" },
+];
+
+const REPORT_DATA: Record<
+  ReportTabKey,
+  {
+    subtitle: string;
+    cards: Array<{ label: string; value: string; detail: string; tone?: "success" | "warning" | "critical" }>;
+    trend: TrendPoint[];
+    rows: ReportRow[];
+  }
+> = {
+  attention: {
+    subtitle: "Track where operators should focus first, which queues are blocked, and what can wait.",
+    cards: [
+      { label: "Needs action now", value: "28", detail: "+5 since yesterday", tone: "critical" },
+      { label: "Unassigned incidents", value: "9", detail: "Owner reassignment pending", tone: "warning" },
+      { label: "Awaiting driver response", value: "14", detail: "Median wait: 3.1h" },
+      { label: "Resolved today", value: "31", detail: "Outpaced intake by 12%", tone: "success" },
+    ],
+    trend: [
+      { label: "Mon", value: 18 },
+      { label: "Tue", value: 24 },
+      { label: "Wed", value: 20 },
+      { label: "Thu", value: 27 },
+      { label: "Fri", value: 28 },
+    ],
+    rows: [
+      { queue: "High-severity collisions", owner: "Ops Alpha", unresolved: 7, blocked: 3, ready: 2, nextAction: "Escalate evidence chase" },
+      { queue: "Late-night incidents", owner: "Ops Bravo", unresolved: 11, blocked: 2, ready: 5, nextAction: "Rebalance on-call coverage" },
+      { queue: "Insurance escalations", owner: "Ops Delta", unresolved: 10, blocked: 4, ready: 1, nextAction: "Assign legal reviewer" },
+    ],
+  },
+  readiness: {
+    subtitle: "Show what is export-ready, what is blocked, and exactly where evidence is incomplete.",
+    cards: [
+      { label: "Ready for export", value: "64%", detail: "+4 points week-over-week", tone: "success" },
+      { label: "Blocked by missing media", value: "12", detail: "Mostly witness uploads", tone: "critical" },
+      { label: "Conditionally ready", value: "17", detail: "Require owner sign-off", tone: "warning" },
+      { label: "Avg readiness time", value: "19.4h", detail: "From incident open to ready" },
+    ],
+    trend: [
+      { label: "Mon", value: 52 },
+      { label: "Tue", value: 55 },
+      { label: "Wed", value: 58 },
+      { label: "Thu", value: 61 },
+      { label: "Fri", value: 64 },
+    ],
+    rows: [
+      { queue: "Commercial fleet", owner: "Readiness West", unresolved: 15, blocked: 5, ready: 20, nextAction: "Close photo evidence gaps" },
+      { queue: "Campus mobility", owner: "Readiness East", unresolved: 8, blocked: 2, ready: 14, nextAction: "Finalize supervisor review" },
+      { queue: "Airport operations", owner: "Readiness Central", unresolved: 9, blocked: 3, ready: 9, nextAction: "Trigger automated reminders" },
+    ],
+  },
+  sla: {
+    subtitle: "Monitor response performance and identify queues at risk of breaching support commitments.",
+    cards: [
+      { label: "SLA attainment", value: "98.9%", detail: "30-day rolling window", tone: "success" },
+      { label: "At-risk queues", value: "3", detail: "2 due to staffing gaps", tone: "warning" },
+      { label: "SLA breaches", value: "2", detail: "Both recovered under 1 hour", tone: "critical" },
+      { label: "Median first response", value: "11m", detail: "Down from 14m last week" },
+    ],
+    trend: [
+      { label: "Mon", value: 97 },
+      { label: "Tue", value: 99 },
+      { label: "Wed", value: 98 },
+      { label: "Thu", value: 99 },
+      { label: "Fri", value: 99 },
+    ],
+    rows: [
+      { queue: "Enterprise support", owner: "Support Pod A", unresolved: 13, blocked: 1, ready: 11, nextAction: "Maintain weekend coverage" },
+      { queue: "Municipal contracts", owner: "Support Pod B", unresolved: 9, blocked: 2, ready: 8, nextAction: "Cross-train escalation lane" },
+      { queue: "SMB onboarding", owner: "Support Pod C", unresolved: 6, blocked: 1, ready: 12, nextAction: "Automate first-touch routing" },
+    ],
+  },
+};
 
 export default function ReportsPage() {
+  const [activeTab, setActiveTab] = useState<ReportTabKey>("attention");
+  const activeReport = REPORT_DATA[activeTab];
+
+  const maxTrendValue = useMemo(
+    () => Math.max(...activeReport.trend.map((point) => point.value), 1),
+    [activeReport.trend],
+  );
+
   return (
-    <MainLayout title="Commercial Reports">
+    <MainLayout title="Reports">
       <div className="space-y-4">
-        <h2 className="text-2xl font-semibold text-text-primary">Commercial performance reports</h2>
-        <CommercialSummaryCards
-          items={[
-            { label: "Active tenants", value: "48", detail: "+6 from last quarter" },
-            { label: "Pilot conversions", value: "73%", detail: "12-month rolling average" },
-            { label: "Expansion-ready markets", value: "5", detail: "2 blocked by protocol gaps" },
-            { label: "Support SLA attainment", value: "99.4%", detail: "Last 30 days" },
-          ]}
-        />
+        <div className="rounded-lg border border-border-default bg-surface p-4 shadow-card">
+          <h2 className="text-xl font-semibold text-text-primary">Operations reporting overview</h2>
+          <p className="mt-1 text-sm text-text-secondary">{activeReport.subtitle}</p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {REPORT_TABS.map((tab) => {
+              const active = tab.key === activeTab;
+              return (
+                <button
+                  key={tab.key}
+                  type="button"
+                  onClick={() => setActiveTab(tab.key)}
+                  className={[
+                    "rounded-md px-3 py-1.5 text-sm font-medium transition",
+                    active
+                      ? "bg-status-info-soft text-status-info"
+                      : "border border-border-subtle text-text-secondary hover:bg-surface-raised",
+                  ].join(" ")}
+                >
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <ReportSummaryCards items={activeReport.cards} />
+
+        <section className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]">
+          <article className="rounded-lg border border-border-subtle bg-surface p-4 shadow-card">
+            <h3 className="text-base font-semibold text-text-primary">Primary trend</h3>
+            <p className="mt-1 text-sm text-text-secondary">Five-day performance snapshot for the selected report.</p>
+            <div className="mt-4 space-y-3">
+              {activeReport.trend.map((point) => (
+                <div key={point.label}>
+                  <div className="mb-1 flex items-center justify-between text-xs text-text-muted">
+                    <span>{point.label}</span>
+                    <span>{point.value}</span>
+                  </div>
+                  <div className="h-2 rounded-full bg-surface-raised">
+                    <div
+                      className="h-2 rounded-full bg-status-info"
+                      style={{ width: `${(point.value / maxTrendValue) * 100}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </article>
+
+          <article className="rounded-lg border border-border-subtle bg-surface p-4 shadow-card">
+            <h3 className="text-base font-semibold text-text-primary">Supporting queue table</h3>
+            <div className="mt-3 overflow-x-auto">
+              <table className="min-w-full text-left text-sm">
+                <thead className="text-xs uppercase tracking-wide text-text-muted">
+                  <tr>
+                    <th className="pb-2 pr-3">Queue</th>
+                    <th className="pb-2 pr-3">Owner</th>
+                    <th className="pb-2 pr-3">Unresolved</th>
+                    <th className="pb-2 pr-3">Blocked</th>
+                    <th className="pb-2 pr-3">Ready</th>
+                    <th className="pb-2">Next action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {activeReport.rows.map((row) => (
+                    <tr key={row.queue} className="border-t border-border-subtle text-text-secondary">
+                      <td className="py-2 pr-3 font-medium text-text-primary">{row.queue}</td>
+                      <td className="py-2 pr-3">{row.owner}</td>
+                      <td className="py-2 pr-3">{row.unresolved}</td>
+                      <td className="py-2 pr-3">{row.blocked}</td>
+                      <td className="py-2 pr-3">{row.ready}</td>
+                      <td className="py-2">{row.nextAction}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </article>
+        </section>
       </div>
     </MainLayout>
   );

--- a/frontend/app/reports/page.tsx
+++ b/frontend/app/reports/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import MainLayout from "@/components/MainLayout";
 import ReportSummaryCards from "@/components/reports/ReportSummaryCards";
 
@@ -103,11 +103,35 @@ const REPORT_DATA: Record<
 export default function ReportsPage() {
   const [activeTab, setActiveTab] = useState<ReportTabKey>("attention");
   const activeReport = REPORT_DATA[activeTab];
+  const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
 
   const maxTrendValue = useMemo(
     () => Math.max(...activeReport.trend.map((point) => point.value), 1),
     [activeReport.trend],
   );
+
+  function handleTabKeyDown(event: React.KeyboardEvent, currentKey: ReportTabKey) {
+    const keys = REPORT_TABS.map((t) => t.key);
+    const currentIndex = keys.indexOf(currentKey);
+    let nextIndex: number | null = null;
+
+    if (event.key === "ArrowRight") {
+      nextIndex = (currentIndex + 1) % keys.length;
+    } else if (event.key === "ArrowLeft") {
+      nextIndex = (currentIndex - 1 + keys.length) % keys.length;
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = keys.length - 1;
+    }
+
+    if (nextIndex !== null) {
+      event.preventDefault();
+      const nextKey = keys[nextIndex];
+      setActiveTab(nextKey);
+      tabRefs.current[nextKey]?.focus();
+    }
+  }
 
   return (
     <MainLayout title="Reports">
@@ -115,14 +139,21 @@ export default function ReportsPage() {
         <div className="rounded-lg border border-border-default bg-surface p-4 shadow-card">
           <h2 className="text-xl font-semibold text-text-primary">Operations reporting overview</h2>
           <p className="mt-1 text-sm text-text-secondary">{activeReport.subtitle}</p>
-          <div className="mt-3 flex flex-wrap gap-2">
+          <div role="tablist" aria-label="Report categories" className="mt-3 flex flex-wrap gap-2">
             {REPORT_TABS.map((tab) => {
               const active = tab.key === activeTab;
               return (
                 <button
                   key={tab.key}
+                  id={`report-tab-${tab.key}`}
+                  role="tab"
                   type="button"
+                  aria-selected={active}
+                  aria-controls={`report-panel-${tab.key}`}
+                  tabIndex={active ? 0 : -1}
+                  ref={(el) => { tabRefs.current[tab.key] = el; }}
                   onClick={() => setActiveTab(tab.key)}
+                  onKeyDown={(e) => handleTabKeyDown(e, tab.key)}
                   className={[
                     "rounded-md px-3 py-1.5 text-sm font-medium transition",
                     active
@@ -137,6 +168,13 @@ export default function ReportsPage() {
           </div>
         </div>
 
+        <div
+          id={`report-panel-${activeTab}`}
+          role="tabpanel"
+          aria-labelledby={`report-tab-${activeTab}`}
+          tabIndex={0}
+          className="space-y-4 focus:outline-none"
+        >
         <ReportSummaryCards items={activeReport.cards} />
 
         <section className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]">
@@ -191,6 +229,7 @@ export default function ReportsPage() {
             </div>
           </article>
         </section>
+        </div>
       </div>
     </MainLayout>
   );

--- a/frontend/app/trust/page.tsx
+++ b/frontend/app/trust/page.tsx
@@ -1,28 +1,91 @@
 import MainLayout from "@/components/MainLayout";
-import TrustSectionCard from "@/components/commercial/TrustSectionCard";
+import ReportSummaryCards from "@/components/reports/ReportSummaryCards";
+import TrustSectionCard from "@/components/support/TrustSectionCard";
+
+const TRUST_SECTIONS = [
+  {
+    id: "security-controls",
+    title: "Security controls",
+    summary: "Controls focused on protecting operational evidence and limiting access to need-to-know teams.",
+    points: [
+      "Role-based access separates incident operators, managers, and administrators.",
+      "Export activity is recorded with immutable audit events and actor timestamps.",
+      "Production and sandbox tenant data are scoped to prevent cross-environment bleed.",
+    ],
+  },
+  {
+    id: "compliance-evidence",
+    title: "Compliance evidence",
+    summary: "Short-form artifacts that help legal and compliance teams verify readiness and retention posture.",
+    points: [
+      "Retention policy summary maps evidence classes to required storage windows.",
+      "Runbook checkpoints define owner and next action for blocked readiness cases.",
+      "Quarterly control attestations are packaged with export readiness reports.",
+    ],
+  },
+  {
+    id: "incident-response",
+    title: "Incident response",
+    summary: "Operational response commitments and escalation mechanics for security-impacting events.",
+    points: [
+      "On-call rotation guarantees acknowledgement targets for critical events.",
+      "Post-incident reviews capture corrective actions and ownership deadlines.",
+      "Customer communication templates support timely trust updates.",
+    ],
+  },
+];
 
 export default function TrustPage() {
   return (
     <MainLayout title="Trust Center">
-      <div className="grid gap-4 md:grid-cols-2">
-        <TrustSectionCard
-          title="Security controls"
-          summary="Operational controls designed for legal and safety workflows."
-          highlights={[
-            "Role-based access control across operations and administration surfaces.",
-            "Immutable export audit trail with event-level timestamps.",
-            "Scoped production and sandbox tenant isolation.",
+      <div className="space-y-4">
+        <section className="rounded-lg border border-border-default bg-surface p-4 shadow-card">
+          <h2 className="text-xl font-semibold text-text-primary">Trust and assurance overview</h2>
+          <p className="mt-1 text-sm text-text-secondary">
+            Review concise controls, evidence commitments, and next actions for audit-ready operations.
+          </p>
+          <nav className="mt-3 flex flex-wrap gap-2 text-sm">
+            {TRUST_SECTIONS.map((section) => (
+              <a
+                key={section.id}
+                href={`#${section.id}`}
+                className="rounded-md border border-border-subtle px-3 py-1.5 text-text-secondary hover:bg-surface-raised"
+              >
+                {section.title}
+              </a>
+            ))}
+          </nav>
+        </section>
+
+        <ReportSummaryCards
+          items={[
+            { label: "Control coverage", value: "96%", detail: "Core controls documented", tone: "success" },
+            { label: "Open trust follow-ups", value: "4", detail: "2 require policy sign-off", tone: "warning" },
+            { label: "Audit blockers", value: "1", detail: "Pending vendor attestation", tone: "critical" },
+            { label: "Latest review", value: "Apr 22", detail: "Quarterly trust review completed" },
           ]}
         />
-        <TrustSectionCard
-          title="Compliance evidence"
-          summary="Artifacts and runbooks used by internal and customer compliance teams."
-          highlights={[
-            "Incident evidence retention policies aligned with export obligations.",
-            "Onboarding readiness checkpoints with blocker ownership.",
-            "Documented deployment SOPs for phased market launches.",
-          ]}
-        />
+
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <TrustSectionCard
+            id={TRUST_SECTIONS[0].id}
+            title="Security controls"
+            summary={TRUST_SECTIONS[0].summary}
+            points={TRUST_SECTIONS[0].points}
+          />
+          <TrustSectionCard
+            id={TRUST_SECTIONS[1].id}
+            title="Compliance evidence"
+            summary={TRUST_SECTIONS[1].summary}
+            points={TRUST_SECTIONS[1].points}
+          />
+          <TrustSectionCard
+            id={TRUST_SECTIONS[2].id}
+            title={TRUST_SECTIONS[2].title}
+            summary={TRUST_SECTIONS[2].summary}
+            points={TRUST_SECTIONS[2].points}
+          />
+        </section>
       </div>
     </MainLayout>
   );

--- a/frontend/app/trust/page.tsx
+++ b/frontend/app/trust/page.tsx
@@ -59,10 +59,10 @@ export default function TrustPage() {
 
         <ReportSummaryCards
           items={[
-            { label: "Control coverage", value: "96%", detail: "Core controls documented", tone: "success" },
-            { label: "Open trust follow-ups", value: "4", detail: "2 require policy sign-off", tone: "warning" },
-            { label: "Audit blockers", value: "1", detail: "Pending vendor attestation", tone: "critical" },
-            { label: "Latest review", value: "Apr 22", detail: "Quarterly trust review completed" },
+            { id: "trust-control-coverage", label: "Control coverage", value: "96%", detail: "Core controls documented", tone: "success" },
+            { id: "trust-open-followups", label: "Open trust follow-ups", value: "4", detail: "2 require policy sign-off", tone: "warning" },
+            { id: "trust-audit-blockers", label: "Audit blockers", value: "1", detail: "Pending vendor attestation", tone: "critical" },
+            { id: "trust-latest-review", label: "Latest review", value: "Apr 22", detail: "Quarterly trust review completed" },
           ]}
         />
 

--- a/frontend/app/trust/page.tsx
+++ b/frontend/app/trust/page.tsx
@@ -67,24 +67,15 @@ export default function TrustPage() {
         />
 
         <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          <TrustSectionCard
-            id={TRUST_SECTIONS[0].id}
-            title="Security controls"
-            summary={TRUST_SECTIONS[0].summary}
-            points={TRUST_SECTIONS[0].points}
-          />
-          <TrustSectionCard
-            id={TRUST_SECTIONS[1].id}
-            title="Compliance evidence"
-            summary={TRUST_SECTIONS[1].summary}
-            points={TRUST_SECTIONS[1].points}
-          />
-          <TrustSectionCard
-            id={TRUST_SECTIONS[2].id}
-            title={TRUST_SECTIONS[2].title}
-            summary={TRUST_SECTIONS[2].summary}
-            points={TRUST_SECTIONS[2].points}
-          />
+          {TRUST_SECTIONS.map((section) => (
+            <TrustSectionCard
+              key={section.id}
+              id={section.id}
+              title={section.title}
+              summary={section.summary}
+              points={section.points}
+            />
+          ))}
         </section>
       </div>
     </MainLayout>

--- a/frontend/app/trust/page.tsx
+++ b/frontend/app/trust/page.tsx
@@ -2,39 +2,6 @@ import MainLayout from "@/components/MainLayout";
 import ReportSummaryCards from "@/components/reports/ReportSummaryCards";
 import TrustSectionCard from "@/components/support/TrustSectionCard";
 
-const TRUST_SECTIONS = [
-  {
-    id: "security-controls",
-    title: "Security controls",
-    summary: "Controls focused on protecting operational evidence and limiting access to need-to-know teams.",
-    points: [
-      "Role-based access separates incident operators, managers, and administrators.",
-      "Export activity is recorded with immutable audit events and actor timestamps.",
-      "Production and sandbox tenant data are scoped to prevent cross-environment bleed.",
-    ],
-  },
-  {
-    id: "compliance-evidence",
-    title: "Compliance evidence",
-    summary: "Short-form artifacts that help legal and compliance teams verify readiness and retention posture.",
-    points: [
-      "Retention policy summary maps evidence classes to required storage windows.",
-      "Runbook checkpoints define owner and next action for blocked readiness cases.",
-      "Quarterly control attestations are packaged with export readiness reports.",
-    ],
-  },
-  {
-    id: "incident-response",
-    title: "Incident response",
-    summary: "Operational response commitments and escalation mechanics for security-impacting events.",
-    points: [
-      "On-call rotation guarantees acknowledgement targets for critical events.",
-      "Post-incident reviews capture corrective actions and ownership deadlines.",
-      "Customer communication templates support timely trust updates.",
-    ],
-  },
-];
-
 export default function TrustPage() {
   return (
     <MainLayout title="Trust Center">
@@ -45,15 +12,24 @@ export default function TrustPage() {
             Review concise controls, evidence commitments, and next actions for audit-ready operations.
           </p>
           <nav className="mt-3 flex flex-wrap gap-2 text-sm">
-            {TRUST_SECTIONS.map((section) => (
-              <a
-                key={section.id}
-                href={`#${section.id}`}
-                className="rounded-md border border-border-subtle px-3 py-1.5 text-text-secondary hover:bg-surface-raised"
-              >
-                {section.title}
-              </a>
-            ))}
+            <a
+              href="#security-controls"
+              className="rounded-md border border-border-subtle px-3 py-1.5 text-text-secondary hover:bg-surface-raised"
+            >
+              Security controls
+            </a>
+            <a
+              href="#compliance-evidence"
+              className="rounded-md border border-border-subtle px-3 py-1.5 text-text-secondary hover:bg-surface-raised"
+            >
+              Compliance evidence
+            </a>
+            <a
+              href="#incident-response"
+              className="rounded-md border border-border-subtle px-3 py-1.5 text-text-secondary hover:bg-surface-raised"
+            >
+              Incident response
+            </a>
           </nav>
         </section>
 
@@ -67,15 +43,36 @@ export default function TrustPage() {
         />
 
         <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {TRUST_SECTIONS.map((section) => (
-            <TrustSectionCard
-              key={section.id}
-              id={section.id}
-              title={section.title}
-              summary={section.summary}
-              points={section.points}
-            />
-          ))}
+          <TrustSectionCard
+            id="security-controls"
+            title="Security controls"
+            summary="Controls focused on protecting operational evidence and limiting access to need-to-know teams."
+            points={[
+              "Role-based access separates incident operators, managers, and administrators.",
+              "Export activity is recorded with immutable audit events and actor timestamps.",
+              "Production and sandbox tenant data are scoped to prevent cross-environment bleed.",
+            ]}
+          />
+          <TrustSectionCard
+            id="compliance-evidence"
+            title="Compliance evidence"
+            summary="Short-form artifacts that help legal and compliance teams verify readiness and retention posture."
+            points={[
+              "Retention policy summary maps evidence classes to required storage windows.",
+              "Runbook checkpoints define owner and next action for blocked readiness cases.",
+              "Quarterly control attestations are packaged with export readiness reports.",
+            ]}
+          />
+          <TrustSectionCard
+            id="incident-response"
+            title="Incident response"
+            summary="Operational response commitments and escalation mechanics for security-impacting events."
+            points={[
+              "On-call rotation guarantees acknowledgement targets for critical events.",
+              "Post-incident reviews capture corrective actions and ownership deadlines.",
+              "Customer communication templates support timely trust updates.",
+            ]}
+          />
         </section>
       </div>
     </MainLayout>

--- a/frontend/components/reports/ReportSummaryCards.tsx
+++ b/frontend/components/reports/ReportSummaryCards.tsx
@@ -1,4 +1,5 @@
 interface ReportSummaryItem {
+  id: string;
   label: string;
   value: string;
   detail: string;
@@ -23,7 +24,7 @@ export default function ReportSummaryCards({ items }: ReportSummaryCardsProps) {
         const tone = item.tone ?? "neutral";
         return (
           <article
-            key={item.label}
+            key={item.id}
             className={`rounded-lg border bg-surface p-4 shadow-card ${TONE_STYLES[tone]}`}
           >
             <p className="text-xs uppercase tracking-wide text-text-muted">{item.label}</p>

--- a/frontend/components/reports/ReportSummaryCards.tsx
+++ b/frontend/components/reports/ReportSummaryCards.tsx
@@ -1,0 +1,37 @@
+interface ReportSummaryItem {
+  label: string;
+  value: string;
+  detail: string;
+  tone?: "neutral" | "success" | "warning" | "critical";
+}
+
+interface ReportSummaryCardsProps {
+  items: ReportSummaryItem[];
+}
+
+const TONE_STYLES: Record<NonNullable<ReportSummaryItem["tone"]>, string> = {
+  neutral: "border-border-subtle",
+  success: "border-status-success/40",
+  warning: "border-status-warning/40",
+  critical: "border-status-critical/40",
+};
+
+export default function ReportSummaryCards({ items }: ReportSummaryCardsProps) {
+  return (
+    <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      {items.map((item) => {
+        const tone = item.tone ?? "neutral";
+        return (
+          <article
+            key={item.label}
+            className={`rounded-lg border bg-surface p-4 shadow-card ${TONE_STYLES[tone]}`}
+          >
+            <p className="text-xs uppercase tracking-wide text-text-muted">{item.label}</p>
+            <p className="mt-1 text-2xl font-semibold text-text-primary">{item.value}</p>
+            <p className="mt-1 text-sm text-text-secondary">{item.detail}</p>
+          </article>
+        );
+      })}
+    </section>
+  );
+}

--- a/frontend/components/support/HelpArticleCard.tsx
+++ b/frontend/components/support/HelpArticleCard.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+
+export interface HelpArticle {
+  title: string;
+  href: string;
+  description: string;
+  readTime: string;
+  audience: string;
+}
+
+interface HelpArticleCardProps {
+  article: HelpArticle;
+}
+
+export default function HelpArticleCard({ article }: HelpArticleCardProps) {
+  return (
+    <article className="rounded-lg border border-border-subtle bg-surface p-4 shadow-card">
+      <div className="flex flex-wrap gap-2 text-xs">
+        <span className="rounded-full bg-status-info-soft px-2 py-0.5 text-status-info">{article.audience}</span>
+        <span className="rounded-full bg-surface-raised px-2 py-0.5 text-text-muted">{article.readTime}</span>
+      </div>
+      <h3 className="mt-3 text-base font-semibold text-text-primary">
+        <Link href={article.href} className="hover:underline">
+          {article.title}
+        </Link>
+      </h3>
+      <p className="mt-1 text-sm text-text-secondary">{article.description}</p>
+    </article>
+  );
+}

--- a/frontend/components/support/TrustSectionCard.tsx
+++ b/frontend/components/support/TrustSectionCard.tsx
@@ -1,0 +1,23 @@
+interface TrustSectionCardProps {
+  id: string;
+  title: string;
+  summary: string;
+  points: string[];
+}
+
+export default function TrustSectionCard({ id, title, summary, points }: TrustSectionCardProps) {
+  return (
+    <section id={id} className="scroll-mt-24 rounded-lg border border-border-subtle bg-surface p-4 shadow-card">
+      <h3 className="text-base font-semibold text-text-primary">{title}</h3>
+      <p className="mt-1 text-sm text-text-secondary">{summary}</p>
+      <ul className="mt-3 space-y-2 text-sm text-text-secondary">
+        {points.map((point) => (
+          <li key={point} className="flex gap-2">
+            <span aria-hidden className="mt-1 h-2 w-2 rounded-full bg-status-info" />
+            <span>{point}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/components/support/TrustSectionCard.tsx
+++ b/frontend/components/support/TrustSectionCard.tsx
@@ -11,8 +11,8 @@ export default function TrustSectionCard({ id, title, summary, points }: TrustSe
       <h3 className="text-base font-semibold text-text-primary">{title}</h3>
       <p className="mt-1 text-sm text-text-secondary">{summary}</p>
       <ul className="mt-3 space-y-2 text-sm text-text-secondary">
-        {points.map((point) => (
-          <li key={point} className="flex gap-2">
+        {points.map((point, index) => (
+          <li key={`${id}-point-${index}`} className="flex gap-2">
             <span aria-hidden className="mt-1 h-2 w-2 rounded-full bg-status-info" />
             <span>{point}</span>
           </li>


### PR DESCRIPTION
### Motivation
- Align reporting, help, and trust surfaces with the product UI contract to emphasize incident attention, evidence/readiness status, ownership, and clear next actions.
- Replace generic commercial/marketing layouts with operator-focused components and layouts that surface the single clearest next action and status at-a-glance.
- Consolidate repeatable presentation into small, reusable components for summary KPIs, help article cards, and trust section blocks.

### Description
- Refactored pages: replaced previous content with operator-focused layouts in `frontend/app/reports/page.tsx`, `frontend/app/help/page.tsx`, and `frontend/app/trust/page.tsx` implementing tabs, concise summary cards, a primary trend chart and supporting table (reports), category tabs with article lists and a featured/related rail (help), and summary cards plus anchored trust sections and nav (trust).
- Added reusable components: `frontend/components/reports/ReportSummaryCards.tsx`, `frontend/components/support/HelpArticleCard.tsx`, and `frontend/components/support/TrustSectionCard.tsx` for consistent KPI, article, and trust-section rendering.
- Kept copy and structure intentionally concise to improve scannability and operational workflow cues (owner, readiness, next action, blockers).

### Testing
- Ran `npm run lint`; lint completed successfully with one existing warning in `frontend/lib/api/core.ts` reported but no new lint errors introduced.
- Ran `npm run typecheck`; typechecking failed due to a pre-existing TypeScript error in `frontend/lib/api/core.ts` (unrelated to the UI changes).
- Ran `npm test`; all automated tests passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee9e9a36208321aeb558e97129f174)