### PR TITLE
Add weather snapshot coverage: frontend tests and crash brief PDF support

### DIFF
--- a/backend/app/api/routes_incidents.py
+++ b/backend/app/api/routes_incidents.py
@@ -115,6 +115,7 @@ def _resolve_weather_snapshot_state(*, events: list) -> tuple[dict | None, str |
             "capture_status": payload.get("capture_status"),
             "normalized_weather": payload.get("normalized_weather") or {},
             "raw_source_metadata": payload.get("raw_source_metadata") or {},
+            "location": payload.get("location") or {},
         }, payload.get("capture_status"), location_source
 
     return None, payload.get("capture_status") or "failed", location_source

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -406,6 +406,7 @@ class CurrentWeatherConditions(BaseModel):
     capture_status: Optional[str] = None
     normalized_weather: dict[str, Any] = Field(default_factory=dict)
     raw_source_metadata: dict[str, Any] = Field(default_factory=dict)
+    location: dict[str, Any] = Field(default_factory=dict)
 
 
 class IncidentDetailResponse(BaseModel):

--- a/backend/app/services/crash_packet_builder.py
+++ b/backend/app/services/crash_packet_builder.py
@@ -42,6 +42,7 @@ def _row_to_template_context(row: CrashPacketRow, *, subject: str) -> dict[str, 
         "loading_dock_reports": row.loading_dock_reports_json,
         "driver_violation_history": row.driver_violation_history_json,
         "driver_violation_history_meta": row.driver_violation_history_meta_json,
+        "current_weather_conditions": row.current_weather_conditions_json,
     }
 
 
@@ -95,6 +96,7 @@ def build_crash_packet(row: CrashPacketRow) -> CrashPacket:
                 "driver_violation_history_meta": (
                     row.driver_violation_history_meta_json
                 ),
+                "current_weather_conditions": row.current_weather_conditions_json,
             },
             sort_keys=True,
             default=str,

--- a/backend/app/services/crash_packet_query.py
+++ b/backend/app/services/crash_packet_query.py
@@ -34,6 +34,7 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
+from app.domain.system_event_types import SystemEventType
 from app.db.models import (
     Artifact,
     DispatchInstruction,
@@ -87,11 +88,44 @@ class CrashPacketRow:
     # FMCSA driver violation history (last 360d, only included_in_brief rows).
     driver_violation_history_json: list[dict[str, Any]] = field(default_factory=list)
     driver_violation_history_meta_json: dict[str, Any] = field(default_factory=dict)
+    current_weather_conditions_json: dict[str, Any] | None = None
 
     @property
     def maintenance_window_days(self) -> int:
         return MAINTENANCE_LOOKBACK_DAYS
 
+
+def _resolve_current_weather_conditions(events: list[Event]) -> dict[str, Any] | None:
+    weather_events = [
+        event
+        for event in events
+        if event.event_type
+        in {
+            SystemEventType.WEATHER_SNAPSHOT_CAPTURED.value,
+            SystemEventType.WEATHER_SNAPSHOT_FAILED.value,
+        }
+    ]
+    if not weather_events:
+        return None
+
+    latest_event = sorted(
+        weather_events, key=lambda event: event.occurred_at_utc or datetime.min
+    )[-1]
+    payload: dict[str, Any] = (
+        latest_event.payload if isinstance(latest_event.payload, dict) else {}
+    )
+
+    return {
+        "capture_status": payload.get("capture_status") or "failed",
+        "normalized_weather": payload.get("normalized_weather") or {},
+        "raw_source_metadata": payload.get("raw_source_metadata") or {},
+        "location": payload.get("location") or {},
+        "captured_at_utc": (
+            latest_event.occurred_at_utc.isoformat()
+            if latest_event.occurred_at_utc
+            else None
+        ),
+    }
 
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
@@ -484,10 +518,10 @@ def fetch_crash_packet_row(
         for a in dashcam_artifacts
     ]
 
-    # Related event count for sanity checks in the report header.
-    event_count = (
-        db.query(Event).filter(Event.incident_id == incident_id).count()
-    )
+    # Related events for sanity checks in the report header and weather context.
+    incident_events = db.query(Event).filter(Event.incident_id == incident_id).all()
+    event_count = len(incident_events)
+    current_weather_conditions = _resolve_current_weather_conditions(incident_events)
 
     # ── Phase 3: dispatch / weigh / loading dock evidence ──
     #
@@ -674,4 +708,5 @@ def fetch_crash_packet_row(
         loading_dock_reports_json=loading_dock_reports,
         driver_violation_history_json=driver_violation_history,
         driver_violation_history_meta_json=driver_violation_history_meta,
+        current_weather_conditions_json=current_weather_conditions,
     )

--- a/backend/app/services/crash_packet_query.py
+++ b/backend/app/services/crash_packet_query.py
@@ -95,24 +95,16 @@ class CrashPacketRow:
         return MAINTENANCE_LOOKBACK_DAYS
 
 
-def _resolve_current_weather_conditions(events: list[Event]) -> dict[str, Any] | None:
-    weather_events = [
-        event
-        for event in events
-        if event.event_type
-        in {
-            SystemEventType.WEATHER_SNAPSHOT_CAPTURED.value,
-            SystemEventType.WEATHER_SNAPSHOT_FAILED.value,
-        }
-    ]
-    if not weather_events:
+def _resolve_current_weather_conditions(
+    latest_weather_event: Event | None,
+) -> dict[str, Any] | None:
+    if latest_weather_event is None:
         return None
 
-    latest_event = sorted(
-        weather_events, key=lambda event: event.occurred_at_utc or datetime.min
-    )[-1]
     payload: dict[str, Any] = (
-        latest_event.payload if isinstance(latest_event.payload, dict) else {}
+        latest_weather_event.payload
+        if isinstance(latest_weather_event.payload, dict)
+        else {}
     )
 
     return {
@@ -121,11 +113,12 @@ def _resolve_current_weather_conditions(events: list[Event]) -> dict[str, Any] |
         "raw_source_metadata": payload.get("raw_source_metadata") or {},
         "location": payload.get("location") or {},
         "captured_at_utc": (
-            latest_event.occurred_at_utc.isoformat()
-            if latest_event.occurred_at_utc
+            latest_weather_event.occurred_at_utc.isoformat()
+            if latest_weather_event.occurred_at_utc
             else None
         ),
     }
+
 
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
@@ -518,10 +511,28 @@ def fetch_crash_packet_row(
         for a in dashcam_artifacts
     ]
 
-    # Related events for sanity checks in the report header and weather context.
-    incident_events = db.query(Event).filter(Event.incident_id == incident_id).all()
-    event_count = len(incident_events)
-    current_weather_conditions = _resolve_current_weather_conditions(incident_events)
+    # Related events for sanity checks in the report header. Keep this as a
+    # database count so crash packets do not materialize long event timelines.
+    event_count = db.query(Event).filter(Event.incident_id == incident_id).count()
+
+    # Weather context only needs the latest terminal weather snapshot event.
+    latest_weather_event = (
+        db.query(Event)
+        .filter(
+            Event.incident_id == incident_id,
+            Event.event_type.in_(
+                (
+                    SystemEventType.WEATHER_SNAPSHOT_CAPTURED.value,
+                    SystemEventType.WEATHER_SNAPSHOT_FAILED.value,
+                )
+            ),
+        )
+        .order_by(Event.occurred_at_utc.desc())
+        .first()
+    )
+    current_weather_conditions = _resolve_current_weather_conditions(
+        latest_weather_event
+    )
 
     # ── Phase 3: dispatch / weigh / loading dock evidence ──
     #

--- a/backend/app/templates/pdf/crash_brief.html
+++ b/backend/app/templates/pdf/crash_brief.html
@@ -181,6 +181,33 @@
   <p><em>No maintenance records ingested yet (TMS sync pending).</em></p>
 {% endif %}
 
+<h2>Weather Snapshot</h2>
+{% if current_weather_conditions %}
+  <table>
+    <tr><th>Status</th><td>{{ current_weather_conditions.capture_status or "unknown" }}</td></tr>
+    <tr><th>Location Source</th><td>{{ current_weather_conditions.location.source or "Location unavailable" }}</td></tr>
+    <tr><th>Captured (UTC)</th><td>{{ current_weather_conditions.captured_at_utc or "—" }}</td></tr>
+    <tr><th>Provider</th><td>{{ current_weather_conditions.raw_source_metadata.provider or "—" }}</td></tr>
+  </table>
+  {% if current_weather_conditions.location.source == "unavailable" %}
+    <p><strong>Location unavailable</strong></p>
+  {% elif current_weather_conditions.location.source == "eld_last_known" %}
+    <p><strong>Using last known location.</strong></p>
+  {% endif %}
+
+  {% if current_weather_conditions.normalized_weather %}
+    <table>
+      {% for key, value in current_weather_conditions.normalized_weather.items() %}
+        <tr><th>{{ key|replace("_", " ") }}</th><td>{{ value if value is not none else "—" }}</td></tr>
+      {% endfor %}
+    </table>
+  {% else %}
+    <p><em>Weather data unavailable.</em></p>
+  {% endif %}
+{% else %}
+  <p><em>Weather data unavailable.</em></p>
+{% endif %}
+
 <h2>ELD Logs (last 8 captured artifacts)</h2>
 {% if eld_logs %}
   <ul>

--- a/backend/tests/test_crash_packet_builder.py
+++ b/backend/tests/test_crash_packet_builder.py
@@ -106,6 +106,17 @@ def _example_row() -> CrashPacketRow:
                 "external_id": "ws-ext-1",
             }
         ],
+        current_weather_conditions_json={
+            "capture_status": "ok",
+            "normalized_weather": {
+                "temperature_f": 42,
+                "wind_speed_mph": 18,
+                "conditions": "Rain",
+            },
+            "raw_source_metadata": {"provider": "nws"},
+            "location": {"source": "driver_gps", "lat": 41.8, "lon": -87.6},
+            "captured_at_utc": "2026-05-01T01:01:00+00:00",
+        },
         loading_dock_reports_json=[
             {
                 "loading_dock_report_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
@@ -168,6 +179,34 @@ class TestCrashPacketBuilder:
         assert "eld_log_report" in html
         # Samsara deep link
         assert "https://cloud.samsara.com/o/fleet/vehicles/sams-9001/dashcam" in html
+
+    def test_html_body_contains_weather_section_before_eld_snapshot(self):
+        packet = build_crash_packet(_example_row())
+        html = packet.html_body
+
+        weather_index = html.index("Weather Snapshot")
+        eld_snapshot_index = html.index("ELD Logs")
+        assert weather_index < eld_snapshot_index
+        assert "temperature f" in html
+        assert "wind speed mph" in html
+        assert "Rain" in html
+        assert "driver_gps" in html
+        assert "nws" in html
+
+    def test_html_body_renders_location_unavailable_for_unresolved_weather_location(self):
+        row = _example_row()
+        row.current_weather_conditions_json = {
+            "capture_status": "failed",
+            "normalized_weather": {},
+            "raw_source_metadata": {},
+            "location": {"source": "unavailable"},
+            "captured_at_utc": "2026-05-01T01:01:00+00:00",
+        }
+
+        packet = build_crash_packet(row)
+
+        assert "Location unavailable" in packet.html_body
+        assert "Weather data unavailable" in packet.html_body
 
     def test_pdf_bytes_returned(self):
         packet = build_crash_packet(_example_row())

--- a/backend/tests/test_crash_packet_query.py
+++ b/backend/tests/test_crash_packet_query.py
@@ -210,6 +210,59 @@ class TestCrashPacketQuery:
         with pytest.raises(LookupError):
             fetch_crash_packet_row(db_session, incident_id=uuid.uuid4())
 
+    def test_weather_context_uses_latest_weather_event_without_affecting_count(
+        self, db_session, seeded
+    ):
+        incident = seeded["incident"]
+        old_failed_at = datetime(2026, 5, 1, 11, 0, tzinfo=timezone.utc)
+        latest_captured_at = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+        db_session.add_all(
+            [
+                Event(
+                    incident_id=incident.incident_id,
+                    event_type="weather_snapshot_failed",
+                    actor_type="system",
+                    actor_id="weather",
+                    occurred_at_utc=old_failed_at,
+                    payload={"capture_status": "unavailable"},
+                ),
+                Event(
+                    incident_id=incident.incident_id,
+                    event_type="incident_note_added",
+                    actor_type="operator",
+                    actor_id="ops",
+                    occurred_at_utc=latest_captured_at + timedelta(minutes=5),
+                    payload={"note": "newer non-weather event"},
+                ),
+                Event(
+                    incident_id=incident.incident_id,
+                    event_type="weather_snapshot_captured",
+                    actor_type="system",
+                    actor_id="weather",
+                    occurred_at_utc=latest_captured_at,
+                    payload={
+                        "capture_status": "captured",
+                        "normalized_weather": {"temperature_f": 72},
+                        "raw_source_metadata": {"provider": "open-meteo"},
+                        "location": {"source": "incident_address"},
+                    },
+                ),
+            ]
+        )
+        db_session.commit()
+
+        row = fetch_crash_packet_row(db_session, incident_id=incident.incident_id)
+
+        assert row.related_event_count == 4
+        assert row.current_weather_conditions_json is not None
+        assert row.current_weather_conditions_json["capture_status"] == "captured"
+        assert row.current_weather_conditions_json["normalized_weather"] == {
+            "temperature_f": 72
+        }
+        assert row.current_weather_conditions_json["captured_at_utc"].startswith(
+            "2026-05-01T12:00:00"
+        )
+
 
 class TestPhase3DispatchWeighDock:
     """Phase 3: dispatch / weigh / loading dock evidence on the crash brief."""

--- a/backend/tests/test_pdf_render_templates.py
+++ b/backend/tests/test_pdf_render_templates.py
@@ -15,6 +15,7 @@ import pytest
 
 from app.services.pdf_render import (
     TEMPLATE_REGISTRY,
+    TEMPLATES_DIR,
     render_html,
     render_pdf,
 )
@@ -81,6 +82,58 @@ def test_render_html_autoescapes_user_supplied_strings() -> None:
     # Autoescape must convert the raw script tag into safe entities.
     assert "<script>alert(1)</script>" not in html
     assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+
+
+def test_crash_brief_template_scopes_weather_section_before_eld_snapshot() -> None:
+    html = render_html(
+        "crash_brief",
+        {
+            "subject": "Crash brief",
+            "incident": {
+                "incident_id": "inc-1",
+                "status": "accident_occurred",
+                "severity": "serious",
+                "created_at_utc": "2026-01-02T03:04:05+00:00",
+            },
+            "driver": None,
+            "driver_history": [],
+            "vehicle": None,
+            "trailer": None,
+            "maintenance": [],
+            "maintenance_window_days": 365,
+            "current_weather_conditions": {
+                "capture_status": "degraded",
+                "normalized_weather": {"visibility_miles": 2},
+                "raw_source_metadata": {"provider": "nws"},
+                "location": {"source": "eld_last_known"},
+                "captured_at_utc": "2026-01-02T03:05:00+00:00",
+            },
+            "eld_logs": [],
+            "samsara_clip_links": [],
+            "related_event_count": 0,
+            "dispatch_instructions": [],
+            "weigh_station_reports": [],
+            "loading_dock_reports": [],
+            "driver_violation_history": [],
+            "driver_violation_history_meta": {},
+        },
+    )
+
+    weather_index = html.index("Weather Snapshot")
+    eld_snapshot_index = html.index("ELD Logs")
+    assert weather_index < eld_snapshot_index
+    assert "Using last known location" in html
+    assert "visibility miles" in html
+    assert "nws" in html
+
+
+def test_weather_section_is_scoped_to_crash_brief_template() -> None:
+    for template_name, template_file in TEMPLATE_REGISTRY.items():
+        template_text = (TEMPLATES_DIR / template_file).read_text()
+        if template_name == "crash_brief":
+            assert "Weather Snapshot" in template_text
+        else:
+            assert "Weather Snapshot" not in template_text
 
 
 def test_render_html_telematics_report_handles_empty_records() -> None:

--- a/contracts/schemas/runtime_api_contracts.json
+++ b/contracts/schemas/runtime_api_contracts.json
@@ -485,6 +485,11 @@
               "default": null,
               "title": "Capture Status"
             },
+            "location": {
+              "additionalProperties": true,
+              "title": "Location",
+              "type": "object"
+            },
             "normalized_weather": {
               "additionalProperties": true,
               "title": "Normalized Weather",

--- a/frontend/tests/incidentDetailWeatherPanel.test.mjs
+++ b/frontend/tests/incidentDetailWeatherPanel.test.mjs
@@ -4,6 +4,10 @@ import { readFileSync } from 'node:fs';
 
 const incidentDetailClient = readFileSync(new URL('../app/incidents/[id]/IncidentDetailClient.tsx', import.meta.url), 'utf8');
 
+function assertContains(snippet, message) {
+  assert.ok(incidentDetailClient.includes(snippet), message);
+}
+
 test('incident detail renders dedicated weather snapshot panel before evidence inventory', () => {
   const weatherPanelIndex = incidentDetailClient.indexOf('Weather snapshot');
   const evidenceInventoryIndex = incidentDetailClient.indexOf('Evidence inventory');
@@ -12,15 +16,26 @@ test('incident detail renders dedicated weather snapshot panel before evidence i
   assert.ok(weatherPanelIndex < evidenceInventoryIndex, 'weather panel should appear before evidence inventory');
 });
 
-test('incident detail weather panel includes degraded-state messaging', () => {
-  assert.match(incidentDetailClient, /Using last known location/);
-  assert.match(incidentDetailClient, /Location unavailable/);
-  assert.match(incidentDetailClient, /Weather data unavailable/);
+test('incident detail weather panel renders full weather data attribution', () => {
+  assertContains('toWeatherMetrics(weatherConditions?.normalized_weather)', 'normalized weather should be converted into display metrics');
+  assertContains('weatherMetrics.map((metric) => (', 'full weather data should render each normalized metric');
+  assertContains('Source: {formatWeatherValue(weatherSource)}', 'weather source attribution should be rendered');
+  assertContains('Captured: {formatTime(typeof weatherCapturedAt === "string" ? weatherCapturedAt : null)}', 'captured timestamp should be rendered');
 });
 
-test('incident detail weather panel renders normalized metrics and attribution defensively', () => {
-  assert.match(incidentDetailClient, /toWeatherMetrics\(weatherConditions\?\.normalized_weather\)/);
-  assert.match(incidentDetailClient, /Source: \{formatWeatherValue\(weatherSource\)\}/);
-  assert.match(incidentDetailClient, /Captured: \{formatTime\(typeof weatherCapturedAt === "string" \? weatherCapturedAt : null\)\}/);
-  assert.match(incidentDetailClient, /weatherMetrics\.length === 0/);
+test('incident detail weather panel supports partial degraded weather data', () => {
+  assertContains('weatherLocationSource === "eld_last_known"', 'degraded location source should be detected');
+  assertContains('Using last known location', 'degraded location messaging should render');
+  assertContains('weatherMetrics.length > 0 ? (', 'partial data should still render available metrics');
+});
+
+test('incident detail weather panel handles unavailable weather data', () => {
+  assertContains('weatherConditions?.capture_status === "unavailable"', 'unavailable capture status should be detected');
+  assertContains('weatherMetrics.length === 0', 'missing metrics should count as unavailable weather');
+  assertContains('Weather data unavailable', 'unavailable data messaging should render');
+});
+
+test('incident detail weather panel renders unresolved location as Location unavailable', () => {
+  assertContains('weatherLocationSource === "unavailable"', 'unresolved location source should be detected');
+  assertContains('Location unavailable', 'unresolved location messaging should render');
 });


### PR DESCRIPTION
### Motivation
- Ensure the incident detail UI surfaces weather snapshot state correctly for full, partial (degraded), unavailable, and unresolved-location cases so operators see defensible messaging.
- Include weather snapshot data in the crash brief PDF and guarantee it renders before ELD snapshot content for readability and legal-context ordering.
- Keep the change scoped so non-`crash_brief` PDF templates remain unchanged and runtime API contracts reflect the added location metadata.

### Description
- Frontend: expanded `frontend/tests/incidentDetailWeatherPanel.test.mjs` with assertions for full-weather rendering, partial/degraded behavior, unavailable-state messaging, and unresolved-location rendering as “Location unavailable”, and added a small test helper for string checks.
- Backend: added resolution plumbing to `backend/app/services/crash_packet_query.py` (`_resolve_current_weather_conditions`) and surface `current_weather_conditions` on the `CrashPacketRow`; threaded that into the crash-packet rendering context in `backend/app/services/crash_packet_builder.py` and included `current_weather_conditions` in the payload-hash to avoid silent drift.
- Templates/tests: added a `Weather Snapshot` section to `backend/app/templates/pdf/crash_brief.html` (renders capture status, provider, location source, captured timestamp, and normalized metrics with fallbacks) and added tests in `backend/tests/test_crash_packet_builder.py` and `backend/tests/test_pdf_render_templates.py` to ensure the weather section appears before ELD logs and that the weather section is scoped only to the `crash_brief` template.
- API/schema/contract: exposed `location` inside `CurrentWeatherConditions` in `backend/app/api/schemas.py` and included `location` in `_resolve_weather_snapshot_state` response in `backend/app/api/routes_incidents.py`, then updated `contracts/schemas/runtime_api_contracts.json` to match the new shape.

### Testing
- Frontend: `cd frontend && npm test -- incidentDetailWeatherPanel.test.mjs` — tests passed (all new weather assertions succeeded).; `npm run lint` and `npm run typecheck` also passed.
- Backend unit tests: ran focused backend tests (`tests/test_crash_packet_builder.py`, `tests/test_pdf_render_templates.py`, `tests/test_export_pdf_service.py`) and the runtime contract snapshot test, and then the full test suite with `pytest tests/`; all tests passed after updating the runtime API contract snapshot (final run: backend tests passed with existing repo warnings reported but unrelated to these changes).
- Static checks: `ruff check app/ tests/` passed and `mypy` check on the modified backend modules (`app/services/crash_packet_query.py`, `app/services/crash_packet_builder.py`, `app/api/schemas.py`, `app/api/routes_incidents.py`) succeeded; repo-wide `mypy` still reports unrelated test-suite typing issues outside this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2372e052948321b7de15a0a8e51278)