### PR TITLE
Add targeted weather and initiation regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: mypy --ignore-missing-imports app/core/config.py app/services/schema_validate.py
 
       - name: Targeted weather/initiation regression tests
-        run: pytest tests/services/test_nws_client.py tests/services/test_nws_parser.py tests/test_incident_location_resolver.py tests/test_driver_admin_endpoints.py -v
+        run: pytest tests/services/test_nws_client.py tests/services/test_nws_parser.py tests/services/test_weather_snapshot_service.py tests/test_incident_location_resolver.py tests/test_incident_workflow_service.py tests/test_api_endpoints.py::TestDriverIncidentInitiationDuplicateBehavior tests/test_driver_admin_endpoints.py -v
 
       - name: Tests (pytest)
         run: pytest tests/ -v

--- a/backend/tests/services/test_nws_client.py
+++ b/backend/tests/services/test_nws_client.py
@@ -2,7 +2,11 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from app.services.weather.nws_client import InvalidWeatherWindowError, build_time_series_query
+from app.services.weather.nws_client import (
+    InvalidWeatherWindowError,
+    WEATHER_ELEMENTS,
+    build_time_series_query,
+)
 
 
 def test_build_time_series_query_option_b_window() -> None:
@@ -14,6 +18,7 @@ def test_build_time_series_query_option_b_window() -> None:
 
     assert params["begin"] == begin.isoformat()
     assert params["end"] == end.isoformat()
+    assert end - begin == timedelta(hours=2)
 
 
 def test_build_time_series_query_includes_required_params() -> None:
@@ -26,7 +31,17 @@ def test_build_time_series_query_includes_required_params() -> None:
     assert params["lon"] == "-70.000000"
     assert params["product"] == "time-series"
     assert params["Unit"] == "e"
-    for key in ("temp", "qpf", "snow", "wspd", "wdir", "wgust", "wwa", "iceaccum", "snowlvl", "vis"):
+    weather_keys = tuple(WEATHER_ELEMENTS.split("&"))
+    assert set(params) == {
+        "lat",
+        "lon",
+        "product",
+        "begin",
+        "end",
+        "Unit",
+        *weather_keys,
+    }
+    for key in weather_keys:
         assert params[key] == key
 
 

--- a/backend/tests/services/test_nws_parser.py
+++ b/backend/tests/services/test_nws_parser.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 
 import pytest
+from xml.etree.ElementTree import ParseError
 
-from app.services.weather.nws_parser import parse_nws_time_series_xml
+from app.services.weather.nws_parser import FIELDS, parse_nws_time_series_xml
 
 _FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "nws"
 
@@ -16,21 +17,31 @@ def test_parse_nws_time_series_xml_full_fields() -> None:
 
     assert parsed["is_partial"] is False
     assert parsed["missing_fields"] == []
-    assert parsed["weather"]["temp"]["values"] == ["72", "73"]
-    assert parsed["weather"]["vis"]["present"] is True
+    assert set(parsed["weather"].keys()) == set(FIELDS)
+    assert all(field["present"] is True for field in parsed["weather"].values())
+    assert parsed["weather"]["temp"] == {"values": ["72", "73"], "present": True}
+    assert parsed["weather"]["vis"] == {"values": ["10"], "present": True}
 
 
 def test_parse_nws_time_series_xml_partial_fields() -> None:
     parsed = parse_nws_time_series_xml(_read_fixture("time_series_partial.xml"))
 
-    assert parsed["weather"]["temp"]["present"] is True
-    assert parsed["weather"]["temp"]["values"] == ["72"]
-    assert parsed["weather"]["qpf"]["present"] is True
-    assert parsed["weather"]["snow"]["present"] is False
-    assert "snow" in parsed["missing_fields"]
+    assert set(parsed["weather"].keys()) == set(FIELDS)
+    assert parsed["weather"]["temp"] == {"values": ["72"], "present": True}
+    assert parsed["weather"]["qpf"] == {"values": ["0.1"], "present": True}
+    assert parsed["weather"]["snow"] == {"values": [], "present": False}
+    assert parsed["missing_fields"] == [
+        "snow",
+        "wdir",
+        "wgust",
+        "wwa",
+        "iceaccum",
+        "snowlvl",
+        "vis",
+    ]
     assert parsed["is_partial"] is True
 
 
 def test_parse_nws_time_series_xml_malformed_payload_raises_parse_error() -> None:
-    with pytest.raises(Exception):
+    with pytest.raises(ParseError):
         parse_nws_time_series_xml(_read_fixture("time_series_malformed.xml"))

--- a/backend/tests/services/test_weather_snapshot_service.py
+++ b/backend/tests/services/test_weather_snapshot_service.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db.models import Base, Event, Incident, Org
+from app.services.weather_snapshot_service import capture_weather_snapshot_if_missing
+
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine, expire_on_commit=False)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def incident(db_session):
+    org = Org(name="Weather Org")
+    db_session.add(org)
+    db_session.commit()
+    db_session.refresh(org)
+
+    record = Incident(org_id=org.id, status="open")
+    db_session.add(record)
+    db_session.commit()
+    db_session.refresh(record)
+    return record
+
+
+def _window() -> tuple[datetime, datetime]:
+    return (
+        datetime(2026, 1, 2, 11, 0, tzinfo=timezone.utc),
+        datetime(2026, 1, 2, 13, 0, tzinfo=timezone.utc),
+    )
+
+
+def _event_payloads(db_session, incident: Incident) -> list[dict]:
+    events = (
+        db_session.query(Event)
+        .filter(Event.incident_id == incident.incident_id)
+        .order_by(Event.created_at_utc)
+        .all()
+    )
+    return [event.payload for event in events]
+
+
+def test_capture_weather_snapshot_persists_location_source_and_degraded_partial_payload(
+    db_session,
+    incident,
+    monkeypatch,
+):
+    begin, end = _window()
+
+    monkeypatch.setattr(
+        "app.services.weather_snapshot_service.resolve_incident_location",
+        lambda *args, **kwargs: {
+            "lat": 40.0,
+            "lon": -74.0,
+            "source": "eld_last_known",
+            "fallback_reason": None,
+        },
+    )
+    monkeypatch.setattr(
+        "app.services.weather_snapshot_service.fetch_nws_time_series_xml",
+        lambda **kwargs: (
+            "<dwml><data><parameters><temp><value>72</value></temp></parameters></data></dwml>"
+        ),
+    )
+
+    capture_weather_snapshot_if_missing(
+        db_session,
+        incident=incident,
+        request_window_start=begin,
+        request_window_end=end,
+    )
+
+    payloads = _event_payloads(db_session, incident)
+    assert payloads[0]["location"] == {
+        "lat": 40.0,
+        "lon": -74.0,
+        "source": "eld_last_known",
+        "fallback_reason": None,
+    }
+    captured = payloads[1]
+    assert captured["capture_status"] == "degraded"
+    assert captured["degraded"] is True
+    assert captured["normalized_weather"]["weather"]["temp"] == {
+        "values": ["72"],
+        "present": True,
+    }
+    assert "qpf" in captured["normalized_weather"]["missing_fields"]
+
+
+def test_capture_weather_snapshot_external_fetch_failure_is_non_blocking(
+    db_session,
+    incident,
+    monkeypatch,
+):
+    begin, end = _window()
+    monkeypatch.setattr(
+        "app.services.weather_snapshot_service.resolve_incident_location",
+        lambda *args, **kwargs: {
+            "lat": 40.0,
+            "lon": -74.0,
+            "source": "device_location",
+            "fallback_reason": None,
+        },
+    )
+    monkeypatch.setattr(
+        "app.services.weather_snapshot_service.fetch_nws_time_series_xml",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("nws down")),
+    )
+
+    capture_weather_snapshot_if_missing(
+        db_session,
+        incident=incident,
+        request_window_start=begin,
+        request_window_end=end,
+    )
+
+    events = (
+        db_session.query(Event).filter(Event.incident_id == incident.incident_id).all()
+    )
+    assert [event.event_type for event in events] == [
+        "weather_snapshot_requested",
+        "weather_snapshot_failed",
+    ]
+    assert events[1].payload["reason"] == "RuntimeError"
+    assert events[1].payload["degraded"] is False
+
+
+def test_capture_weather_snapshot_skips_duplicate_terminal_event(
+    db_session,
+    incident,
+    monkeypatch,
+):
+    begin, end = _window()
+    fetch_calls = {"count": 0}
+
+    monkeypatch.setattr(
+        "app.services.weather_snapshot_service.resolve_incident_location",
+        lambda *args, **kwargs: {
+            "lat": 40.0,
+            "lon": -74.0,
+            "source": "device_location",
+            "fallback_reason": None,
+        },
+    )
+
+    def fake_fetch(**kwargs):
+        fetch_calls["count"] += 1
+        return "<dwml><data><parameters><temp><value>72</value></temp></parameters></data></dwml>"
+
+    monkeypatch.setattr(
+        "app.services.weather_snapshot_service.fetch_nws_time_series_xml", fake_fetch
+    )
+
+    capture_weather_snapshot_if_missing(
+        db_session,
+        incident=incident,
+        request_window_start=begin,
+        request_window_end=end,
+    )
+    capture_weather_snapshot_if_missing(
+        db_session,
+        incident=incident,
+        request_window_start=begin,
+        request_window_end=end,
+    )
+
+    assert fetch_calls["count"] == 1
+    assert (
+        db_session.query(Event)
+        .filter(Event.incident_id == incident.incident_id)
+        .count()
+        == 2
+    )

--- a/backend/tests/services/test_weather_snapshot_service.py
+++ b/backend/tests/services/test_weather_snapshot_service.py
@@ -47,14 +47,13 @@ def _window() -> tuple[datetime, datetime]:
     )
 
 
-def _event_payloads(db_session, incident: Incident) -> list[dict]:
+def _event_payloads_by_type(db_session, incident: Incident) -> dict[str, dict]:
     events = (
         db_session.query(Event)
         .filter(Event.incident_id == incident.incident_id)
-        .order_by(Event.created_at_utc)
         .all()
     )
-    return [event.payload for event in events]
+    return {event.event_type: event.payload for event in events}
 
 
 def test_capture_weather_snapshot_persists_location_source_and_degraded_partial_payload(
@@ -87,14 +86,14 @@ def test_capture_weather_snapshot_persists_location_source_and_degraded_partial_
         request_window_end=end,
     )
 
-    payloads = _event_payloads(db_session, incident)
-    assert payloads[0]["location"] == {
+    payloads_by_type = _event_payloads_by_type(db_session, incident)
+    assert payloads_by_type["weather_snapshot_requested"]["location"] == {
         "lat": 40.0,
         "lon": -74.0,
         "source": "eld_last_known",
         "fallback_reason": None,
     }
-    captured = payloads[1]
+    captured = payloads_by_type["weather_snapshot_captured"]
     assert captured["capture_status"] == "degraded"
     assert captured["degraded"] is True
     assert captured["normalized_weather"]["weather"]["temp"] == {

--- a/backend/tests/services/test_weather_snapshot_service.py
+++ b/backend/tests/services/test_weather_snapshot_service.py
@@ -130,15 +130,14 @@ def test_capture_weather_snapshot_external_fetch_failure_is_non_blocking(
         request_window_end=end,
     )
 
-    events = (
-        db_session.query(Event).filter(Event.incident_id == incident.incident_id).all()
-    )
-    assert [event.event_type for event in events] == [
+    payloads_by_type = _event_payloads_by_type(db_session, incident)
+    assert set(payloads_by_type) == {
         "weather_snapshot_requested",
         "weather_snapshot_failed",
-    ]
-    assert events[1].payload["reason"] == "RuntimeError"
-    assert events[1].payload["degraded"] is False
+    }
+    failed = payloads_by_type["weather_snapshot_failed"]
+    assert failed["reason"] == "RuntimeError"
+    assert failed["degraded"] is False
 
 
 def test_capture_weather_snapshot_skips_duplicate_terminal_event(

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -477,7 +477,10 @@ class TestIntegrationDiagnosticsRoutes:
             row.event_type
             for row in db_session.query(AuditEvent).filter(
                 AuditEvent.event_type.in_(
-                    ["onboarding_test_run_created", "onboarding_test_run_step_completed"]
+                    [
+                        "onboarding_test_run_created",
+                        "onboarding_test_run_step_completed",
+                    ]
                 )
             )
         }
@@ -531,7 +534,9 @@ class TestIntegrationDiagnosticsRoutes:
         success = client.post("/org/onboarding/export-check", headers=auth_headers)
         assert success.status_code == 200
         step = next(
-            item for item in success.json()["steps"] if item["key"] == "export_validation"
+            item
+            for item in success.json()["steps"]
+            if item["key"] == "export_validation"
         )
         assert step["status"] == "completed"
         latest = success.json()["latest_export_validation"]
@@ -644,7 +649,9 @@ class TestIntegrationDiagnosticsRoutes:
         refreshed = client.get("/org/onboarding/status", headers=auth_headers)
         assert refreshed.status_code == 200
         driver_protocol_step = next(
-            item for item in refreshed.json()["steps"] if item["key"] == "driver_protocol"
+            item
+            for item in refreshed.json()["steps"]
+            if item["key"] == "driver_protocol"
         )
         assert driver_protocol_step["status"] == "completed"
 
@@ -1407,6 +1414,85 @@ class TestPatchIncidentOwner:
         assert response.json()["detail"] == "Owner user not found"
 
 
+class TestDriverIncidentInitiationDuplicateBehavior:
+    @patch("app.api.routes_driver.notify_safety_manager")
+    @patch("app.api.routes_driver.capture_telematics_bundle")
+    @patch("app.api.routes_driver.capture_dashcam")
+    @patch("app.api.routes_driver.capture_weather_map_snapshot")
+    @patch("app.api.routes_driver.capture_weather_snapshot")
+    def test_duplicate_driver_initiation_dispatches_core_capture_once(
+        self,
+        mock_weather,
+        mock_weather_map,
+        mock_dash,
+        mock_tele,
+        mock_notify_manager,
+        client,
+        db_session,
+        test_org,
+    ):
+        driver = Driver(
+            org_id=test_org.id,
+            phone_e164="+15555550100",
+            display_name="Endpoint Driver",
+        )
+        db_session.add(driver)
+        db_session.commit()
+        db_session.refresh(driver)
+        db_session.add(
+            DriverVehicleAssignment(
+                org_id=test_org.id,
+                driver_id=driver.driver_id,
+                adc_vehicle_id="veh-endpoint-1",
+                source="manual",
+            )
+        )
+        db_session.commit()
+
+        driver_headers = {
+            "Authorization": f"Bearer {create_access_token({'sub': str(driver.driver_id), 'scope': 'driver'})}",
+            "Idempotency-Key": "endpoint-duplicate-key",
+        }
+        mock_weather.delay = MagicMock()
+        mock_weather_map.delay = MagicMock()
+        mock_dash.delay = MagicMock()
+        mock_tele.delay = MagicMock()
+        mock_notify_manager.delay = MagicMock()
+
+        first = client.post(
+            "/driver/incidents/initiate",
+            json={"vehicle_strategy": "last_assigned"},
+            headers=driver_headers,
+        )
+        second = client.post(
+            "/driver/incidents/initiate",
+            json={"vehicle_strategy": "last_assigned"},
+            headers=driver_headers,
+        )
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.json()["incident_id"] == second.json()["incident_id"]
+        assert first.json()["capture_started"] is True
+        assert second.json()["capture_started"] is False
+        mock_dash.delay.assert_called_once()
+        mock_tele.delay.assert_called_once()
+        mock_notify_manager.delay.assert_called_once()
+
+        initiated_events = (
+            db_session.query(Event)
+            .filter(Event.event_type == "incident_protocol_initiated")
+            .all()
+        )
+        lockdown_events = (
+            db_session.query(Event)
+            .filter(Event.event_type == "evidence_lockdown_started")
+            .all()
+        )
+        assert len(initiated_events) == 1
+        assert len(lockdown_events) == 1
+
+
 # ── GET /incidents (list) ───────────────────────────────────────────
 
 
@@ -1453,7 +1539,9 @@ class TestListIncidents:
     def test_list_incidents_excludes_test_incidents_by_default(
         self, client, db_session, test_org, auth_headers
     ):
-        operational = Incident(org_id=test_org.id, status="open", is_test_incident=False)
+        operational = Incident(
+            org_id=test_org.id, status="open", is_test_incident=False
+        )
         test_run = Incident(org_id=test_org.id, status="open", is_test_incident=True)
         db_session.add_all([operational, test_run])
         db_session.commit()

--- a/backend/tests/test_incident_location_resolver.py
+++ b/backend/tests/test_incident_location_resolver.py
@@ -20,6 +20,20 @@ class _Provider:
         return self._state_rows
 
 
+class _RecordingProvider:
+    def __init__(self, gps_rows, state_rows):
+        self._gps_rows = gps_rows
+        self._state_rows = state_rows
+        self.calls = []
+
+    def fetch_gps_window(self, start=None, end=None):
+        self.calls.append(("gps", start, end))
+        return self._gps_rows
+
+    def fetch_vehicle_state(self, start=None, end=None):
+        self.calls.append(("state", start, end))
+        return self._state_rows
+
 
 def _db_session():
     engine = create_engine("sqlite:///:memory:")
@@ -56,7 +70,9 @@ def test_prefers_device_location(monkeypatch):
     monkeypatch.setattr(
         resolver,
         "get_telematics_provider",
-        lambda: _Provider(gps_rows=[{"vehicleId": "veh-1", "lat": 1, "lon": 2}], state_rows=[]),
+        lambda: _Provider(
+            gps_rows=[{"vehicleId": "veh-1", "lat": 1, "lon": 2}], state_rows=[]
+        ),
     )
 
     result = resolver.resolve_incident_location(db, incident_id=incident.incident_id)
@@ -74,7 +90,10 @@ def test_falls_back_to_eld_current(monkeypatch):
     monkeypatch.setattr(
         resolver,
         "get_telematics_provider",
-        lambda: _Provider(gps_rows=[{"vehicleId": "veh-1", "latitude": 33.1, "longitude": -97.2}], state_rows=[]),
+        lambda: _Provider(
+            gps_rows=[{"vehicleId": "veh-1", "latitude": 33.1, "longitude": -97.2}],
+            state_rows=[],
+        ),
     )
 
     result = resolver.resolve_incident_location(db, incident_id=incident.incident_id)
@@ -90,7 +109,9 @@ def test_falls_back_to_last_known(monkeypatch):
     monkeypatch.setattr(
         resolver,
         "get_telematics_provider",
-        lambda: _Provider(gps_rows=[], state_rows=[{"vehicleId": "veh-1", "lat": 44.0, "lon": -88.0}]),
+        lambda: _Provider(
+            gps_rows=[], state_rows=[{"vehicleId": "veh-1", "lat": 44.0, "lon": -88.0}]
+        ),
     )
 
     result = resolver.resolve_incident_location(db, incident_id=incident.incident_id)
@@ -102,7 +123,11 @@ def test_falls_back_to_last_known(monkeypatch):
 def test_returns_unavailable_sentinel(monkeypatch):
     db = _db_session()
     incident = _incident(db)
-    monkeypatch.setattr(resolver, "get_telematics_provider", lambda: _Provider(gps_rows=[], state_rows=[]))
+    monkeypatch.setattr(
+        resolver,
+        "get_telematics_provider",
+        lambda: _Provider(gps_rows=[], state_rows=[]),
+    )
 
     result = resolver.resolve_incident_location(db, incident_id=incident.incident_id)
     assert result == {
@@ -119,7 +144,10 @@ def test_does_not_match_telematics_rows_without_incident_vehicle_ids(monkeypatch
     monkeypatch.setattr(
         resolver,
         "get_telematics_provider",
-        lambda: _Provider(gps_rows=[{"vehicleId": "veh-999", "lat": 40.0, "lon": -74.0}], state_rows=[]),
+        lambda: _Provider(
+            gps_rows=[{"vehicleId": "veh-999", "lat": 40.0, "lon": -74.0}],
+            state_rows=[],
+        ),
     )
 
     result = resolver.resolve_incident_location(db, incident_id=incident.incident_id)
@@ -129,3 +157,39 @@ def test_does_not_match_telematics_rows_without_incident_vehicle_ids(monkeypatch
         "source": "unavailable",
         "fallback_reason": "no_location_available",
     }
+
+
+def test_telematics_fallback_order_uses_current_before_last_known(monkeypatch):
+    db = _db_session()
+    incident = _incident(db)
+    provider = _RecordingProvider(
+        gps_rows=[{"vehicleId": "veh-999", "lat": 1, "lon": 2}],
+        state_rows=[{"vehicleId": "veh-1", "lat": 44.0, "lon": -88.0}],
+    )
+    monkeypatch.setattr(resolver, "get_telematics_provider", lambda: provider)
+
+    result = resolver.resolve_incident_location(db, incident_id=incident.incident_id)
+
+    assert result == {
+        "lat": 44.0,
+        "lon": -88.0,
+        "source": "eld_last_known",
+        "fallback_reason": None,
+    }
+    assert [call[0] for call in provider.calls] == ["gps", "state"]
+
+
+def test_incident_not_found_returns_unavailable_without_provider_call(monkeypatch):
+    db = _db_session()
+    provider = _RecordingProvider(gps_rows=[], state_rows=[])
+    monkeypatch.setattr(resolver, "get_telematics_provider", lambda: provider)
+
+    result = resolver.resolve_incident_location(db, incident_id=uuid.uuid4())
+
+    assert result == {
+        "lat": None,
+        "lon": None,
+        "source": "unavailable",
+        "fallback_reason": "incident_not_found",
+    }
+    assert provider.calls == []

--- a/backend/tests/test_incident_workflow_service.py
+++ b/backend/tests/test_incident_workflow_service.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db.models import Base, Event, Incident, Org
+from app.domain.system_event_types import SystemEventType
+from app.services.incident_workflow_service import initiate_driver_incident
+
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine, expire_on_commit=False)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def org(db_session):
+    record = Org(name="Workflow Org")
+    db_session.add(record)
+    db_session.commit()
+    db_session.refresh(record)
+    return record
+
+
+def _initiate(
+    db_session, org: Org, driver_id: uuid.UUID, *, idempotency_key: str | None
+):
+    return initiate_driver_incident(
+        db_session,
+        org_id=org.id,
+        driver_id=driver_id,
+        adc_vehicle_id="veh-100",
+        vehicle_strategy="last_assigned",
+        device_location={"lat": 40.0, "lon": -74.0},
+        device={"platform": "ios"},
+        idempotency_key=idempotency_key,
+    )
+
+
+def _events(db_session, incident: Incident, event_type: SystemEventType) -> list[Event]:
+    return (
+        db_session.query(Event)
+        .filter(
+            Event.incident_id == incident.incident_id,
+            Event.event_type == event_type.value,
+        )
+        .all()
+    )
+
+
+def test_initiate_driver_incident_writes_protocol_and_lockdown_exactly_once_for_retry(
+    db_session,
+    org,
+):
+    driver_id = uuid.uuid4()
+
+    first = _initiate(db_session, org, driver_id, idempotency_key="retry-key")
+    second = _initiate(db_session, org, driver_id, idempotency_key="retry-key")
+
+    assert first.protocol_already_started is False
+    assert second.protocol_already_started is True
+    assert first.incident.incident_id == second.incident.incident_id
+    assert db_session.query(Incident).count() == 1
+
+    protocol_events = _events(
+        db_session,
+        first.incident,
+        SystemEventType.INCIDENT_PROTOCOL_INITIATED,
+    )
+    lockdown_events = _events(
+        db_session,
+        first.incident,
+        SystemEventType.EVIDENCE_LOCKDOWN_STARTED,
+    )
+    assert len(protocol_events) == 1
+    assert len(lockdown_events) == 1
+    assert protocol_events[0].payload["idempotency_key"] == "retry-key"
+    assert protocol_events[0].payload["idempotency_key_hash"]
+
+
+def test_initiate_driver_incident_does_not_duplicate_with_new_key_after_protocol_started(
+    db_session,
+    org,
+):
+    driver_id = uuid.uuid4()
+
+    first = _initiate(db_session, org, driver_id, idempotency_key="original-key")
+    second = _initiate(db_session, org, driver_id, idempotency_key="new-key")
+
+    assert second.protocol_already_started is True
+    assert first.incident.incident_id == second.incident.incident_id
+    assert (
+        len(
+            _events(
+                db_session, first.incident, SystemEventType.INCIDENT_PROTOCOL_INITIATED
+            )
+        )
+        == 1
+    )
+    assert (
+        len(
+            _events(
+                db_session, first.incident, SystemEventType.EVIDENCE_LOCKDOWN_STARTED
+            )
+        )
+        == 1
+    )
+
+
+def test_initiate_driver_incident_uses_existing_active_vehicle_incident_once(
+    db_session, org
+):
+    driver_id = uuid.uuid4()
+    existing = Incident(
+        org_id=org.id,
+        adc_vehicle_id="veh-100",
+        adc_driver_id=None,
+        status="evidence_capturing",
+    )
+    db_session.add(existing)
+    db_session.commit()
+    db_session.refresh(existing)
+
+    result = _initiate(db_session, org, driver_id, idempotency_key=None)
+
+    assert result.protocol_already_started is False
+    assert result.incident.incident_id == existing.incident_id
+    assert db_session.query(Incident).count() == 1
+    assert (
+        len(_events(db_session, existing, SystemEventType.INCIDENT_PROTOCOL_INITIATED))
+        == 1
+    )


### PR DESCRIPTION
### Motivation
- Harden NWS/weather and driver-initiation behavior around required query params, XML parsing, location resolution fallbacks, and idempotent initiation so regressions are caught quickly.
- Ensure weather capture failures do not block incident initiation and that duplicate initiation does not re-dispatch core capture work.

### Description
- Added/strengthened unit tests for NWS client query building including the Option-B two-hour window, required params, and the `end >= begin` guard (`backend/tests/services/test_nws_client.py`).
- Tightened NWS XML parser assertions and explicit malformed-XML expectation, and exercised full/partial payload normalization using fixtures (`backend/tests/services/test_nws_parser.py` and existing fixtures under `backend/tests/fixtures/nws/`).
- Added regression tests for weather snapshot capture covering persistent location source/fallback metadata, degraded/partial payload handling, non-blocking external failures, and duplicate-terminal-event skipping (`backend/tests/services/test_weather_snapshot_service.py`).
- Added coverage for incident location resolver fallback ordering and that missing-incident returns the unavailable sentinel without calling telematics provider (`backend/tests/test_incident_location_resolver.py`).
- Added workflow-level tests validating exact-once protocol/lockdown event creation and that endpoint duplicate driver-initiations dispatch core capture only once (`backend/tests/test_incident_workflow_service.py` and `backend/tests/test_api_endpoints.py` extension).
- Updated CI selection to include the new weather snapshot and workflow tests in the targeted regression phase (`.github/workflows/ci.yml`).

### Testing
- Ran duplicate-module guard: `python scripts/check_no_duplicate_modules.py` and it passed.
- Ran linter: `cd backend && ruff check app/ tests/` and all checks passed.
- Ran mypy on critical modules: `cd backend && mypy --ignore-missing-imports app/core/config.py app/services/schema_validate.py` and it reported no issues.
- Ran targeted regression suite: `pytest tests/services/test_nws_client.py tests/services/test_nws_parser.py tests/services/test_weather_snapshot_service.py tests/test_incident_location_resolver.py tests/test_incident_workflow_service.py tests/test_api_endpoints.py::TestDriverIncidentInitiationDuplicateBehavior tests/test_driver_admin_endpoints.py -v` and all collected tests passed.
- Ran full backend test suite: `cd backend && pytest tests/ -v` and the run completed successfully (all backend tests passed: 861 passed, 1 skipped at time of run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a221ca144b0832194187afdf15c364f)