### PR TITLE
Document driver app serial test checks

### DIFF
--- a/driver-app/TESTING.md
+++ b/driver-app/TESTING.md
@@ -25,12 +25,29 @@ The RNTL project also re-applies `react-native/jest/setup.js` and
 cd driver-app
 npm install            # first time
 npm test               # both projects
+npm run test:serial    # both projects serially (pilot/CI hang triage)
+npm run test:open-handles # serial run with Jest open-handle diagnostics
 npm run test:unit      # ts-jest only
 npm run test:rntl      # rntl only
 npm run test:coverage  # both projects + coverage report (enforces thresholds)
 ```
 
 Coverage HTML lands in `driver-app/coverage/lcov-report/index.html`.
+
+For pilot-readiness verification, run the serial suite and open-handle
+check exactly as follows:
+
+```bash
+cd driver-app
+npm test -- --runInBand
+npm test -- --runInBand --detectOpenHandles
+```
+
+The `test:serial` and `test:open-handles` scripts are aliases for these
+commands. The open-handle run is intentionally slower because Jest tracks
+async resources; it should still finish with a normal pass/fail result and
+without serious open-handle reports. Unit and screen tests must mock API
+calls and native storage rather than depending on a live backend.
 
 ## Coverage thresholds
 

--- a/driver-app/package.json
+++ b/driver-app/package.json
@@ -10,7 +10,9 @@
     "test": "jest",
     "test:unit": "jest --selectProjects unit",
     "test:rntl": "jest --selectProjects rntl",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "test:serial": "jest --runInBand",
+    "test:open-handles": "jest --runInBand --detectOpenHandles"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.1.1",


### PR DESCRIPTION
### Motivation

- Provide a reproducible, pilot-ready way to run the driver app Jest suites serially and with open-handle diagnostics so test hangs/leaks can be triaged reliably. 
- Make it explicit how to verify that RNTL and unit suites complete cleanly with `--runInBand` and `--detectOpenHandles` so the driver flow can be used in a controlled pilot. 
- Encourage test hygiene by clarifying that unit/screen tests should mock API and native storage rather than depend on a live backend.

### Description

- Added `test:serial` and `test:open-handles` npm scripts to `driver-app/package.json` that run `jest --runInBand` and `jest --runInBand --detectOpenHandles` respectively. 
- Updated `driver-app/TESTING.md` to document the exact pilot-readiness verification commands and note that the open-handle run is slower but should finish without serious open-handle reports. 
- Explicitly called out that unit and screen tests must mock API calls and native storage instead of depending on a live backend to keep suites reliable and deterministic.

### Testing

- Ran `cd driver-app && npm test -- --runInBand` which completed successfully (23 suites, 198 tests passed). 
- Ran `cd driver-app && npm test -- --runInBand --detectOpenHandles` which completed successfully (23 suites, 198 tests passed) with no Jest open-handle diagnostics. 
- Ran backend checks: `cd backend && ruff check app/ tests/` passed and `cd backend && APP_ENV=test pytest tests/ -q --durations=20` passed (866 passed, 1 skipped); `cd backend && mypy app tests` shows an existing typing backlog (1,051 errors) unrelated to the driver-app docs/script change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ef73b26688321938749ab9915675c)