### PR TITLE
Add driver scope to legacy OTP tokens and regression test

### DIFF
--- a/backend/app/api/routes_driver.py
+++ b/backend/app/api/routes_driver.py
@@ -282,7 +282,9 @@ def verify_driver_otp(body: DriverOtpVerifyRequest, db: Session = Depends(get_db
             detail="Driver not found",
         )
 
-    token = create_access_token({"sub": str(driver.driver_id), "role": "driver"})
+    token = create_access_token(
+        {"sub": str(driver.driver_id), "role": "driver", "scope": "driver"}
+    )
     return DriverOtpVerifyResponse(access_token=token)
 
 

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -1323,7 +1323,7 @@ class DriverOtpVerifyRequest(BaseModel):
 
 class DriverOtpVerifyResponse(BaseModel):
     access_token: Annotated[str, StringConstraints(min_length=16)]
-    refresh_token: Annotated[str, StringConstraints(min_length=16)]
+    refresh_token: Annotated[str, StringConstraints(min_length=16)] | None = None
     token_type: Literal["bearer"] = "bearer"
 
 

--- a/backend/tests/test_driver_auth_endpoints.py
+++ b/backend/tests/test_driver_auth_endpoints.py
@@ -1,5 +1,6 @@
 """Tests for driver auth OTP endpoints."""
 from datetime import datetime, timedelta, timezone
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -8,7 +9,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from app.api import routes_driver_auth
+from app.api import routes_driver, routes_driver_auth
+from app.core.security import decode_access_token
 from app.db.models import Base, Driver, MessageOperation, Org, OtpChallenge
 from app.db.session import get_db
 from app.main import app
@@ -64,7 +66,7 @@ def driver(db_session):
 
 @pytest.fixture(autouse=True)
 def reset_rate_limits():
-    routes_driver_auth._redis_client = FakeRedisRateLimiter()
+    routes_driver_auth._redis_client = cast(Any, FakeRedisRateLimiter())
     routes_driver_auth._rate_limit_script_sha = None
     yield
     routes_driver_auth._redis_client = None
@@ -128,6 +130,38 @@ def test_driver_otp_flow(client, db_session, driver):
         )
         assert me_resp.status_code == 200
         assert me_resp.json()["phone_e164"] == driver.phone_e164
+
+
+def test_legacy_driver_otp_token_accesses_driver_route(client, db_session, driver):
+    otp_code = "123456"
+    challenge = OtpChallenge(
+        phone_e164=driver.phone_e164,
+        otp_code_hash=routes_driver._hash_otp_code(otp_code),
+        status="pending",
+        expires_at_utc=datetime.now(timezone.utc) + timedelta(minutes=5),
+    )
+    db_session.add(challenge)
+    db_session.commit()
+
+    verify_resp = client.post(
+        "/driver/legacy/auth/verify-otp",
+        json={"phone_e164": driver.phone_e164, "otp_code": otp_code},
+    )
+
+    assert verify_resp.status_code == 200
+    token = verify_resp.json()["access_token"]
+    payload = decode_access_token(token)
+    assert payload is not None
+    assert payload["sub"] == str(driver.driver_id)
+    assert payload["role"] == "driver"
+    assert payload["scope"] == "driver"
+
+    me_resp = client.get(
+        "/driver/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert me_resp.status_code == 200
+    assert me_resp.json()["driver_id"] == str(driver.driver_id)
 
 
 def test_driver_otp_rejects_invalid_code(client, driver):


### PR DESCRIPTION
### Motivation
- The legacy OTP verification endpoint issued access tokens without a `scope` claim, which prevents `get_current_driver` (which requires `payload["scope"] == "driver"`) from accepting those tokens.
- Ensure backward-compatible behavior by preserving existing claims required by clients while aligning legacy tokens with the newer auth flow.

### Description
- Add the `scope: "driver"` claim to tokens created in `backend/app/api/routes_driver.py` for the legacy OTP verify flow so they satisfy `get_current_driver` expectations.
- Change `DriverOtpVerifyResponse` in `backend/app/api/schemas.py` to allow `refresh_token` to be omitted (`refresh_token: ... | None = None`) so legacy responses that only return an access token still validate.
- Add `test_legacy_driver_otp_token_accesses_driver_route` to `backend/tests/test_driver_auth_endpoints.py` which creates a legacy OTP challenge, verifies it via `/driver/legacy/auth/verify-otp`, asserts the issued token contains `sub`, `role`, and `scope`, and then uses it to call `/driver/me` (protected by `get_current_driver`).
- Make the fake Redis rate-limiter injection in the test type-checkable by casting it to `Any` in the fixture to satisfy `mypy`.

### Testing
- Ran `python -m ruff check backend` and it passed.
- Ran targeted type checks `python -m mypy backend/app/api/routes_driver.py backend/app/api/schemas.py backend/tests/test_driver_auth_endpoints.py` and they passed.
- Running full `python -m mypy backend/app tests` reported unrelated existing type errors outside the scope of this change and therefore did not pass.
- Attempted to run `pytest` for the affected tests with `cd backend && pytest tests/test_driver_auth_endpoints.py tests/test_driver_auth.py`, but test collection failed due to a missing `PyJWT` dependency in the environment (`ModuleNotFoundError: No module named 'jwt'`).
- Attempted to install requirements with `python -m pip install -r backend/requirements.txt`, but the `PyJWT` package download was blocked by the package index returning `403 Forbidden`, preventing running the full test suite in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20dcb64b8c83218f71e434508eff82)