### PR TITLE
Centralize frontend status mappings and replace ad hoc status logic

### DIFF
--- a/frontend/app/exports/page.tsx
+++ b/frontend/app/exports/page.tsx
@@ -6,6 +6,7 @@ import ExportListItem from "@/components/exports/ExportListItem";
 import { downloadExport, getExport, getExportContents, getExportDownloadHistory, listExports, retryExport, type ExportContentsItem, type ExportDownloadAuditResponse, type ExportListItem as ExportItem, type ExportStatus, type ExportSummary, toUserErrorMessage } from "@/lib/api";
 import { safeOpenDownloadUrl } from "@/lib/safeUrl";
 import { designTokens } from "@/lib/design/tokens";
+import { EXPORT_STATUS_OPTIONS } from "@/lib/status";
 
 export default function ExportsPage() {
   const [exports, setExports] = useState<ExportItem[]>([]);
@@ -144,12 +145,9 @@ export default function ExportsPage() {
           />
           <select className={designTokens.control.input} value={status} onChange={(e) => setStatus(e.target.value as typeof status)}>
             <option value="all">All statuses</option>
-            <option value="requested">Requested</option>
-            <option value="queued">Queued</option>
-            <option value="processing">Processing</option>
-            <option value="ready">Ready</option>
-            <option value="failed">Failed</option>
-            <option value="expired">Expired</option>
+            {EXPORT_STATUS_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
           </select>
         </div>
 

--- a/frontend/app/incidents/page.tsx
+++ b/frontend/app/incidents/page.tsx
@@ -7,7 +7,8 @@ import DocumentationCenter from "@/components/commercial/DocumentationCenter";
 import DataTableShell from "@/components/data-display/DataTableShell";
 import PageHeader from "@/components/layout/PageHeader";
 import { listIncidents, type Incident } from "@/lib/api";
-import { statusBadgeClass, type StatusTone, designTokens } from "@/lib/design/tokens";
+import { statusBadgeClass, designTokens } from "@/lib/design/tokens";
+import { getCaseStatusMeta, getReadinessMeta, READINESS_STATUS_OPTIONS } from "@/lib/status";
 import { useAuth } from "@/lib/useAuth";
 
 type SavedViewKey = "all" | "attention" | "driver_wait" | "ready";
@@ -59,25 +60,6 @@ export default function IncidentsPage() {
       .finally(() => setLoading(false));
   }, [user]);
 
-  function friendlyStatus(s: string): string {
-    if (s === "open") return "Open";
-    if (s === "evidence_capturing") return "Capturing Evidence";
-    if (s === "closed") return "Closed";
-    return s.split("_").map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
-  }
-
-  function statusTone(s: string): StatusTone {
-    if (s === "open") return "info";
-    if (s === "evidence_capturing") return "warning";
-    if (s === "closed") return "success";
-    return "info";
-  }
-
-  function readinessTone(readiness: string): StatusTone {
-    if (["ready_for_export", "exported", "closed"].includes(readiness)) return "success";
-    if (readiness === "not_ready") return "critical";
-    return "warning";
-  }
 
   function formatTime(iso?: string): string {
     if (!iso) return "—";
@@ -270,11 +252,9 @@ export default function IncidentsPage() {
               className="rounded border border-border-default bg-surface px-3 py-2 text-sm"
             >
               <option value="all">Readiness: all</option>
-              <option value="not_ready">Not ready</option>
-              <option value="conditionally_ready">Conditionally ready</option>
-              <option value="ready_for_export">Ready for export</option>
-              <option value="exported">Exported</option>
-              <option value="closed">Closed</option>
+              {READINESS_STATUS_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
             </select>
             <select
               value={filters.evidenceState}
@@ -354,13 +334,13 @@ export default function IncidentsPage() {
                   </td>
                   <td className="px-4 py-3">
                     <div className="flex flex-wrap items-center gap-1.5">
-                      <span className={statusBadgeClass(statusTone(incident.status))}>{friendlyStatus(incident.status)}</span>
+                      <span className={statusBadgeClass(getCaseStatusMeta(incident.status).tone)}>{getCaseStatusMeta(incident.status).label}</span>
                       {waitingOnDriver ? <span className={statusBadgeClass("warning")}>Waiting on driver</span> : null}
                     </div>
                   </td>
                   <td className="px-4 py-3">
-                    <span className={statusBadgeClass(readinessTone(readiness))}>
-                      {readiness.split("_").map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ")}
+                    <span className={statusBadgeClass(getReadinessMeta(readiness).tone)}>
+                      {getReadinessMeta(readiness).label}
                     </span>
                   </td>
                   <td className="px-4 py-3">

--- a/frontend/app/incidents/page.tsx
+++ b/frontend/app/incidents/page.tsx
@@ -8,7 +8,7 @@ import DataTableShell from "@/components/data-display/DataTableShell";
 import PageHeader from "@/components/layout/PageHeader";
 import { listIncidents, type Incident } from "@/lib/api";
 import { statusBadgeClass, designTokens } from "@/lib/design/tokens";
-import { getCaseStatusMeta, getReadinessMeta, READINESS_STATUS_OPTIONS } from "@/lib/status";
+import { getIncidentStatusMeta, getReadinessMeta, READINESS_STATUS_OPTIONS } from "@/lib/status";
 import { useAuth } from "@/lib/useAuth";
 
 type SavedViewKey = "all" | "attention" | "driver_wait" | "ready";
@@ -334,7 +334,7 @@ export default function IncidentsPage() {
                   </td>
                   <td className="px-4 py-3">
                     <div className="flex flex-wrap items-center gap-1.5">
-                      <span className={statusBadgeClass(getCaseStatusMeta(incident.status).tone)}>{getCaseStatusMeta(incident.status).label}</span>
+                      <span className={statusBadgeClass(getIncidentStatusMeta(incident.status).tone)}>{getIncidentStatusMeta(incident.status).label}</span>
                       {waitingOnDriver ? <span className={statusBadgeClass("warning")}>Waiting on driver</span> : null}
                     </div>
                   </td>

--- a/frontend/components/case-ops/IncidentQueueTable.tsx
+++ b/frontend/components/case-ops/IncidentQueueTable.tsx
@@ -130,8 +130,8 @@ export default function IncidentQueueTable({
                       </Link>
                       <div className="text-text-secondary">{item.adc_vehicle_id ?? "—"} / {item.adc_driver_id ?? "—"}</div>
                     </td>
-                    <td className="px-3 py-3 capitalize text-text-primary">{getCaseStatusMeta(item.case_status).label}</td>
-                    <td className="px-3 py-3 capitalize text-text-primary">{getReadinessMeta(item.readiness_state).label}</td>
+                    <td className="px-3 py-3 text-text-primary">{getCaseStatusMeta(item.case_status).label}</td>
+                    <td className="px-3 py-3 text-text-primary">{getReadinessMeta(item.readiness_state).label}</td>
                     <td className="px-3 py-3 font-mono text-xs text-text-primary">{item.owner_user_id ? item.owner_user_id.slice(0, 8) : "Unassigned"}</td>
                     <td className="px-3 py-3 text-text-primary">{item.blockers.critical} critical · {item.blockers.important} important</td>
                     <td className="px-3 py-3 text-text-primary">{Math.round(item.completeness_percent)}%</td>

--- a/frontend/components/case-ops/IncidentQueueTable.tsx
+++ b/frontend/components/case-ops/IncidentQueueTable.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { CaseOpsQueueItem, CaseStatus } from "@/lib/api";
+import { CASE_STATUS_META, getCaseStatusMeta, getReadinessMeta } from "@/lib/status";
 
 type QueueTabKey = "all" | "new" | "in_review" | "awaiting_evidence" | "ready_for_export" | "escalated" | "awaiting_follow_up" | "exported" | "closed";
 
@@ -21,7 +22,7 @@ interface IncidentQueueTableProps {
   onCaseStatusChange: (incidentId: string, caseStatus: CaseStatus) => void;
 }
 
-const STATUSES = [
+const STATUSES: CaseStatus[] = [
   "new",
   "awaiting_evidence",
   "in_review",
@@ -31,10 +32,6 @@ const STATUSES = [
   "exported",
   "closed",
 ];
-
-function statusLabel(value: string) {
-  return value.replaceAll("_", " ");
-}
 
 function getUrgencyTone(item: CaseOpsQueueItem) {
   if (item.blockers.critical > 0 || item.case_status === "escalated") {
@@ -133,8 +130,8 @@ export default function IncidentQueueTable({
                       </Link>
                       <div className="text-text-secondary">{item.adc_vehicle_id ?? "—"} / {item.adc_driver_id ?? "—"}</div>
                     </td>
-                    <td className="px-3 py-3 capitalize text-text-primary">{statusLabel(item.case_status)}</td>
-                    <td className="px-3 py-3 capitalize text-text-primary">{statusLabel(item.readiness_state)}</td>
+                    <td className="px-3 py-3 capitalize text-text-primary">{getCaseStatusMeta(item.case_status).label}</td>
+                    <td className="px-3 py-3 capitalize text-text-primary">{getReadinessMeta(item.readiness_state).label}</td>
                     <td className="px-3 py-3 font-mono text-xs text-text-primary">{item.owner_user_id ? item.owner_user_id.slice(0, 8) : "Unassigned"}</td>
                     <td className="px-3 py-3 text-text-primary">{item.blockers.critical} critical · {item.blockers.important} important</td>
                     <td className="px-3 py-3 text-text-primary">{Math.round(item.completeness_percent)}%</td>
@@ -148,7 +145,7 @@ export default function IncidentQueueTable({
                           className="rounded border border-border-default bg-surface px-2 py-1 text-xs"
                         >
                           {STATUSES.map((status) => (
-                            <option key={status} value={status}>{statusLabel(status)}</option>
+                            <option key={status} value={status}>{CASE_STATUS_META[status].label}</option>
                           ))}
                         </select>
                       </div>

--- a/frontend/components/data-display/EvidenceTable.tsx
+++ b/frontend/components/data-display/EvidenceTable.tsx
@@ -12,6 +12,7 @@
 "use client";
 
 import { type ArtifactSummary } from "@/lib/api";
+import { getEvidenceMeta, getStatusBadgeClass } from "@/lib/status";
 
 // The canonical list of evidence types supported by the platform.  If
 // additional types are added server‑side they should be reflected here
@@ -39,19 +40,6 @@ function formatTime(iso?: string | null): string {
   });
 }
 
-function statusBadge(status: string) {
-  if (status === "captured") return "bg-green-100 text-green-800";
-  if (status === "unavailable") return "bg-red-100 text-red-800";
-  if (status === "pending") return "bg-yellow-100 text-yellow-800";
-  return "bg-gray-100 text-gray-800";
-}
-
-function statusLabel(status: string): string {
-  if (status === "captured") return "Captured";
-  if (status === "unavailable") return "Unavailable";
-  if (status === "pending") return "Pending";
-  return status;
-}
 
 interface EvidenceTableProps {
   artifacts: ArtifactSummary[];
@@ -125,12 +113,8 @@ export default function EvidenceTable({ artifacts }: EvidenceTableProps) {
                   {label}
                 </td>
                 <td className="px-4 py-2">
-                  <span
-                    className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${statusBadge(
-                      status
-                    )}`}
-                  >
-                    {statusLabel(status)}
+                  <span className={getStatusBadgeClass(getEvidenceMeta(status).tone)}>
+                    {getEvidenceMeta(status).label}
                   </span>
                 </td>
                 <td className="px-4 py-2 text-gray-500 dark:text-gray-400">

--- a/frontend/components/data-display/EvidenceTable.tsx
+++ b/frontend/components/data-display/EvidenceTable.tsx
@@ -104,6 +104,7 @@ export default function EvidenceTable({ artifacts }: EvidenceTableProps) {
           {EVIDENCE_TYPES.map(({ type, label }) => {
             const art = artifactMap.get(type);
             const status = art?.status ?? "pending";
+            const evidenceMeta = getEvidenceMeta(status);
             return (
               <tr
                 key={type}
@@ -113,8 +114,8 @@ export default function EvidenceTable({ artifacts }: EvidenceTableProps) {
                   {label}
                 </td>
                 <td className="px-4 py-2">
-                  <span className={getStatusBadgeClass(getEvidenceMeta(status).tone)}>
-                    {getEvidenceMeta(status).label}
+                  <span className={getStatusBadgeClass(evidenceMeta.tone)}>
+                    {evidenceMeta.label}
                   </span>
                 </td>
                 <td className="px-4 py-2 text-gray-500 dark:text-gray-400">

--- a/frontend/components/data-display/ReadinessBadge.tsx
+++ b/frontend/components/data-display/ReadinessBadge.tsx
@@ -1,3 +1,4 @@
+import { getReadinessMeta } from "@/lib/status";
 import StatusChip, { type StatusChipSize } from "./StatusChip";
 
 export type ReadinessStatus = "not_started" | "in_progress" | "ready" | "blocked";
@@ -8,20 +9,7 @@ export interface ReadinessBadgeProps {
   className?: string;
 }
 
-const LABELS: Record<ReadinessStatus, string> = {
-  not_started: "Not started",
-  in_progress: "In progress",
-  ready: "Ready",
-  blocked: "Blocked",
-};
-
-const TONES: Record<ReadinessStatus, "neutral" | "warning" | "success" | "critical"> = {
-  not_started: "neutral",
-  in_progress: "warning",
-  ready: "success",
-  blocked: "critical",
-};
-
 export default function ReadinessBadge({ status, size = "md", className }: ReadinessBadgeProps) {
-  return <StatusChip label={LABELS[status]} tone={TONES[status]} size={size} className={className} />;
+  const meta = getReadinessMeta(status);
+  return <StatusChip label={meta.label} tone={meta.tone} size={size} className={className} />;
 }

--- a/frontend/lib/exportStatus.ts
+++ b/frontend/lib/exportStatus.ts
@@ -1,13 +1,13 @@
 import type { ExportStatus } from "@/lib/api";
-import { statusBadgeClass } from "@/lib/design/tokens";
+import { getExportStateMeta, getStatusBadgeClass } from "@/lib/status";
 
 export const EXPORT_STATUS_LABELS: Record<ExportStatus, string> = {
-  requested: "Requested",
-  queued: "Queued",
-  processing: "Processing",
-  ready: "Ready",
-  failed: "Failed",
-  expired: "Expired",
+  requested: getExportStateMeta("requested").label,
+  queued: getExportStateMeta("queued").label,
+  processing: getExportStateMeta("processing").label,
+  ready: getExportStateMeta("ready").label,
+  failed: getExportStateMeta("failed").label,
+  expired: getExportStateMeta("expired").label,
 };
 
 export function getExportStatusLabel(status: ExportStatus): string {
@@ -15,7 +15,5 @@ export function getExportStatusLabel(status: ExportStatus): string {
 }
 
 export function getExportStatusBadgeClass(status: ExportStatus): string {
-  if (status === "ready") return statusBadgeClass("success");
-  if (status === "failed" || status === "expired") return statusBadgeClass("critical");
-  return statusBadgeClass("warning");
+  return getStatusBadgeClass(getExportStateMeta(status).tone);
 }

--- a/frontend/lib/status/index.ts
+++ b/frontend/lib/status/index.ts
@@ -83,20 +83,20 @@ export const READINESS_STATUS_OPTIONS: StatusOption<ReadinessState>[] = READINES
 }));
 
 export function getCaseStatusMeta(status: string): StatusMeta {
-  if (status in CASE_STATUS_META) return CASE_STATUS_META[status as CaseStatus];
-  if (status in INCIDENT_STATUS_META) return INCIDENT_STATUS_META[status as IncidentStatus];
+  if (Object.prototype.hasOwnProperty.call(CASE_STATUS_META, status)) return CASE_STATUS_META[status as CaseStatus];
+  if (Object.prototype.hasOwnProperty.call(INCIDENT_STATUS_META, status)) return INCIDENT_STATUS_META[status as IncidentStatus];
   if (!status) return UNKNOWN_STATUS_META;
   return { label: titleize(status), tone: "neutral" };
 }
 
 export function getReadinessMeta(state: string): StatusMeta {
-  if (state in READINESS_META) return READINESS_META[state as ReadinessState];
+  if (Object.prototype.hasOwnProperty.call(READINESS_META, state)) return READINESS_META[state as ReadinessState];
   if (!state) return UNKNOWN_STATUS_META;
   return { label: titleize(state), tone: "neutral" };
 }
 
 export function getEvidenceMeta(state: string): StatusMeta {
-  if (state in EVIDENCE_META) return EVIDENCE_META[state as EvidenceState];
+  if (Object.prototype.hasOwnProperty.call(EVIDENCE_META, state)) return EVIDENCE_META[state as EvidenceState];
   if (!state) return UNKNOWN_STATUS_META;
   return { label: titleize(state), tone: "neutral" };
 }

--- a/frontend/lib/status/index.ts
+++ b/frontend/lib/status/index.ts
@@ -1,0 +1,110 @@
+import type { CaseStatus, ExportStatus, IncidentStatus } from "@/lib/api";
+import { statusBadgeClass, type StatusTone } from "@/lib/design/tokens";
+
+export interface StatusMeta {
+  label: string;
+  tone: StatusTone;
+}
+
+export interface StatusOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+const titleize = (value: string): string => value.replaceAll("_", " ").replace(/\b\w/g, (char) => char.toUpperCase());
+
+const UNKNOWN_STATUS_META: StatusMeta = {
+  label: "Unknown",
+  tone: "neutral",
+};
+
+export const CASE_STATUS_META: Record<CaseStatus, StatusMeta> = {
+  new: { label: "New", tone: "info" },
+  in_review: { label: "In review", tone: "warning" },
+  awaiting_evidence: { label: "Awaiting evidence", tone: "warning" },
+  awaiting_follow_up: { label: "Awaiting follow up", tone: "warning" },
+  ready_for_export: { label: "Ready for export", tone: "success" },
+  exported: { label: "Exported", tone: "success" },
+  escalated: { label: "Escalated", tone: "critical" },
+  closed: { label: "Closed", tone: "success" },
+};
+
+export const INCIDENT_STATUS_META: Record<IncidentStatus, StatusMeta> = {
+  open: { label: "Open", tone: "info" },
+  evidence_capturing: { label: "Capturing evidence", tone: "warning" },
+  closed: { label: "Closed", tone: "success" },
+};
+
+const READINESS_META = {
+  not_started: { label: "Not started", tone: "neutral" },
+  in_progress: { label: "In progress", tone: "warning" },
+  blocked: { label: "Blocked", tone: "critical" },
+  ready: { label: "Ready", tone: "success" },
+  not_ready: { label: "Not ready", tone: "critical" },
+  conditionally_ready: { label: "Conditionally ready", tone: "warning" },
+  ready_for_export: { label: "Ready for export", tone: "success" },
+  exported: { label: "Exported", tone: "success" },
+  closed: { label: "Closed", tone: "success" },
+} as const satisfies Record<string, StatusMeta>;
+
+export type ReadinessState = keyof typeof READINESS_META;
+
+const EVIDENCE_META = {
+  missing: { label: "Missing", tone: "critical" },
+  partial: { label: "Partial", tone: "warning" },
+  complete: { label: "Complete", tone: "success" },
+  pending: { label: "Pending", tone: "warning" },
+  captured: { label: "Captured", tone: "success" },
+  unavailable: { label: "Unavailable", tone: "critical" },
+} as const satisfies Record<string, StatusMeta>;
+
+export type EvidenceState = keyof typeof EVIDENCE_META;
+
+export const EXPORT_STATE_META: Record<ExportStatus, StatusMeta> = {
+  requested: { label: "Requested", tone: "warning" },
+  queued: { label: "Queued", tone: "warning" },
+  processing: { label: "Processing", tone: "warning" },
+  ready: { label: "Ready", tone: "success" },
+  failed: { label: "Failed", tone: "critical" },
+  expired: { label: "Expired", tone: "critical" },
+};
+
+const EXPORT_STATUS_VALUES = ["requested", "queued", "processing", "ready", "failed", "expired"] as const;
+const READINESS_STATUS_VALUES = ["not_ready", "conditionally_ready", "ready_for_export", "exported", "closed"] as const;
+
+export const EXPORT_STATUS_OPTIONS: StatusOption<ExportStatus>[] = EXPORT_STATUS_VALUES.map((value) => ({
+  value,
+  label: EXPORT_STATE_META[value].label,
+}));
+
+export const READINESS_STATUS_OPTIONS: StatusOption<ReadinessState>[] = READINESS_STATUS_VALUES.map((value) => ({
+  value,
+  label: READINESS_META[value].label,
+}));
+
+export function getCaseStatusMeta(status: string): StatusMeta {
+  if (status in CASE_STATUS_META) return CASE_STATUS_META[status as CaseStatus];
+  if (status in INCIDENT_STATUS_META) return INCIDENT_STATUS_META[status as IncidentStatus];
+  if (!status) return UNKNOWN_STATUS_META;
+  return { label: titleize(status), tone: "neutral" };
+}
+
+export function getReadinessMeta(state: string): StatusMeta {
+  if (state in READINESS_META) return READINESS_META[state as ReadinessState];
+  if (!state) return UNKNOWN_STATUS_META;
+  return { label: titleize(state), tone: "neutral" };
+}
+
+export function getEvidenceMeta(state: string): StatusMeta {
+  if (state in EVIDENCE_META) return EVIDENCE_META[state as EvidenceState];
+  if (!state) return UNKNOWN_STATUS_META;
+  return { label: titleize(state), tone: "neutral" };
+}
+
+export function getExportStateMeta(state: ExportStatus): StatusMeta {
+  return EXPORT_STATE_META[state];
+}
+
+export function getStatusBadgeClass(tone: StatusTone): string {
+  return statusBadgeClass(tone);
+}

--- a/frontend/lib/status/index.ts
+++ b/frontend/lib/status/index.ts
@@ -82,23 +82,29 @@ export const READINESS_STATUS_OPTIONS: StatusOption<ReadinessState>[] = READINES
   label: READINESS_META[value].label,
 }));
 
-export function getCaseStatusMeta(status: string): StatusMeta {
-  if (Object.prototype.hasOwnProperty.call(CASE_STATUS_META, status)) return CASE_STATUS_META[status as CaseStatus];
-  if (Object.prototype.hasOwnProperty.call(INCIDENT_STATUS_META, status)) return INCIDENT_STATUS_META[status as IncidentStatus];
+function fallbackStatusMeta(status: string): StatusMeta {
   if (!status) return UNKNOWN_STATUS_META;
   return { label: titleize(status), tone: "neutral" };
 }
 
+export function getCaseStatusMeta(status: string): StatusMeta {
+  if (Object.prototype.hasOwnProperty.call(CASE_STATUS_META, status)) return CASE_STATUS_META[status as CaseStatus];
+  return fallbackStatusMeta(status);
+}
+
+export function getIncidentStatusMeta(status: string): StatusMeta {
+  if (Object.prototype.hasOwnProperty.call(INCIDENT_STATUS_META, status)) return INCIDENT_STATUS_META[status as IncidentStatus];
+  return fallbackStatusMeta(status);
+}
+
 export function getReadinessMeta(state: string): StatusMeta {
   if (Object.prototype.hasOwnProperty.call(READINESS_META, state)) return READINESS_META[state as ReadinessState];
-  if (!state) return UNKNOWN_STATUS_META;
-  return { label: titleize(state), tone: "neutral" };
+  return fallbackStatusMeta(state);
 }
 
 export function getEvidenceMeta(state: string): StatusMeta {
   if (Object.prototype.hasOwnProperty.call(EVIDENCE_META, state)) return EVIDENCE_META[state as EvidenceState];
-  if (!state) return UNKNOWN_STATUS_META;
-  return { label: titleize(state), tone: "neutral" };
+  return fallbackStatusMeta(state);
 }
 
 export function getExportStateMeta(state: ExportStatus): StatusMeta {


### PR DESCRIPTION
### Motivation

- Consolidate scattered status labels, tones, and selector options into a single source-of-truth so visual semantics remain consistent across chips, badges, tables, and selectors. 
- Replace per-page ad hoc color/label logic with reusable helpers so components like `StatusChip` and `ReadinessBadge` share identical meanings and styles. 
- Provide selector option lists and badge helpers to reduce duplication and make future changes to status semantics straightforward.

### Description

- Add a centralized status module at `frontend/lib/status/index.ts` that defines metadata for case statuses, incident statuses, readiness states, evidence states, and export states, and exposes `getCaseStatusMeta`, `getReadinessMeta`, `getEvidenceMeta`, `getExportStateMeta`, `getStatusBadgeClass`, plus reusable option lists like `EXPORT_STATUS_OPTIONS` and `READINESS_STATUS_OPTIONS`.
- Wire `ReadinessBadge` to consume `getReadinessMeta` rather than local label/tone maps so it uses the centralized metadata.
- Refactor `frontend/lib/exportStatus.ts` to delegate labels and badge class selection to the new status helpers.
- Replace ad hoc status/readiness label & tone logic and hardcoded selector option lists on pages and table renderers by calling the new helpers in `frontend/app/incidents/page.tsx`, `frontend/app/exports/page.tsx`, `frontend/components/case-ops/IncidentQueueTable.tsx`, and `frontend/components/data-display/EvidenceTable.tsx` so UI views and selectors use consistent labels and tones.

### Testing

- Ran lint with `npm --prefix frontend run lint` which completed successfully with one pre-existing warning in `frontend/lib/api/core.ts` (no new lint errors). 
- Ran unit/JS tests with `npm --prefix frontend run test` and all tests passed (`26` tests, `0` failures). 
- Ran type checking with `npm --prefix frontend run typecheck` which failed due to an existing typing issue in `frontend/lib/api/core.ts` (the `requestValidated` return typing), not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eec5e1e5848321a997100c130c262a)