### PR TITLE
Add local Docker Compose workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,12 +8,12 @@
 # IMPORTANT: replace any "__CHANGE_ME__" value before running anywhere except local dev.
 # config.settings.validate_production_invariants() refuses to start in staging/prod
 # if the JWT_SECRET_KEY or OTP_HASH_PEPPER still contain the placeholder string.
-DATABASE_URL=postgresql://__CHANGE_ME__:__CHANGE_ME__@localhost:5432/adc_mvp
-POSTGRES_USER=__CHANGE_ME__
-POSTGRES_PASSWORD=__CHANGE_ME__
+DATABASE_URL=postgresql://adc_local:adc_local_password@localhost:5432/adc_mvp
+POSTGRES_USER=adc_local
+POSTGRES_PASSWORD=adc_local_password
 POSTGRES_DB=adc_mvp
 REDIS_URL=redis://localhost:6379/0
-JWT_SECRET_KEY=__CHANGE_ME__
+JWT_SECRET_KEY=local-dev-jwt-secret-not-for-staging-or-prod
 SAMSARA_API_TOKEN=
 
 # ── CORS / Cookies ──────────────────────────────────────────────
@@ -36,7 +36,7 @@ TWILIO_SMS_FROM=
 TWILIO_VOICE_FROM=
 
 # ── Driver OTP ───────────────────────────────────────────────────
-OTP_HASH_PEPPER=__CHANGE_ME__
+OTP_HASH_PEPPER=local-dev-otp-pepper-not-for-staging-or-prod
 OTP_RESEND_COOLDOWN_SECONDS=60
 
 # ── AWS / S3 (not used in local dev) ────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,27 @@
-.PHONY: dev test fmt lint guard-duplicates check-prod-hardening-gates check-hardening-matrix verify-demo
+.PHONY: dev local-up local-down local-logs local-ps local-rebuild test fmt lint guard-duplicates check-prod-hardening-gates check-hardening-matrix verify-demo
+
+
+LOCAL_COMPOSE = docker compose -f infra/docker-compose.local.yml
+
+## Start the local-only Docker stack (Postgres, Redis, API, worker, frontend).
+local-up:
+	$(LOCAL_COMPOSE) up -d --build
+
+## Stop the local-only Docker stack without deleting local volumes.
+local-down:
+	$(LOCAL_COMPOSE) down
+
+## Tail logs from the local-only Docker stack.
+local-logs:
+	$(LOCAL_COMPOSE) logs -f
+
+## Show local-only Docker stack service status.
+local-ps:
+	$(LOCAL_COMPOSE) ps
+
+## Rebuild and restart the local-only Docker stack.
+local-rebuild:
+	$(LOCAL_COMPOSE) up -d --build --force-recreate
 
 ## Start all services (infra + backend + worker + frontend) from repo root
 ## Uses docker compose (plugin-style command)
@@ -38,5 +61,5 @@ check-hardening-matrix:
 ## every Phase 1+2+3 record the guided tour calls out is present and
 ## well-formed. Offline — no Postgres / Celery / SES / S3 needed.
 verify-demo:
-cd backend && pip install -q -r requirements.txt
-python scripts/verify_demo.py
+	cd backend && pip install -q -r requirements.txt
+	python scripts/verify_demo.py

--- a/README.md
+++ b/README.md
@@ -157,13 +157,35 @@ and **only activates** when both env vars are set at frontend build time
 Production builds never embed or autofill these credentials, even if a
 visitor appends `?demo=1` to the URL.
 
-### Manual Development (from repo root)
+### Local Docker Development (from repo root)
 
-Open four terminals and run each command:
+Use the local-only compose stack for development and pilot demo prep. It starts PostgreSQL, Redis, the FastAPI API, a Celery worker, and the Next.js frontend without AWS credentials, AWS Secrets Manager, staging secrets, Twilio, Samsara, FMCSA, or other live provider credentials.
 
 ```bash
-# 1. Start infrastructure (PostgreSQL, Redis, etc.)
-docker compose -f infra/docker-compose.yml up -d
+cp .env.example .env
+make local-up
+make local-ps
+curl http://localhost:8000/health
+curl http://localhost:3000
+make local-down
+```
+
+Local ports:
+
+- Frontend: `http://localhost:3000`
+- API: `http://localhost:8000`
+- PostgreSQL: `127.0.0.1:5432`
+- Redis: `127.0.0.1:6379`
+
+The local compose file is `infra/docker-compose.local.yml`. Its backend services run with `APP_ENV=local`, `SECRET_PROVIDER=env`, local Postgres/Redis container URLs, filesystem storage, insecure local-only JWT/OTP secrets, `COOKIE_SECURE=false`, and `FRONTEND_ORIGIN=http://localhost:3000`. Inside compose, the frontend calls the API at `http://api:8000`; from the browser it uses `http://localhost:8000`.
+
+### Manual Development (from repo root)
+
+If you prefer running application processes directly on the host, start local infrastructure first and then run each app process in separate terminals:
+
+```bash
+# 1. Start local infrastructure (PostgreSQL, Redis, etc.)
+docker compose -f infra/docker-compose.local.yml up -d db redis
 
 # 2. Start the FastAPI backend
 cd backend && uvicorn app.main:app --reload
@@ -218,7 +240,9 @@ See [`driver-app/TESTING.md`](driver-app/TESTING.md) for the test
 architecture (unit + RNTL Jest projects), running tests, mocking
 conventions, and coverage thresholds.
 
-### Docker (from repo root)
+### Staging-Oriented Docker Compose (from repo root)
+
+The original compose file remains staging-oriented and still expects externally supplied secrets such as AWS Secrets Manager configuration. For normal local development, use `make local-up` instead.
 
 ```bash
 docker compose -f infra/docker-compose.yml up --build

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,6 +5,8 @@ RUN npm ci
 
 FROM node:20-alpine AS builder
 WORKDIR /app
+ARG NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -1,0 +1,126 @@
+# Local-only Docker Compose stack for development and pilot demo prep.
+# This file intentionally avoids AWS Secrets Manager, staging secrets, and live provider credentials.
+services:
+  db:
+    image: postgres:15.7-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-adc_local}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-adc_local_password}
+      POSTGRES_DB: ${POSTGRES_DB:-adc_mvp}
+    ports:
+      - "127.0.0.1:5432:5432"
+    volumes:
+      - local_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7.2-alpine
+    ports:
+      - "127.0.0.1:6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  api:
+    build: ../backend
+    ports:
+      - "8000:8000"
+    environment:
+      APP_ENV: local
+      SECRET_PROVIDER: env
+      DATABASE_URL: postgresql://${POSTGRES_USER:-adc_local}:${POSTGRES_PASSWORD:-adc_local_password}@db:5432/${POSTGRES_DB:-adc_mvp}
+      REDIS_URL: redis://redis:6379/0
+      COOKIE_SECURE: "false"
+      FRONTEND_ORIGIN: http://localhost:3000
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY:-local-dev-jwt-secret-not-for-staging-or-prod}
+      OTP_HASH_PEPPER: ${OTP_HASH_PEPPER:-local-dev-otp-pepper-not-for-staging-or-prod}
+      STORAGE_BACKEND: fs
+      VAULT_ROOT: /var/adc/vault
+      PUBLIC_APP_BASE_URL: http://localhost:3000
+      EMAIL_PROVIDER: noop
+      SAMSARA_API_KEY: ""
+      SAMSARA_API_TOKEN: ""
+      TWILIO_ACCOUNT_SID: ""
+      TWILIO_AUTH_TOKEN: ""
+      TWILIO_VERIFY_SERVICE_SID: ""
+      TWILIO_SMS_FROM: ""
+      TWILIO_VOICE_FROM: ""
+      SOCRATA_APP_TOKEN: ""
+      FMCSA_INSPECTIONS_ENABLED: "false"
+      FMCSA_INSPECTIONS_REPOLL_ENABLED: "false"
+      AWS_ACCESS_KEY_ID: ""
+      AWS_SECRET_ACCESS_KEY: ""
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+      S3_BUCKET: adc-local-artifacts
+      S3_ARTIFACTS_BUCKET: adc-local-artifacts
+      S3_EXPORTS_BUCKET: adc-local-exports
+    volumes:
+      - local_vaultdata:/var/adc/vault
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  worker:
+    build: ../backend
+    command: celery -A app.tasks.celery_app worker --loglevel=info
+    environment:
+      APP_ENV: local
+      SECRET_PROVIDER: env
+      DATABASE_URL: postgresql://${POSTGRES_USER:-adc_local}:${POSTGRES_PASSWORD:-adc_local_password}@db:5432/${POSTGRES_DB:-adc_mvp}
+      REDIS_URL: redis://redis:6379/0
+      COOKIE_SECURE: "false"
+      FRONTEND_ORIGIN: http://localhost:3000
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY:-local-dev-jwt-secret-not-for-staging-or-prod}
+      OTP_HASH_PEPPER: ${OTP_HASH_PEPPER:-local-dev-otp-pepper-not-for-staging-or-prod}
+      STORAGE_BACKEND: fs
+      VAULT_ROOT: /var/adc/vault
+      PUBLIC_APP_BASE_URL: http://localhost:3000
+      EMAIL_PROVIDER: noop
+      SAMSARA_API_KEY: ""
+      SAMSARA_API_TOKEN: ""
+      TWILIO_ACCOUNT_SID: ""
+      TWILIO_AUTH_TOKEN: ""
+      TWILIO_VERIFY_SERVICE_SID: ""
+      TWILIO_SMS_FROM: ""
+      TWILIO_VOICE_FROM: ""
+      SOCRATA_APP_TOKEN: ""
+      FMCSA_INSPECTIONS_ENABLED: "false"
+      FMCSA_INSPECTIONS_REPOLL_ENABLED: "false"
+      AWS_ACCESS_KEY_ID: ""
+      AWS_SECRET_ACCESS_KEY: ""
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+      S3_BUCKET: adc-local-artifacts
+      S3_ARTIFACTS_BUCKET: adc-local-artifacts
+      S3_EXPORTS_BUCKET: adc-local-exports
+    volumes:
+      - local_vaultdata:/var/adc/vault
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  frontend:
+    build:
+      context: ../frontend
+      args:
+        NEXT_PUBLIC_API_BASE_URL: http://localhost:8000
+    ports:
+      - "3000:3000"
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: http://localhost:8000
+      API_INTERNAL_BASE_URL: http://api:8000
+    depends_on:
+      - api
+
+volumes:
+  local_pgdata:
+  local_vaultdata:


### PR DESCRIPTION
### Motivation
- The existing compose setup is staging-oriented and requires AWS Secrets Manager and live provider credentials, which blocks a simple local development and pilot-demo flow.
- Provide a local-first, self-contained way to start Postgres, Redis, the backend API, Celery worker, and the frontend without external providers or secrets.

### Description
- Add `infra/docker-compose.local.yml` that defines local-only `db`, `redis`, `api`, `worker`, and `frontend` services and configures the backend with `APP_ENV=local`, `SECRET_PROVIDER=env`, container-local `DATABASE_URL`/`REDIS_URL`, filesystem vault storage, and safe local JWT/OTP defaults.
- Add Makefile targets `local-up`, `local-down`, `local-logs`, `local-ps`, and `local-rebuild` that operate only on the new local compose file and fix a Makefile indentation for `verify-demo`.
- Update `.env.example` to include local-safe defaults for `POSTGRES_USER`, `POSTGRES_PASSWORD`, `DATABASE_URL`, `JWT_SECRET_KEY`, and `OTP_HASH_PEPPER` to make `cp .env.example .env` usable for local development.
- Update `frontend/Dockerfile` to accept `NEXT_PUBLIC_API_BASE_URL` as a build `ARG`/`ENV`, and update `README.md` with exact local startup/shutdown commands and port information while explicitly preserving the original staging-oriented compose.

### Testing
- Ran backend lint: `cd backend && ruff check app/ tests/`, which passed in CI runs performed here.
- Ran backend unit tests: `cd backend && pytest tests/ -v`, which resulted in `866 passed, 1 skipped` in the test environment used for verification.
- Validated both compose files syntactically by loading them with Ruby YAML: `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "ok #{p}" }' infra/docker-compose.local.yml infra/docker-compose.yml`, which parsed OK.
- Attempted to run `docker compose` / `make local-ps` in the verification environment but Docker is not installed there, so runtime compose bring-up was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d84484e5c832190ee1da9ea706cfa)