### PR TITLE
Add reliable local demo bootstrap workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-.PHONY: dev local-up local-down local-logs local-ps local-rebuild test fmt lint guard-duplicates check-prod-hardening-gates check-hardening-matrix verify-demo
+.PHONY: dev local-up local-down local-logs local-ps local-rebuild local-wait-db local-wait-api local-migrate local-seed local-verify-demo local-reset local-bootstrap test fmt lint guard-duplicates check-prod-hardening-gates check-hardening-matrix verify-demo
 
 
 LOCAL_COMPOSE = docker compose -f infra/docker-compose.local.yml
+LOCAL_API_URL ?= http://localhost:8000
 
 ## Start the local-only Docker stack (Postgres, Redis, API, worker, frontend).
 local-up:
@@ -22,6 +23,58 @@ local-ps:
 ## Rebuild and restart the local-only Docker stack.
 local-rebuild:
 	$(LOCAL_COMPOSE) up -d --build --force-recreate
+
+## Wait until the local-only Postgres container is healthy.
+local-wait-db:
+	@echo "Waiting for local Postgres..."
+	@for i in $$(seq 1 60); do \
+		if $(LOCAL_COMPOSE) exec -T db pg_isready -U $${POSTGRES_USER:-adc_local} -d $${POSTGRES_DB:-adc_mvp} >/dev/null 2>&1; then \
+			echo "Local Postgres is ready."; \
+			exit 0; \
+		fi; \
+		sleep 2; \
+	done; \
+	echo "Timed out waiting for local Postgres." >&2; \
+	exit 1
+
+## Wait until the local-only API readiness endpoint is healthy.
+local-wait-api:
+	@echo "Waiting for local API at $(LOCAL_API_URL)/health..."
+	@for i in $$(seq 1 90); do \
+		if curl --fail --silent --show-error "$(LOCAL_API_URL)/health" >/dev/null 2>&1; then \
+			echo "Local API is ready."; \
+			exit 0; \
+		fi; \
+		sleep 2; \
+	done; \
+	echo "Timed out waiting for local API." >&2; \
+	exit 1
+
+## Run Alembic migrations against local-only Docker Postgres from the backend container.
+local-migrate: local-wait-db
+	$(LOCAL_COMPOSE) run --rm api alembic -c alembic.ini upgrade head
+
+## Seed the local-only Docker Postgres database with the deterministic demo tenant.
+local-seed: local-wait-db
+	$(LOCAL_COMPOSE) run --rm api python /scripts/seed_demo_data.py
+
+## Verify seeded local demo data and login usability against the local-only stack.
+local-verify-demo: local-wait-api
+	$(LOCAL_COMPOSE) run --rm -e DEMO_API_BASE_URL=http://api:8000 api python /scripts/verify_demo.py --local-db
+
+## Delete local-only containers and volumes. This removes local Postgres/vault data only.
+local-reset:
+	$(LOCAL_COMPOSE) down --volumes --remove-orphans
+
+## Start local services, migrate, seed demo data, and verify the local demo tenant.
+local-bootstrap:
+	$(LOCAL_COMPOSE) up -d --build
+	$(MAKE) local-wait-db
+	$(MAKE) local-migrate
+	$(MAKE) local-wait-api
+	$(MAKE) local-seed
+	$(MAKE) local-verify-demo
+	@echo "Local bootstrap complete. Frontend: http://localhost:3000 Backend: $(LOCAL_API_URL) Demo login: demo-admin@adc.local / DemoAdmin!2345"
 
 ## Start all services (infra + backend + worker + frontend) from repo root
 ## Uses docker compose (plugin-style command)

--- a/README.md
+++ b/README.md
@@ -161,21 +161,60 @@ visitor appends `?demo=1` to the URL.
 
 Use the local-only compose stack for development and pilot demo prep. It starts PostgreSQL, Redis, the FastAPI API, a Celery worker, and the Next.js frontend without AWS credentials, AWS Secrets Manager, staging secrets, Twilio, Samsara, FMCSA, or other live provider credentials.
 
+Fresh local demo bootstrap:
+
 ```bash
 cp .env.example .env
-make local-up
-make local-ps
-curl http://localhost:8000/health
-curl http://localhost:3000
-make local-down
+make local-bootstrap
 ```
 
-Local ports:
+`make local-bootstrap` builds and starts the local containers, waits for Postgres and the API, runs Alembic migrations inside the backend container against the local Compose database, seeds the deterministic demo tenant, and verifies the seeded demo plus API login.
 
-- Frontend: `http://localhost:3000`
-- API: `http://localhost:8000`
-- PostgreSQL: `127.0.0.1:5432`
-- Redis: `127.0.0.1:6379`
+After bootstrap:
+
+```bash
+curl http://localhost:8000/health
+curl http://localhost:3000
+make local-verify-demo
+```
+
+Local URLs and ports:
+
+| Service | URL / port | Notes |
+| --- | --- | --- |
+| Frontend | `http://localhost:3000` | Next.js web app. |
+| Backend API | `http://localhost:8000` | FastAPI; readiness is `http://localhost:8000/health`. |
+| PostgreSQL | `127.0.0.1:5432` | Local-only Compose database. |
+| Redis | `127.0.0.1:6379` | Local-only Compose broker/cache. |
+
+Demo credentials:
+
+| Field | Value |
+| --- | --- |
+| Demo login email | `demo-admin@adc.local` |
+| Demo login password | `DemoAdmin!2345` |
+| Demo organization | `ADC Demo Org` |
+
+Local demo commands:
+
+```bash
+make local-up           # Start local containers without deleting data
+make local-migrate      # Run Alembic migrations against local Postgres
+make local-seed         # Idempotently seed/reset the demo tenant and scenario
+make local-verify-demo  # Print pass/fail checks for local demo data and login
+make local-down         # Stop containers, keep local volumes
+make local-reset        # LOCAL ONLY: stop containers and delete local volumes
+```
+
+`make local-reset` uses `infra/docker-compose.local.yml` and `docker compose down --volumes --remove-orphans`; it deletes only this local Compose stack's Postgres and vault volumes. It is intentionally separate from staging/production commands.
+
+Common troubleshooting:
+
+- Port `3000` already in use: stop the other frontend/dev server, then rerun `make local-bootstrap` or `make local-up`.
+- Port `8000` already in use: stop the other API process/container and rerun `make local-wait-api`; inspect logs with `make local-logs`.
+- Port `5432` already in use: stop your host Postgres or change the local Compose port mapping before bootstrapping. The backend container still uses the Compose service hostname `db`.
+- Port `6379` already in use: stop your host Redis or change the local Compose port mapping. The backend container still uses the Compose service hostname `redis`.
+- API readiness does not pass: run `make local-logs`, then rerun `make local-migrate` and `make local-verify-demo` after the containers are healthy.
 
 The local compose file is `infra/docker-compose.local.yml`. Its backend services run with `APP_ENV=local`, `SECRET_PROVIDER=env`, local Postgres/Redis container URLs, filesystem storage, insecure local-only JWT/OTP secrets, `COOKIE_SECURE=false`, and `FRONTEND_ORIGIN=http://localhost:3000`. Inside compose, the frontend calls the API at `http://api:8000`; from the browser it uses `http://localhost:8000`.
 

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -61,6 +61,7 @@ services:
       S3_ARTIFACTS_BUCKET: adc-local-artifacts
       S3_EXPORTS_BUCKET: adc-local-exports
     volumes:
+      - ../scripts:/scripts:ro
       - local_vaultdata:/var/adc/vault
     depends_on:
       db:

--- a/scripts/verify_demo.py
+++ b/scripts/verify_demo.py
@@ -16,9 +16,13 @@ Exit codes:
 
 from __future__ import annotations
 
+import argparse
+import json
 import os
 import sys
 import traceback
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 # Make ``app`` importable when running from the repo root.
@@ -27,6 +31,103 @@ sys.path.insert(0, str(_BACKEND_DIR))
 
 
 SCENARIO_KEY = "crash_with_full_packet"
+DEFAULT_DEMO_EMAIL = "demo-admin@adc.local"
+DEFAULT_DEMO_PASSWORD = "DemoAdmin!2345"
+DEFAULT_DEMO_ORG = "ADC Demo Org"
+
+
+def _check_api_login(api_base_url: str, email: str, password: str) -> bool:
+    """Return True when the running API accepts the seeded demo login."""
+    url = api_base_url.rstrip("/") + "/auth/login"
+    payload = json.dumps({"email": email, "password": password}).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            return response.status == 200 and bool(data.get("access_token"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+        return False
+
+
+def run_local_db() -> int:
+    """Verify demo data in the configured local Postgres database."""
+    email = os.environ.get("DEMO_ADMIN_EMAIL", DEFAULT_DEMO_EMAIL)
+    password = os.environ.get("DEMO_ADMIN_PASSWORD", DEFAULT_DEMO_PASSWORD)
+    org_name = os.environ.get("DEMO_ORG", DEFAULT_DEMO_ORG)
+    api_base_url = os.environ.get("DEMO_API_BASE_URL", "http://localhost:8000")
+
+    print("Verifying local demo database and API login")
+    print(f"  org={org_name}")
+    print(f"  admin={email}")
+    print(f"  api={api_base_url}")
+
+    from app.core.security import verify_password
+    from app.db.models import Incident, Org, User, UserOrg
+    from app.db.session import SessionLocal
+    from app.security.permissions import Role
+
+    errors: list[str] = []
+    db = SessionLocal()
+    try:
+        org = db.query(Org).filter(Org.name == org_name).one_or_none()
+        _check("demo organization exists", org is not None, errors=errors)
+
+        user = db.query(User).filter(User.email == email).one_or_none()
+        _check("demo admin user exists", user is not None, errors=errors)
+        if user is not None:
+            _check("demo admin is active", bool(user.is_active), errors=errors)
+            _check(
+                "demo admin role is org_admin",
+                user.role == Role.ORG_ADMIN.value,
+                errors=errors,
+            )
+            _check(
+                "demo admin password matches documented credential",
+                verify_password(password, user.password_hash),
+                errors=errors,
+            )
+
+        membership_exists = False
+        incident_count = 0
+        if org is not None and user is not None:
+            membership_exists = (
+                db.query(UserOrg)
+                .filter(UserOrg.org_id == org.id, UserOrg.user_id == user.id)
+                .first()
+                is not None
+            )
+            incident_count = (
+                db.query(Incident).filter(Incident.org_id == org.id).count()
+            )
+        _check(
+            "demo admin belongs to demo organization", membership_exists, errors=errors
+        )
+        _check("at least one demo incident exists", incident_count >= 1, errors=errors)
+        _check(
+            "demo API login returns an access token",
+            _check_api_login(api_base_url, email, password),
+            errors=errors,
+        )
+
+        if errors:
+            print(
+                f"\nlocal verify-demo FAILED with {len(errors)} check(s) failing.",
+                file=sys.stderr,
+            )
+            return 1
+
+        print("\nlocal verify-demo OK — seeded demo tenant is usable.")
+        return 0
+    except Exception:
+        traceback.print_exc()
+        return 1
+    finally:
+        db.close()
 
 
 def _build_session():
@@ -188,9 +289,7 @@ def run() -> int:
         trailers = db.query(Trailer).filter(Trailer.org_id == org.id).all()
         _check("exactly one Trailer seeded", len(trailers) == 1, errors=errors)
         maint = (
-            db.query(MaintenanceRecord)
-            .filter(MaintenanceRecord.org_id == org.id)
-            .all()
+            db.query(MaintenanceRecord).filter(MaintenanceRecord.org_id == org.id).all()
         )
         _check(
             "three MaintenanceRecord rows seeded (mixed tractor + trailer)",
@@ -199,9 +298,7 @@ def run() -> int:
         )
         drivers = (
             db.query(Driver)
-            .filter(
-                Driver.org_id == org.id, Driver.display_name == "Pat Demo-Driver"
-            )
+            .filter(Driver.org_id == org.id, Driver.display_name == "Pat Demo-Driver")
             .all()
         )
         _check(
@@ -260,7 +357,9 @@ def run() -> int:
             # The fill must have used the canonical row, not the placeholder
             # ``incident.adc_driver_id`` text id. The DriverName field is
             # required + ``upper`` transform.
-            by_name = {f["name"]: f for f in (filling.payload_json or {}).get("fields", [])}
+            by_name = {
+                f["name"]: f for f in (filling.payload_json or {}).get("fields", [])
+            }
             _check(
                 "fill resolved DriverName from canonical row (Driver join + upper)",
                 by_name.get("DriverName", {}).get("value") == "PAT DEMO-DRIVER",
@@ -288,5 +387,18 @@ def run() -> int:
         db.close()
 
 
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--local-db",
+        action="store_true",
+        help="verify seeded demo data in DATABASE_URL and API login",
+    )
+    args = parser.parse_args()
+    if args.local_db:
+        return run_local_db()
+    return run()
+
+
 if __name__ == "__main__":
-    raise SystemExit(run())
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a single, repeatable local path from a fresh checkout to a usable demo tenant with API/frontend/worker/infra running and seeded demo data.
- Ensure the flow is clearly local-only (no AWS/staging/production secrets or external provider credentials) and idempotent for repeated developer use.
- Make migrations, seeding, and verification run inside the backend environment so they target the Compose-provided Postgres and Redis reliably.

### Description
- Added Makefile targets: `local-wait-db`, `local-wait-api`, `local-migrate`, `local-seed`, `local-verify-demo`, `local-reset`, and `local-bootstrap` to orchestrate start, readiness checks, migrations, seeding, verification, and local-only reset. 
- Run Alembic migrations inside the backend container via `local-migrate` (`alembic -c alembic.ini upgrade head`) and run seeding/verification inside the backend container so they use the Compose DB. 
- Mounted `./scripts` into the API container (`infra/docker-compose.local.yml`) so `seed_demo_data.py` and `verify_demo.py` execute inside the backend runtime without adding external credentials. 
- Extended `scripts/verify_demo.py` with a `--local-db` mode that validates the demo org, demo admin user and membership, at least one demo incident, the documented demo password, and attempts an API login to assert the running API returns an access token. 
- Documented the one-command bootstrap and local usage in `README.md` (local URLs, ports, demo credentials, reset behavior, and common troubleshooting). 

### Testing
- Ran static checks and formatting: `cd backend && python -m ruff format ../scripts/verify_demo.py && python -m ruff check app/ tests/ ../scripts/verify_demo.py` and the linter/formatter checks passed. 
- Ran the offline demo verifier: `make verify-demo` which executed `scripts/verify_demo.py` (offline SQLite mode) and reported the scenario validated. 
- Ran backend test suite: `cd backend && pytest tests/ -q` which succeeded (`866 passed, 1 skipped`). 
- Validated the Docker bootstrap plan with `make -n local-bootstrap` and `make -n local-reset` to confirm the runtime step sequence; full end-to-end `make local-bootstrap` could not be executed here because the execution environment lacks the `docker` CLI. 
- Noted pre-existing `mypy` SQLAlchemy typing errors remain in the codebase and were not changed by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ed563cab48321bf4834366e407fb3)