### PR TITLE
Make backend tests complete reliably

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ dev:
 ## Run backend tests and contract validation from repo root
 test:
 	python scripts/check_no_duplicate_modules.py
-	cd backend && pip install -q -r requirements.txt && pytest tests/ -v
+	cd backend && pip install -q -r requirements.txt && APP_ENV=test pytest tests/ -q --durations=20
 	python scripts/validate_schemas.py
 
 ## Format & lint backend code (from repo root)

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -209,6 +209,10 @@ class AppSettings(BaseSettings):
     def is_local(self) -> bool:
         return self.APP_ENV == "local"
 
+    @property
+    def is_test(self) -> bool:
+        return self.APP_ENV == "test"
+
     def _prod_validation_errors(self) -> list[str]:
         errors: list[str] = []
         if not self.is_prod:
@@ -313,6 +317,18 @@ class LocalSettings(AppSettings):
 class TestSettings(AppSettings):
     ENV_NAME: ClassVar[str] = "test"
     APP_ENV: str = "test"
+    DATABASE_URL: str = "sqlite+pysqlite:///:memory:"
+    REDIS_URL: str = "redis://test-redis.invalid:6379/0"
+    SAMSARA_API_KEY: str = "test-samsara-key"
+    TWILIO_ACCOUNT_SID: str = "ACtest"
+    TWILIO_AUTH_TOKEN: str = "test-token"
+    TWILIO_VERIFY_SERVICE_SID: str = "VAtest"
+    JWT_SECRET_KEY: str = "test-jwt-secret-for-local-ci-only-32-bytes"
+    OTP_HASH_PEPPER: str = "test-otp-pepper-for-local-ci-only-32-bytes"
+    STORAGE_BACKEND: str = "filesystem"
+    VAULT_ROOT: str = "/tmp/adc-test-vault"
+    FMCSA_INSPECTIONS_ENABLED: bool = False
+    FMCSA_INSPECTIONS_REPOLL_ENABLED: bool = False
 
 
 class StagingSettings(AppSettings):

--- a/backend/app/config/validation.py
+++ b/backend/app/config/validation.py
@@ -19,7 +19,7 @@ def validate_startup_config(settings: AppSettings) -> None:
 
     errors: list[str] = []
 
-    if not settings.is_local:
+    if not settings.is_local and not settings.is_test:
         critical_required = {
             "DATABASE_URL": settings.DATABASE_URL,
             "REDIS_URL": settings.REDIS_URL,

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
+testpaths = tests
 markers =
+    slow: slower tests that are still safe for the default local/CI suite
+    integration: opt-in tests that require external services or native integrations
     weasyprint_native: integration test that runs real WeasyPrint (requires native libs; opt-in via ADC_RUN_WEASYPRINT_NATIVE=1)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,4 @@ weasyprint>=68.0
 Jinja2>=3.1.6
 qrcode[pil]>=8.0
 Pillow>=12.2.0
+pytest-timeout>=2.3.1

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,11 +1,47 @@
-"""Shared test fixtures and SQLite compatibility shims."""
+"""Shared test fixtures, safe test defaults, and SQLite compatibility shims."""
+
+from __future__ import annotations
 
 import hashlib
-from types import SimpleNamespace
+import os
+import signal
+from types import FrameType, SimpleNamespace
 
 import pytest
 from sqlalchemy.dialects.postgresql import JSONB as PG_JSONB, UUID as PG_UUID
 from sqlalchemy.ext.compiler import compiles
+
+_TEST_TIMEOUT_SECONDS = int(os.getenv("ADC_PYTEST_TIMEOUT_SECONDS", "60"))
+
+_TEST_ENV_DEFAULTS = {
+    "APP_ENV": "test",
+}
+
+
+for _key, _value in _TEST_ENV_DEFAULTS.items():
+    os.environ.setdefault(_key, _value)
+
+
+def _handle_test_timeout(signum: int, frame: FrameType | None) -> None:
+    raise TimeoutError(f"pytest test exceeded {_TEST_TIMEOUT_SECONDS} seconds")
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_protocol(item: pytest.Item, nextitem: pytest.Item | None):
+    """Bound each test item so one hang cannot stall the full backend suite."""
+
+    if _TEST_TIMEOUT_SECONDS <= 0 or not hasattr(signal, "SIGALRM"):
+        yield
+        return
+
+    previous_handler = signal.getsignal(signal.SIGALRM)
+    signal.signal(signal.SIGALRM, _handle_test_timeout)
+    signal.alarm(_TEST_TIMEOUT_SECONDS)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous_handler)
 
 
 # Register SQLite type compilers so that Postgres-specific column types


### PR DESCRIPTION
### Motivation
- Tests were hanging or failing startup due to strict production validation and missing test defaults, and there was no suite-wide guard for hung tests. 
- The goal is to make the backend test run finish with a clear pass/fail summary in local and CI without requiring live external services.

### Description
- Add a repository-local per-test timeout hook in `backend/tests/conftest.py` (signal-based, configurable via `ADC_PYTEST_TIMEOUT_SECONDS`) so individual hangs raise instead of stalling the suite. 
- Treat the `test` environment as an allowed non-deploy environment by adding `is_test` and adding safe `TestSettings` defaults in `backend/app/config/settings.py` so `APP_ENV=test` does not require live Postgres/Redis/Twilio/Samsara/FMCSA/S3 secrets. 
- Relax `validate_startup_config` to skip critical-secret checks when `APP_ENV=test` in `backend/app/config/validation.py`. 
- Add test discovery and opt-in markers (`slow`, `integration`) to `backend/pytest.ini` while preserving the opt-in `weasyprint_native` marker. 
- Add `pytest-timeout` to `backend/requirements.txt` as a recommended dependency for environments that can install from PyPI. 
- Update Makefile `test` target to run backend tests under `APP_ENV=test` and use quiet CI-friendly pytest flags: `APP_ENV=test pytest tests/ -q --durations=20`.

### Testing
- Ran the focused config tests with `cd backend && APP_ENV=test python -m pytest tests/test_config.py -q` which passed (`16 passed`).
- Ran the full backend suite with `cd backend && APP_ENV=test python -m pytest tests/ -q --durations=20` which succeeded: `866 passed, 1 skipped` in ~235s.
- Ran lints with `cd backend && python -m ruff check app/ tests/` which passed (`All checks passed!`).
- Ran repository checks `python scripts/check_no_duplicate_modules.py` and `python scripts/validate_schemas.py` which passed (no duplicate modules; JSON schemas valid).
- Attempted to install `pytest-timeout` inside this environment but package-index access failed (`403 Forbidden`), so the repo-local timeout guard is included to ensure bounded runs even without the plugin.
- Noted: `python -m pyright app tests` reports many pre-existing typing errors (SQLAlchemy column typing) unrelated to this reliability change and not modified by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ede3514b88321add477f714f48e2c)