### PR TITLE
Add weather snapshot panel with degraded-state handling on incident detail

### DIFF
--- a/frontend/app/incidents/[id]/IncidentDetailClient.tsx
+++ b/frontend/app/incidents/[id]/IncidentDetailClient.tsx
@@ -54,6 +54,11 @@ function formatWeatherValue(value: unknown): string {
   if (typeof value === "number") return Number.isFinite(value) ? value.toString() : "—";
   if (typeof value === "boolean") return value ? "Yes" : "No";
   if (typeof value === "string") return value.trim().length > 0 ? value : "—";
+  if (Array.isArray(value)) {
+    const rendered = value.map((item) => formatWeatherValue(item)).filter((item) => item !== "—");
+    return rendered.length > 0 ? rendered.join(", ") : "—";
+  }
+  if (typeof value === "object") return "—";
   return String(value);
 }
 
@@ -160,11 +165,15 @@ export default function IncidentDetailClient() {
   const workspaceActivity = workspace?.activity ?? [];
   const weatherConditions = incident?.current_weather_conditions;
   const weatherMetrics = toWeatherMetrics(weatherConditions?.normalized_weather);
-  const weatherSource = weatherConditions?.raw_source_metadata?.source;
-  const weatherCapturedAt = weatherConditions?.raw_source_metadata?.captured_at_utc;
+  const weatherSource = weatherConditions?.location?.source;
+  const weatherCapturedAt = incident?.timeline
+    ?.filter((event) => event.event_type === "weather_snapshot_captured")
+    .map((event) => event.occurred_at_utc)
+    .reverse()
+    .find((occurredAt): occurredAt is string => typeof occurredAt === "string" && occurredAt.length > 0) ?? null;
   const weatherLocationSource = incident?.weather_location_source;
   const isLocationUnavailable = weatherLocationSource === "unavailable";
-  const isUsingLastKnownLocation = weatherLocationSource === "last_known";
+  const isUsingLastKnownLocation = weatherLocationSource === "eld_last_known";
   const isWeatherUnavailable = weatherConditions?.capture_status === "unavailable" || weatherMetrics.length === 0;
 
   const nextAction = workspaceMissingItems.length > 0

--- a/frontend/app/incidents/[id]/IncidentDetailClient.tsx
+++ b/frontend/app/incidents/[id]/IncidentDetailClient.tsx
@@ -49,6 +49,25 @@ function formatTime(iso?: string | null): string {
   });
 }
 
+function formatWeatherValue(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "number") return Number.isFinite(value) ? value.toString() : "—";
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (typeof value === "string") return value.trim().length > 0 ? value : "—";
+  return String(value);
+}
+
+function toWeatherMetrics(weather: unknown): Array<{ key: string; value: string }> {
+  if (!weather || typeof weather !== "object" || Array.isArray(weather)) return [];
+
+  return Object.entries(weather)
+    .filter(([key]) => key.trim().length > 0)
+    .map(([key, value]) => ({
+      key: key.replaceAll("_", " "),
+      value: formatWeatherValue(value),
+    }));
+}
+
 const REFRESH_INTERVAL_MS = 4000;
 
 export default function IncidentDetailClient() {
@@ -139,6 +158,14 @@ export default function IncidentDetailClient() {
   const workspaceMissingItems = workspace?.missing_items ?? incident?.completeness_missing_items ?? [];
   const workspaceEvidence = workspace?.evidence_summary;
   const workspaceActivity = workspace?.activity ?? [];
+  const weatherConditions = incident?.current_weather_conditions;
+  const weatherMetrics = toWeatherMetrics(weatherConditions?.normalized_weather);
+  const weatherSource = weatherConditions?.raw_source_metadata?.source;
+  const weatherCapturedAt = weatherConditions?.raw_source_metadata?.captured_at_utc;
+  const weatherLocationSource = incident?.weather_location_source;
+  const isLocationUnavailable = weatherLocationSource === "unavailable";
+  const isUsingLastKnownLocation = weatherLocationSource === "last_known";
+  const isWeatherUnavailable = weatherConditions?.capture_status === "unavailable" || weatherMetrics.length === 0;
 
   const nextAction = workspaceMissingItems.length > 0
     ? `Collect ${workspaceMissingItems[0]} to unblock readiness.`
@@ -281,6 +308,29 @@ export default function IncidentDetailClient() {
               <CaseTasksPanel tasks={tasks} onAddTask={onAddTask} onCompleteTask={onCompleteTask} />
               <CaseNotesPanel notes={notes} onAddNote={onAddNote} />
             </div>
+
+            <section className="rounded-lg border bg-white p-6 shadow-sm">
+              <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-600">Weather snapshot</h2>
+              <div className="space-y-3 text-sm">
+                {isUsingLastKnownLocation ? <p className="text-amber-700">Using last known location</p> : null}
+                {isLocationUnavailable ? <p className="text-amber-700">Location unavailable</p> : null}
+                {isWeatherUnavailable ? <p className="text-gray-500">Weather data unavailable</p> : null}
+
+                {weatherMetrics.length > 0 ? (
+                  <dl className="grid gap-2 sm:grid-cols-2">
+                    {weatherMetrics.map((metric) => (
+                      <div key={metric.key} className="rounded border border-gray-100 bg-gray-50 px-3 py-2">
+                        <dt className="text-xs uppercase tracking-wide text-gray-500">{metric.key}</dt>
+                        <dd className="text-sm font-medium text-gray-900">{metric.value}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                ) : null}
+
+                <p className="text-xs text-gray-500">Source: {formatWeatherValue(weatherSource)}</p>
+                <p className="text-xs text-gray-500">Captured: {formatTime(typeof weatherCapturedAt === "string" ? weatherCapturedAt : null)}</p>
+              </div>
+            </section>
 
             <div className="rounded-lg border bg-white p-6 shadow-sm">
               <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-600">Evidence inventory</h2>

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -248,6 +248,7 @@ export interface CurrentWeatherConditions {
   capture_status?: string | null;
   normalized_weather?: JsonObject;
   raw_source_metadata?: JsonObject;
+  location?: JsonObject;
 }
 
 export interface WeatherSnapshotArtifactReference {

--- a/frontend/tests/incidentDetailWeatherPanel.test.mjs
+++ b/frontend/tests/incidentDetailWeatherPanel.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const incidentDetailClient = readFileSync(new URL('../app/incidents/[id]/IncidentDetailClient.tsx', import.meta.url), 'utf8');
+
+test('incident detail renders dedicated weather snapshot panel before evidence inventory', () => {
+  const weatherPanelIndex = incidentDetailClient.indexOf('Weather snapshot');
+  const evidenceInventoryIndex = incidentDetailClient.indexOf('Evidence inventory');
+  assert.ok(weatherPanelIndex >= 0, 'weather panel heading should exist');
+  assert.ok(evidenceInventoryIndex >= 0, 'evidence inventory heading should exist');
+  assert.ok(weatherPanelIndex < evidenceInventoryIndex, 'weather panel should appear before evidence inventory');
+});
+
+test('incident detail weather panel includes degraded-state messaging', () => {
+  assert.match(incidentDetailClient, /Using last known location/);
+  assert.match(incidentDetailClient, /Location unavailable/);
+  assert.match(incidentDetailClient, /Weather data unavailable/);
+});
+
+test('incident detail weather panel renders normalized metrics and attribution defensively', () => {
+  assert.match(incidentDetailClient, /toWeatherMetrics\(weatherConditions\?\.normalized_weather\)/);
+  assert.match(incidentDetailClient, /Source: \{formatWeatherValue\(weatherSource\)\}/);
+  assert.match(incidentDetailClient, /Captured: \{formatTime\(typeof weatherCapturedAt === "string" \? weatherCapturedAt : null\)\}/);
+  assert.match(incidentDetailClient, /weatherMetrics\.length === 0/);
+});


### PR DESCRIPTION
### Motivation
- Surface weather context for incidents by adding a dedicated snapshot panel above the evidence/artifact area so operators can quickly see normalized metrics, source attribution, and capture time.
- Provide clear degraded-state messaging when location or weather data are partial or missing to avoid confusion during triage.
- Prevent runtime errors from optional/missing weather fields by normalizing and defensively rendering incoming weather payloads.

### Description
- Added two helpers, `formatWeatherValue` and `toWeatherMetrics`, to normalize optional weather values and transform `normalized_weather` into displayable key/value pairs.
- Derived weather fields from the incident detail using safe optional chaining (`incident?.current_weather_conditions`, `incident?.weather_location_source`) and added booleans to drive degraded-state messaging (`Using last known location`, `Location unavailable`, `Weather data unavailable`).
- Inserted a new `Weather snapshot` section in `IncidentDetailClient` (rendered before the Evidence inventory) that defensively renders metrics, a `Source` attribution, and a captured timestamp using `formatTime`.
- Added unit-style page tests in `frontend/tests/incidentDetailWeatherPanel.test.mjs` that assert panel placement, presence of degraded messaging, and usage of the defensive rendering helpers.

### Testing
- Frontend lint: `cd frontend && npm run lint` completed successfully.
- Frontend typecheck: `cd frontend && npm run typecheck` completed successfully with no TypeScript errors.
- Frontend tests: `cd frontend && npm run test` ran and all frontend tests passed (37 passed, 0 failed).
- Backend checks: `ruff` lint run and `pytest` executed successfully (`ruff check` passed; `pytest` reported 845 passed, 1 skipped).
- Note: repo-root `make lint` was not used because it fails due to an unrelated Makefile syntax issue (`Makefile:41: *** missing separator.`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e015a1bc83219e647cf4386e4bbe)