### PR TITLE
Import InvalidTokenError from PyJWT exceptions

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 
 import bcrypt
 import jwt
-from jwt import InvalidTokenError
+from jwt.exceptions import InvalidTokenError
 
 from app.core.config import settings
 


### PR DESCRIPTION
### Motivation
- Use PyJWT's explicit exception namespace so JWT error handling uses the correct import path and avoids version-dependent `ImportError` behavior.

### Description
- Replace `from jwt import InvalidTokenError` with `from jwt.exceptions import InvalidTokenError` in `backend/app/core/security.py` and confirm `PyJWT[crypto]` remains in `backend/requirements.txt` and there are no `python-jose`/`jose` references.

### Testing
- Ran `rg -n "python-jose|from jose|import jose|jose\." .` (no matches), `rg -n "PyJWT|import jwt|from jwt" backend` (expected backend references), and `python -m ruff check backend` (passed), while `python -m pip install -r backend/requirements.txt` failed to fetch `PyJWT` due to a package index `403 Forbidden`, `cd backend && python -m mypy app tests` reported unrelated existing type errors, and `cd backend && python -m pytest` failed during collection because `PyJWT` was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20da99cce48321a8c1274d8c0229fd)