### PR TITLE
Add NWS fixtures, extend NWS tests, and strengthen duplicate-initiation regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Type check (mypy critical modules)
         run: mypy --ignore-missing-imports app/core/config.py app/services/schema_validate.py
 
+      - name: Targeted weather/initiation regression tests
+        run: pytest tests/services/test_nws_client.py tests/services/test_nws_parser.py tests/test_incident_location_resolver.py tests/test_driver_admin_endpoints.py -v
+
       - name: Tests (pytest)
         run: pytest tests/ -v
 

--- a/backend/tests/fixtures/nws/time_series_full.xml
+++ b/backend/tests/fixtures/nws/time_series_full.xml
@@ -1,0 +1,16 @@
+<dwml>
+  <data>
+    <parameters>
+      <temp><value>72</value><value>73</value></temp>
+      <qpf><value>0.1</value></qpf>
+      <snow><value>0.0</value></snow>
+      <wspd><value>14</value></wspd>
+      <wdir><value>180</value></wdir>
+      <wgust><value>24</value></wgust>
+      <wwa><value>NONE</value></wwa>
+      <iceaccum><value>0.0</value></iceaccum>
+      <snowlvl><value>0</value></snowlvl>
+      <vis><value>10</value></vis>
+    </parameters>
+  </data>
+</dwml>

--- a/backend/tests/fixtures/nws/time_series_malformed.xml
+++ b/backend/tests/fixtures/nws/time_series_malformed.xml
@@ -1,0 +1,6 @@
+<dwml>
+  <data>
+    <parameters>
+      <temp><value>72</value></temp>
+      <qpf><value>0.1</value></qpf>
+    <!-- malformed: missing closing tags on purpose -->

--- a/backend/tests/fixtures/nws/time_series_partial.xml
+++ b/backend/tests/fixtures/nws/time_series_partial.xml
@@ -1,0 +1,9 @@
+<dwml>
+  <data>
+    <parameters>
+      <temp><value>72</value></temp>
+      <qpf><value>0.1</value></qpf>
+      <wspd><value>14</value></wspd>
+    </parameters>
+  </data>
+</dwml>

--- a/backend/tests/services/test_nws_client.py
+++ b/backend/tests/services/test_nws_client.py
@@ -22,15 +22,26 @@ def test_build_time_series_query_includes_required_params() -> None:
 
     params = build_time_series_query(lat=40.0, lon=-70.0, begin=begin, end=end)
 
+    assert params["lat"] == "40.000000"
+    assert params["lon"] == "-70.000000"
     assert params["product"] == "time-series"
     assert params["Unit"] == "e"
     for key in ("temp", "qpf", "snow", "wspd", "wdir", "wgust", "wwa", "iceaccum", "snowlvl", "vis"):
         assert params[key] == key
 
 
+def test_build_time_series_query_accepts_equal_window() -> None:
+    begin = datetime(2026, 1, 2, 13, 0, tzinfo=timezone.utc)
+    end = begin
+
+    params = build_time_series_query(lat=1.0, lon=1.0, begin=begin, end=end)
+
+    assert params["begin"] == params["end"]
+
+
 def test_build_time_series_query_invalid_window_guard() -> None:
     begin = datetime(2026, 1, 2, 13, 0, tzinfo=timezone.utc)
     end = datetime(2026, 1, 2, 11, 0, tzinfo=timezone.utc)
 
-    with pytest.raises(InvalidWeatherWindowError):
+    with pytest.raises(InvalidWeatherWindowError, match="greater than or equal"):
         build_time_series_query(lat=1.0, lon=1.0, begin=begin, end=end)

--- a/backend/tests/services/test_nws_parser.py
+++ b/backend/tests/services/test_nws_parser.py
@@ -1,20 +1,27 @@
+from pathlib import Path
+
+import pytest
+
 from app.services.weather.nws_parser import parse_nws_time_series_xml
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "nws"
+
+
+def _read_fixture(name: str) -> str:
+    return (_FIXTURES / name).read_text(encoding="utf-8")
+
+
+def test_parse_nws_time_series_xml_full_fields() -> None:
+    parsed = parse_nws_time_series_xml(_read_fixture("time_series_full.xml"))
+
+    assert parsed["is_partial"] is False
+    assert parsed["missing_fields"] == []
+    assert parsed["weather"]["temp"]["values"] == ["72", "73"]
+    assert parsed["weather"]["vis"]["present"] is True
 
 
 def test_parse_nws_time_series_xml_partial_fields() -> None:
-    xml_payload = """
-    <dwml>
-      <data>
-        <parameters>
-          <temp><value>72</value></temp>
-          <qpf><value>0.1</value></qpf>
-          <wspd><value>14</value></wspd>
-        </parameters>
-      </data>
-    </dwml>
-    """
-
-    parsed = parse_nws_time_series_xml(xml_payload)
+    parsed = parse_nws_time_series_xml(_read_fixture("time_series_partial.xml"))
 
     assert parsed["weather"]["temp"]["present"] is True
     assert parsed["weather"]["temp"]["values"] == ["72"]
@@ -22,3 +29,8 @@ def test_parse_nws_time_series_xml_partial_fields() -> None:
     assert parsed["weather"]["snow"]["present"] is False
     assert "snow" in parsed["missing_fields"]
     assert parsed["is_partial"] is True
+
+
+def test_parse_nws_time_series_xml_malformed_payload_raises_parse_error() -> None:
+    with pytest.raises(Exception):
+        parse_nws_time_series_xml(_read_fixture("time_series_malformed.xml"))

--- a/backend/tests/test_driver_admin_endpoints.py
+++ b/backend/tests/test_driver_admin_endpoints.py
@@ -502,6 +502,13 @@ class TestDriverInitiate:
         assert len(initiated_events) == 1
         assert initiated_events[0].payload["idempotency_key"] == "idem-001"
 
+        lockdown_events = (
+            db_session.query(Event)
+            .filter(Event.event_type == "evidence_lockdown_started")
+            .all()
+        )
+        assert len(lockdown_events) == 1
+
         mock_dash.delay.assert_called_once()
         mock_tele.delay.assert_called_once()
         mock_notify_manager.delay.assert_called_once()


### PR DESCRIPTION
### Motivation
- Improve coverage and robustness for NWS time-series handling (query building + XML parsing) including full, partial and malformed payloads.
- Ensure incident initiation idempotency is strictly enforced by tests that verify exactly-once protocol and lockdown events on idempotent retries.
- Make sure these weather/initiation regression paths are explicitly exercised by CI so regressions are caught early.

### Description
- Added XML fixtures `backend/tests/fixtures/nws/time_series_full.xml`, `time_series_partial.xml`, and `time_series_malformed.xml` and updated the NWS parser tests to load and verify them.
- Extended `backend/tests/services/test_nws_client.py` to assert required query params, Option B `begin`/`end` behavior, acceptance of equal windows (`end == begin`), and the `end < begin` guard.
- Updated `backend/tests/services/test_nws_parser.py` to validate full-field normalization, partial-field detection and that malformed XML raises a parse error.
- Extended `backend/tests/test_driver_admin_endpoints.py` duplicate-initiation test to assert a single `incident_protocol_initiated` and a single `evidence_lockdown_started` event on idempotent retries.
- Updated CI backend job (`.github/workflows/ci.yml`) to run targeted weather/initiation regression tests before the full backend test suite.

### Testing
- Ran linter: `ruff check app/ tests/` and it passed.
- Ran type checks: `mypy --ignore-missing-imports app/core/config.py app/services/schema_validate.py` and it reported no issues for the checked files.
- Ran the targeted regression suite: `pytest tests/services/test_nws_client.py tests/services/test_nws_parser.py tests/test_incident_location_resolver.py tests/test_driver_admin_endpoints.py -v` and those tests passed (collected targeted tests and all passed).
- Ran the full backend test suite: `pytest tests/ -q` and the run completed successfully with `848 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f00e059a883218aab51f2a29c046d)