### PR TITLE
Add optional weather snapshot fields to incident detail contract

### DIFF
--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -38,8 +38,8 @@ from app.db.repo.fmcsa_inspections import (
 from app.db.repo.incidents import create_incident, get_incident, list_incidents
 from app.db.repo.message_operations import get_messaging_reliability_summary
 from app.db.session import get_db
-from app.domain.system_event_types import SystemEventType
 from app.domain.packet_profiles import get_default_packet_profile
+from app.domain.system_event_types import SystemEventType
 from app.tasks.export_tasks import build_export
 from app.services.idempotency_service import (
     optional_idempotency_key,
@@ -88,6 +88,54 @@ def _is_privileged_status_target(to_status: str) -> bool:
 def _has_privileged_status_permission(role: str | None) -> bool:
     return role in {"org_admin", "system_admin"}
 
+
+
+
+def _resolve_weather_snapshot_state(*, events: list) -> tuple[dict | None, str | None, str | None]:
+    weather_events = [
+        ev
+        for ev in events
+        if ev.event_type
+        in {
+            SystemEventType.WEATHER_SNAPSHOT_CAPTURED.value,
+            SystemEventType.WEATHER_SNAPSHOT_FAILED.value,
+        }
+    ]
+    if not weather_events:
+        return None, None, None
+
+    latest_event = sorted(weather_events, key=lambda ev: ev.occurred_at_utc or datetime.min)[-1]
+    payload = latest_event.payload or {}
+    location_source = None
+    if isinstance(payload, dict):
+        location_source = (payload.get("location") or {}).get("source")
+
+    if latest_event.event_type == SystemEventType.WEATHER_SNAPSHOT_CAPTURED.value:
+        return {
+            "capture_status": payload.get("capture_status"),
+            "normalized_weather": payload.get("normalized_weather") or {},
+            "raw_source_metadata": payload.get("raw_source_metadata") or {},
+        }, payload.get("capture_status"), location_source
+
+    return None, payload.get("capture_status") or "failed", location_source
+
+
+def _resolve_weather_map_artifact(*, artifacts: list, events: list):
+    map_artifact = next((a for a in artifacts if a.artifact_type == "weather_map_snapshot"), None)
+    if map_artifact is None:
+        return None
+    terminal_types = {
+        SystemEventType.WEATHER_MAP_SNAPSHOT_CAPTURED.value,
+        SystemEventType.WEATHER_MAP_SNAPSHOT_FAILED.value,
+    }
+    has_weather_map_event = any(ev.event_type in terminal_types for ev in events)
+    if not has_weather_map_event:
+        return None
+    return {
+        "artifact_id": map_artifact.artifact_id,
+        "artifact_type": map_artifact.artifact_type,
+        "status": map_artifact.status,
+    }
 
 def _event_context_payload(
     *,
@@ -303,6 +351,8 @@ def get_incident_endpoint(
         for link, insp in violation_history_rows
     ]
     violation_history_meta = get_fmcsa_meta_for_incident(db, incident_id)
+    weather_conditions, weather_status, weather_location_source = _resolve_weather_snapshot_state(events=events)
+    weather_map_artifact = _resolve_weather_map_artifact(artifacts=artifacts, events=events)
 
     return IncidentDetailResponse(
         incident_id=incident.incident_id,
@@ -403,6 +453,10 @@ def get_incident_endpoint(
         ],
         driver_violation_history=violation_history,
         driver_violation_history_meta=violation_history_meta,
+        current_weather_conditions=weather_conditions,
+        weather_snapshot_status=weather_status,
+        weather_location_source=weather_location_source,
+        weather_satellite_snapshot_artifact=weather_map_artifact,
     )
 
 

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -392,6 +392,20 @@ class IncidentListItem(BaseModel):
     blocker_counts: dict[str, int] = Field(default_factory=dict)
 
 
+
+
+class WeatherSnapshotArtifactReference(BaseModel):
+    artifact_id: uuid.UUID
+    artifact_type: str
+    status: str
+
+
+class CurrentWeatherConditions(BaseModel):
+    capture_status: Optional[str] = None
+    normalized_weather: dict[str, Any] = Field(default_factory=dict)
+    raw_source_metadata: dict[str, Any] = Field(default_factory=dict)
+
+
 class IncidentDetailResponse(BaseModel):
     incident_id: uuid.UUID
     status: IncidentStatus
@@ -413,6 +427,10 @@ class IncidentDetailResponse(BaseModel):
         default_factory=list
     )
     driver_violation_history_meta: dict[str, Any] = Field(default_factory=dict)
+    current_weather_conditions: Optional[CurrentWeatherConditions] = None
+    weather_snapshot_status: Optional[str] = None
+    weather_location_source: Optional[str] = None
+    weather_satellite_snapshot_artifact: Optional[WeatherSnapshotArtifactReference] = None
 
 
 class FmcsaInspectionSummary(BaseModel):

--- a/backend/tests/test_frontend_contracts.py
+++ b/backend/tests/test_frontend_contracts.py
@@ -220,3 +220,29 @@ def test_export_response_contract_matches_frontend(
     assert payload["export_type"] == "court_defense"
     assert payload["status"] in {"requested", "queued", "processing", "ready", "failed", "expired"}
     assert isinstance(payload["created_at_utc"], str)
+
+
+@patch("app.api.routes_incidents.IncidentEvidenceOrchestrator.begin_capture")
+def test_incident_detail_weather_fields_are_backward_compatible(
+    mock_begin_capture,
+    client: TestClient,
+    auth_headers: dict[str, str],
+):
+    create_resp = client.post(
+        "/incidents/",
+        json={
+            "severity": "minor",
+            "adc_vehicle_id": "veh-abc",
+            "samsara_vehicle_id": "sm-def",
+            "adc_driver_id": "drv-ghi",
+        },
+        headers=auth_headers,
+    )
+    incident_id = create_resp.json()["incident_id"]
+    detail = client.get(f"/incidents/{incident_id}", headers=auth_headers).json()
+
+    assert "current_weather_conditions" in detail
+    assert detail["current_weather_conditions"] is None
+    assert detail["weather_snapshot_status"] is None
+    assert detail["weather_location_source"] is None
+    assert detail["weather_satellite_snapshot_artifact"] is None

--- a/contracts/schemas/runtime_api_contracts.json
+++ b/contracts/schemas/runtime_api_contracts.json
@@ -471,6 +471,34 @@
           "title": "ArtifactSummary",
           "type": "object"
         },
+        "CurrentWeatherConditions": {
+          "properties": {
+            "capture_status": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Capture Status"
+            },
+            "normalized_weather": {
+              "additionalProperties": true,
+              "title": "Normalized Weather",
+              "type": "object"
+            },
+            "raw_source_metadata": {
+              "additionalProperties": true,
+              "title": "Raw Source Metadata",
+              "type": "object"
+            }
+          },
+          "title": "CurrentWeatherConditions",
+          "type": "object"
+        },
         "EventSummary": {
           "properties": {
             "actor_type": {
@@ -874,6 +902,30 @@
           ],
           "title": "FmcsaInspectionSummary",
           "type": "object"
+        },
+        "WeatherSnapshotArtifactReference": {
+          "properties": {
+            "artifact_id": {
+              "format": "uuid",
+              "title": "Artifact Id",
+              "type": "string"
+            },
+            "artifact_type": {
+              "title": "Artifact Type",
+              "type": "string"
+            },
+            "status": {
+              "title": "Status",
+              "type": "string"
+            }
+          },
+          "required": [
+            "artifact_id",
+            "artifact_type",
+            "status"
+          ],
+          "title": "WeatherSnapshotArtifactReference",
+          "type": "object"
         }
       },
       "properties": {
@@ -946,6 +998,17 @@
           ],
           "default": null,
           "title": "Created At Utc"
+        },
+        "current_weather_conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CurrentWeatherConditions"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "driver_violation_history": {
           "items": {
@@ -1037,6 +1100,41 @@
           },
           "title": "Timeline",
           "type": "array"
+        },
+        "weather_location_source": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Weather Location Source"
+        },
+        "weather_satellite_snapshot_artifact": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WeatherSnapshotArtifactReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "weather_snapshot_status": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Weather Snapshot Status"
         }
       },
       "required": [

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -242,12 +242,30 @@ export interface IncidentBlocker {
   severity: BlockerSeverity;
 }
 
+
+
+export interface CurrentWeatherConditions {
+  capture_status?: string | null;
+  normalized_weather?: JsonObject;
+  raw_source_metadata?: JsonObject;
+}
+
+export interface WeatherSnapshotArtifactReference {
+  artifact_id: string;
+  artifact_type: string;
+  status: string;
+}
+
 export interface IncidentDetail extends Incident {
   evidence_inventory: ArtifactSummary[];
   export_status: ExportSummary[];
   timeline: EventSummary[];
   completeness_missing_items?: string[];
   blockers?: IncidentBlocker[];
+  current_weather_conditions?: CurrentWeatherConditions | null;
+  weather_snapshot_status?: string | null;
+  weather_location_source?: string | null;
+  weather_satellite_snapshot_artifact?: WeatherSnapshotArtifactReference | null;
 }
 
 export type OnboardingStepStatus =


### PR DESCRIPTION
### Motivation
- Surface per-incident weather snapshot metadata in the incident detail response while preserving backward compatibility by keeping the new fields optional and defaulting them to null when absent.
- Derive weather state from existing weather snapshot lifecycle events and weather-map artifact state so the API exposes current weather capture status without changing upstream capture behavior.
- Keep the frontend type contract in sync so TypeScript consumers can safely read the new fields when present.

### Description
- Extended backend schema `IncidentDetailResponse` with `current_weather_conditions`, `weather_snapshot_status`, `weather_location_source`, and `weather_satellite_snapshot_artifact`, and added `CurrentWeatherConditions` and `WeatherSnapshotArtifactReference` models (`backend/app/api/schemas.py`).
- Implemented helpers `_resolve_weather_snapshot_state` and `_resolve_weather_map_artifact` and populated the new fields in the incident detail assembly in `get_incident_endpoint` by inspecting terminal weather events and map artifacts (`backend/app/api/routes_incidents.py`).
- Updated the frontend API contract mirror with `CurrentWeatherConditions` and `WeatherSnapshotArtifactReference` interfaces and added the new optional fields on `IncidentDetail` (`frontend/lib/api/types.ts`).
- Added a contract test `test_incident_detail_weather_fields_are_backward_compatible` to assert the new fields are present and null when weather snapshots are absent (`backend/tests/test_frontend_contracts.py`).

### Testing
- Ran `ruff check app tests` which completed successfully for the modified files.
- Ran `mypy app` which reported unrelated pre-existing typing errors in `app/services/weather/map_snapshot_service.py` that were not introduced by these changes.
- Ran `pytest tests/test_frontend_contracts.py tests/test_api_endpoints.py -q` and observed all tests pass (88 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b4e3f6688321afa5d0ab35eb09b8)