### PR TITLE
Remove placeholder static params and disable static export; add production deployment tests

### DIFF
--- a/frontend/app/incidents/[id]/page.tsx
+++ b/frontend/app/incidents/[id]/page.tsx
@@ -1,9 +1,5 @@
 import IncidentDetailClient from "./IncidentDetailClient";
 
-export async function generateStaticParams() {
-  return [{ id: "placeholder" }];
-}
-
 export default function IncidentDetailPage() {
   return <IncidentDetailClient />;
 }

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: "export",
   images: {
     unoptimized: true,
   },

--- a/frontend/tests/productionDeployment.test.mjs
+++ b/frontend/tests/productionDeployment.test.mjs
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const nextConfigSource = readFileSync(new URL('../next.config.mjs', import.meta.url), 'utf8');
+const incidentDetailPageSource = readFileSync(new URL('../app/incidents/[id]/page.tsx', import.meta.url), 'utf8');
+const apiCoreSource = readFileSync(new URL('../lib/api/core.ts', import.meta.url), 'utf8');
+
+test('Next.js production config uses dynamic app mode and preserves image compatibility', () => {
+  assert.doesNotMatch(nextConfigSource, /output:\s*["']export["']/);
+  assert.match(nextConfigSource, /images:\s*{[\s\S]*unoptimized:\s*true[\s\S]*}/);
+});
+
+test('incident detail page does not rely on placeholder static params', () => {
+  assert.doesNotMatch(incidentDetailPageSource, /generateStaticParams/);
+  assert.doesNotMatch(incidentDetailPageSource, /placeholder/);
+  assert.match(incidentDetailPageSource, /<IncidentDetailClient\s*\/>/);
+});
+
+test('API base URL resolution keeps internal server and public browser env handling', () => {
+  assert.match(apiCoreSource, /typeof window === "undefined"/);
+  assert.match(apiCoreSource, /process\.env\.API_INTERNAL_BASE_URL\s*\?\?/);
+  assert.match(apiCoreSource, /process\.env\.NEXT_PUBLIC_API_BASE_URL\s*\?\?/);
+  assert.match(apiCoreSource, /"http:\/\/localhost:8000"/);
+});


### PR DESCRIPTION
### Motivation
- Enable Next.js dynamic app/runtime behavior by removing a static export configuration that forced a fully static build.
- Eliminate a placeholder `generateStaticParams` in the incident detail page that forced a compile-time param scaffolding not needed at runtime.
- Add automated checks to ensure the production deployment configuration and API base URL handling remain compatible with server/browser environments and image handling.

### Description
- Remove `generateStaticParams` from `app/incidents/[id]/page.tsx` so the page relies on the client component `IncidentDetailClient` at runtime.
- Remove `output: "export"` from `next.config.mjs` to stop forcing a static export while preserving `images.unoptimized: true` for image compatibility.
- Add `frontend/tests/productionDeployment.test.mjs` which uses `node:test` to assert that `next.config.mjs` no longer contains `output: "export"`, that the incident page no longer contains `generateStaticParams` or a `placeholder`, and that `lib/api/core.ts` implements server/browser environment base URL resolution.

### Testing
- Ran the new test file with `node:test frontend/tests/productionDeployment.test.mjs` and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d7d0a1cfc83219b36db2a749988bc)