### PR TITLE
Stabilize frontend production build

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -3,6 +3,9 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  experimental: {
+    cpus: 1,
+  },
 };
 
 export default nextConfig;

--- a/frontend/tests/productionDeployment.test.mjs
+++ b/frontend/tests/productionDeployment.test.mjs
@@ -11,6 +11,10 @@ test('Next.js production config uses dynamic app mode and preserves image compat
   assert.match(nextConfigSource, /images:\s*{[\s\S]*unoptimized:\s*true[\s\S]*}/);
 });
 
+test('Next.js production config limits build worker parallelism for constrained CI', () => {
+  assert.match(nextConfigSource, /experimental:\s*{[\s\S]*cpus:\s*1[\s\S]*}/);
+});
+
 test('incident detail page does not rely on placeholder static params', () => {
   assert.doesNotMatch(incidentDetailPageSource, /generateStaticParams/);
   assert.doesNotMatch(incidentDetailPageSource, /placeholder/);


### PR DESCRIPTION
### Motivation
- Production builds could hang in constrained CI/local environments when Next.js spawns many workers during page data collection, so a minimal cap on build parallelism is needed while preserving normal dynamic app behavior.

### Description
- Add `experimental: { cpus: 1 }` to `frontend/next.config.mjs` and keep `images.unoptimized: true` and no `output: "export"` to avoid changing runtime or export mode.
- Extend `frontend/tests/productionDeployment.test.mjs` with a lightweight assertion that the `experimental.cpus: 1` setting is present to prevent accidental removal.
- Make no route or export-design changes, and preserve the dynamic `/incidents/[id]` server-rendered behavior.

### Testing
- Ran `cd frontend && npm run test`, and all frontend tests passed (`43 passed`).
- Ran `cd frontend && npm run lint && npm run typecheck && npm run build`, and the build completed successfully with Next showing it used 1 worker and preserved the dynamic `/incidents/[id]` route.
- Ran backend checks: `python -m ruff check app/ tests/` passed, `python -m mypy app tests` shows existing repository-wide typing failures (unrelated to this change), and `APP_ENV=test python -m pytest tests/` passed (`870 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a324acd407483219914358ccbf9d2b1)