### PR TITLE
Add NWS time-series client/parser with window validation and tests

### DIFF
--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -157,6 +157,9 @@ class AppSettings(BaseSettings):
     FMCSA_INCIDENT_REFRESH_INTERVAL_HOURS: int = 24
     FMCSA_BASE_URL: str = "https://data.transportation.gov"
 
+    NWS_REQUEST_TIMEOUT_SECONDS: float = 10.0
+    NWS_REQUEST_MAX_RETRIES: int = 2
+
     # API rate limits (per subject/IP sliding windows)
     AUTH_LOGIN_RATE_LIMIT: int = 20
     AUTH_RATE_LIMIT_WINDOW_SECONDS: int = 300

--- a/backend/app/services/weather/nws_client.py
+++ b/backend/app/services/weather/nws_client.py
@@ -1,0 +1,82 @@
+"""NWS time-series query utilities and client."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from urllib.parse import urlencode
+
+import httpx
+
+from app.core.config import settings
+
+BASE_URL = "https://forecast.weather.gov/MapClick.php"
+WEATHER_ELEMENTS = "temp&qpf&snow&wspd&wdir&wgust&wwa&iceaccum&snowlvl&vis"
+
+
+class InvalidWeatherWindowError(ValueError):
+    """Raised when end timestamp occurs before begin timestamp."""
+
+
+@dataclass(frozen=True)
+class NWSQueryWindow:
+    begin: datetime
+    end: datetime
+
+
+def build_time_series_query(
+    *,
+    lat: float,
+    lon: float,
+    begin: datetime,
+    end: datetime,
+    unit: str = "e",
+) -> dict[str, str]:
+    """Build query params for NWS time-series product endpoint."""
+    if end < begin:
+        raise InvalidWeatherWindowError("Weather query end must be greater than or equal to begin")
+
+    return {
+        "lat": f"{lat:.6f}",
+        "lon": f"{lon:.6f}",
+        "product": "time-series",
+        "begin": begin.isoformat(),
+        "end": end.isoformat(),
+        "Unit": unit,
+        "temp": "temp",
+        "qpf": "qpf",
+        "snow": "snow",
+        "wspd": "wspd",
+        "wdir": "wdir",
+        "wgust": "wgust",
+        "wwa": "wwa",
+        "iceaccum": "iceaccum",
+        "snowlvl": "snowlvl",
+        "vis": "vis",
+    }
+
+
+def build_time_series_url(*, lat: float, lon: float, begin: datetime, end: datetime) -> str:
+    """Build full URL for the NWS time-series request."""
+    params = build_time_series_query(lat=lat, lon=lon, begin=begin, end=end)
+    return f"{BASE_URL}?{urlencode(params)}"
+
+
+def fetch_nws_time_series_xml(*, lat: float, lon: float, begin: datetime, end: datetime) -> str:
+    """Fetch NWS time-series XML using configured timeout/retry values."""
+    timeout_seconds = float(getattr(settings, "NWS_REQUEST_TIMEOUT_SECONDS", 10.0))
+    max_retries = int(getattr(settings, "NWS_REQUEST_MAX_RETRIES", 2))
+    params = build_time_series_query(lat=lat, lon=lon, begin=begin, end=end)
+
+    last_error: Exception | None = None
+    for _attempt in range(max_retries + 1):
+        try:
+            with httpx.Client(timeout=timeout_seconds) as client:
+                response = client.get(BASE_URL, params=params)
+                response.raise_for_status()
+                return response.text
+        except (httpx.TimeoutException, httpx.HTTPError) as exc:
+            last_error = exc
+
+    assert last_error is not None
+    raise last_error

--- a/backend/app/services/weather/nws_parser.py
+++ b/backend/app/services/weather/nws_parser.py
@@ -1,0 +1,46 @@
+"""Parser for NWS XML payloads into normalized weather data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from xml.etree import ElementTree
+
+FIELDS = ("temp", "qpf", "snow", "wspd", "wdir", "wgust", "wwa", "iceaccum", "snowlvl", "vis")
+
+
+@dataclass(frozen=True)
+class WeatherField:
+    values: list[str]
+    present: bool
+
+
+def _extract_values(root: ElementTree.Element, field: str) -> list[str]:
+    values: list[str] = []
+    for node in root.findall(f".//{field}"):
+        if node.text and node.text.strip():
+            values.append(node.text.strip())
+        for value_node in node.findall(".//value"):
+            if value_node.text and value_node.text.strip():
+                values.append(value_node.text.strip())
+    return values
+
+
+def parse_nws_time_series_xml(payload: str) -> dict[str, object]:
+    """Return normalized weather payload plus explicit missing field metadata."""
+    root = ElementTree.fromstring(payload)
+
+    weather: dict[str, WeatherField] = {}
+    missing_fields: list[str] = []
+    for field in FIELDS:
+        values = _extract_values(root, field)
+        is_present = bool(values)
+        weather[field] = WeatherField(values=values, present=is_present)
+        if not is_present:
+            missing_fields.append(field)
+
+    normalized = {
+        "weather": {name: {"values": field.values, "present": field.present} for name, field in weather.items()},
+        "missing_fields": missing_fields,
+        "is_partial": bool(missing_fields),
+    }
+    return normalized

--- a/backend/tests/services/test_nws_client.py
+++ b/backend/tests/services/test_nws_client.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.services.weather.nws_client import InvalidWeatherWindowError, build_time_series_query
+
+
+def test_build_time_series_query_option_b_window() -> None:
+    incident_time = datetime(2026, 1, 2, 12, 0, tzinfo=timezone.utc)
+    begin = incident_time - timedelta(hours=1)
+    end = incident_time + timedelta(hours=1)
+
+    params = build_time_series_query(lat=40.7128, lon=-74.006, begin=begin, end=end)
+
+    assert params["begin"] == begin.isoformat()
+    assert params["end"] == end.isoformat()
+
+
+def test_build_time_series_query_includes_required_params() -> None:
+    begin = datetime(2026, 1, 2, 11, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 1, 2, 13, 0, tzinfo=timezone.utc)
+
+    params = build_time_series_query(lat=40.0, lon=-70.0, begin=begin, end=end)
+
+    assert params["product"] == "time-series"
+    assert params["Unit"] == "e"
+    for key in ("temp", "qpf", "snow", "wspd", "wdir", "wgust", "wwa", "iceaccum", "snowlvl", "vis"):
+        assert params[key] == key
+
+
+def test_build_time_series_query_invalid_window_guard() -> None:
+    begin = datetime(2026, 1, 2, 13, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 1, 2, 11, 0, tzinfo=timezone.utc)
+
+    with pytest.raises(InvalidWeatherWindowError):
+        build_time_series_query(lat=1.0, lon=1.0, begin=begin, end=end)

--- a/backend/tests/services/test_nws_parser.py
+++ b/backend/tests/services/test_nws_parser.py
@@ -1,0 +1,24 @@
+from app.services.weather.nws_parser import parse_nws_time_series_xml
+
+
+def test_parse_nws_time_series_xml_partial_fields() -> None:
+    xml_payload = """
+    <dwml>
+      <data>
+        <parameters>
+          <temp><value>72</value></temp>
+          <qpf><value>0.1</value></qpf>
+          <wspd><value>14</value></wspd>
+        </parameters>
+      </data>
+    </dwml>
+    """
+
+    parsed = parse_nws_time_series_xml(xml_payload)
+
+    assert parsed["weather"]["temp"]["present"] is True
+    assert parsed["weather"]["temp"]["values"] == ["72"]
+    assert parsed["weather"]["qpf"]["present"] is True
+    assert parsed["weather"]["snow"]["present"] is False
+    assert "snow" in parsed["missing_fields"]
+    assert parsed["is_partial"] is True


### PR DESCRIPTION
### Motivation
- Provide a reusable client to fetch NWS `product=time-series` weather snapshots for incident windows. 
- Ensure invalid time windows are caught early with a clear domain error rather than making a bad request. 
- Return normalized weather data even when upstream XML is incomplete and explicitly surface which fields are missing. 

### Description
- Added `backend/app/services/weather/nws_client.py` implementing a `time-series` query builder, `build_time_series_url`, `fetch_nws_time_series_xml`, and `InvalidWeatherWindowError` for `end < begin` validation. 
- Fetch logic uses `httpx` and honors config-driven timeout/retry values (`NWS_REQUEST_TIMEOUT_SECONDS`, `NWS_REQUEST_MAX_RETRIES`) added to `backend/app/config/settings.py`. 
- Added `backend/app/services/weather/nws_parser.py` that parses NWS XML into a normalized payload with per-field `values` and `present` metadata plus top-level `missing_fields` and `is_partial`. 
- Added unit tests `backend/tests/services/test_nws_client.py` and `backend/tests/services/test_nws_parser.py` covering the Option B window, required params/elements, invalid-window guard, and partial-XML behavior. 

### Testing
- Ran lint checks via `ruff check app tests` and they passed. 
- Ran unit tests `pytest tests/services/test_nws_client.py tests/services/test_nws_parser.py -v` and all tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6e58d32c832195b4c08710462901)