### PR TITLE
Add JWT invalid token coverage

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,5 +1,6 @@
 """Tests for auth endpoints and helpers."""
 
+import jwt
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -84,9 +85,28 @@ class TestJWT:
     def test_invalid_token_returns_none(self):
         assert decode_access_token("not.a.token") is None
 
+    def test_token_signed_with_wrong_secret_returns_none(self):
+        token = jwt.encode(
+            {"sub": "user-123"},
+            "not-the-configured-secret",
+            algorithm=settings.JWT_ALGORITHM,
+        )
+
+        assert decode_access_token(token) is None
+
+    def test_token_with_unexpected_algorithm_returns_none(self):
+        token = jwt.encode(
+            {"sub": "user-123"},
+            settings.JWT_SECRET_KEY,
+            algorithm="HS384",
+        )
+
+        assert decode_access_token(token) is None
+
     def test_token_contains_exp(self):
         token = create_access_token({"sub": "u1"})
         payload = decode_access_token(token)
+        assert payload is not None
         assert "exp" in payload
         assert "iat" in payload
 


### PR DESCRIPTION
### Motivation
- Ensure `decode_access_token` behavior is exercised for a wider set of invalid JWT cases (malformed, wrong secret, unexpected algorithm) to prevent token validation regressions.
- Confirm the code already catches PyJWT’s invalid-token base exception (`InvalidTokenError`) so tests can assert expected `None` behavior.

### Description
- Added `import jwt` to `backend/tests/test_auth.py` to create tokens with alternate secrets/algorithms for negative tests.
- Added tests `test_token_signed_with_wrong_secret_returns_none` and `test_token_with_unexpected_algorithm_returns_none` to cover wrong-secret and unexpected-algorithm cases.
- Strengthened `test_token_contains_exp` with a non-null assertion on the decoded payload before checking `exp`/`iat`.
- No functional change was required in `backend/app/core/security.py` because it already imports `InvalidTokenError` and catches it in `decode_access_token`.

### Testing
- Ran targeted pytest for the modified areas with `PYTHONPATH=/tmp/pyjwt-only:backend pytest backend/tests/test_auth.py backend/tests/test_production_hardening_suite.py` and all selected tests passed (31 passed, 27 warnings).
- Ran linter with `ruff check backend/app backend/tests` which reported no issues for the modified files.
- Ran focused type-checking with `mypy --config-file backend/mypy.ini backend/app/core/security.py backend/tests/test_auth.py` which passed for the targeted files, while full-project `mypy` remains blocked by pre-existing unrelated typing errors elsewhere in the codebase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20d67628ac83218ed48e6a44185ca4)