### PR TITLE
Update P0 readiness checklist statuses and verification commands

### DIFF
--- a/docs/operations/p0-pilot-readiness-checklist.md
+++ b/docs/operations/p0-pilot-readiness-checklist.md
@@ -2,22 +2,61 @@
 
 Use this checklist for every controlled pilot demo release check. Keep statuses current and treat every P0 item as a launch blocker until its exit criteria are met.
 
-Status values: `Not started`, `In progress`, `Done`.
+Status values: `Done`, `In progress`, `Blocked`, `Needs local verification`.
 
 ## P0 launch blockers
 
-| # | Checklist item | Status | Verification command | Owner notes | Link/path to relevant files | Exit criteria |
+| # | Checklist item | Status | Verification command | Independent verification notes | Link/path to relevant files | Exit criteria |
 |---|---|---|---|---|---|---|
-| 1 | Frontend dynamic deployment fixed | Not started | `cd frontend && npm run build` | Confirm the production build does not depend on demo-only prefills or local-only runtime assumptions. | `frontend/package.json`; `README.md`; `.env.example` | Production build completes and deployment/runtime mode is documented for the pilot environment. |
-| 2 | Frontend typecheck/build/start passes | Not started | `cd frontend && npm run typecheck && npm run build && npm run start` | Run `npm run start` only after a successful build; stop the server after confirming it boots. | `frontend/package.json`; `frontend/`; `frontend/tests/` | TypeScript check passes, Next.js production build passes, and production server starts successfully. |
-| 3 | Local Docker Compose works without AWS secrets | Not started | `cp .env.example .env && make local-bootstrap` | Use the local-only compose stack, not the staging-oriented compose file. It must not require AWS Secrets Manager or live provider credentials. | `Makefile`; `infra/docker-compose.local.yml`; `.env.example`; `README.md` | Local stack builds, starts, migrates, seeds, and verifies using only local/default development secrets. |
-| 4 | Local migration and seed flow works | Not started | `make local-migrate && make local-seed && make local-verify-demo` | Seed flow must be idempotent and keep the documented demo admin usable. | `Makefile`; `backend/app/db/migrations/`; `scripts/seed_demo_data.py`; `scripts/verify_demo.py` | Alembic reaches head, demo seed completes, and verification confirms the seeded tenant and login are usable. |
-| 5 | Backend tests complete | Not started | `make lint && make test` | Backend lint/type/test gate for release readiness; investigate any skipped or flaky tests before pilot sign-off. | `Makefile`; `backend/pytest.ini`; `backend/tests/`; `scripts/validate_schemas.py` | Backend lint and full backend/schema test suite complete cleanly. |
-| 6 | Driver app tests complete | Not started | `cd driver-app && npm test -- --runInBand` | Use serial mode if open handles or Expo/Jest timing make failures hard to read. | `driver-app/package.json`; `driver-app/TESTING.md`; `driver-app/` | Driver app Jest suite completes without failures. |
-| 7 | Local smoke test validates seeded incident workflow | Not started | `make local-smoke` | Requires the local API and worker from `make local-up`/`make local-bootstrap`; validates seeded incident-to-export flow. | `Makefile`; `scripts/verify_demo.py`; `backend/app/tasks/export_tasks.py` | Seeded demo login works, a seeded incident is accessible, export generation is requested, and export reaches ready status. |
-| 8 | Org-level authorization tests pass | Not started | `cd backend && APP_ENV=test pytest tests/test_authorization_regressions.py tests/test_api_endpoints.py::TestExportEndpoints::test_get_export_forbidden_for_other_org tests/test_export_section23_acceptance.py::test_authorization_and_org_isolation -q` | Keep cross-org access checks explicit for pilot sign-off. Expand this command if new org-boundary tests are added. | `backend/tests/test_authorization_regressions.py`; `backend/tests/test_api_endpoints.py`; `backend/tests/test_export_section23_acceptance.py`; `backend/app/security/authz.py` | Cross-org incident/export/content access is rejected and authorization regression tests pass. |
-| 9 | Demo login is documented | Not started | `rg -n "demo-admin@adc.local|DemoAdmin!2345|DEMO_ADMIN_EMAIL|DEMO_ADMIN_PASSWORD" README.md .env.example scripts/seed_demo_data.py` | Confirm docs match seed defaults before each pilot; never document production credentials here. | `README.md`; `.env.example`; `scripts/seed_demo_data.py` | Pilot operator can find the local demo URL, seeded email, seeded password, and organization name in repo docs. |
-| 10 | Known non-P0 features are explicitly listed as out of pilot scope | Not started | `rg -n "P1|P2|out of pilot scope|non-P0" docs/operations/p0-pilot-readiness-checklist.md` | Update the P1/P2 list below when triage changes; do not block the pilot on these unless promoted to P0. | `docs/operations/p0-pilot-readiness-checklist.md` | Later work is visible and explicitly separated from P0 blockers. |
+| 1 | Frontend dynamic deployment fixed | Blocked | `test ! -f .github/workflows/nextjs.yml && cd frontend && npm run build` | The CI workflow uses the dynamic Next.js build, but `.github/workflows/nextjs.yml` still deploys a static GitHub Pages artifact from `frontend/out`. Do not mark Done until that Pages workflow is removed or disabled and the production build path is the pilot deployment path. | `.github/workflows/ci.yml`; `.github/workflows/nextjs.yml`; `frontend/package.json`; `README.md`; `.env.example` | Production build completes and the obsolete GitHub Pages/static export deployment path is removed or disabled for pilot deployment. |
+| 2 | Frontend typecheck/build/start passes | Done | `cd frontend && npm run typecheck && npm run build && timeout 10s npm run start` | Verified locally on 2026-06-18. `npm run build` completed with Next.js `cpus: 1`; `timeout 10s npm run start` reached `Ready` before timeout stopped the server. | `frontend/package.json`; `frontend/`; `frontend/tests/` | TypeScript check passes, Next.js production build passes, and production server starts successfully. |
+| 3 | Local Docker Compose works without AWS secrets | Needs local verification | `cp .env.example .env && make local-bootstrap` | The Makefile and local compose stack are wired for local Postgres/Redis, `SECRET_PROVIDER=env`, filesystem storage, noop email, and blank live-provider credentials, but this Docker path is not Done until `make local-bootstrap` passes in the pilot operator's local environment. | `Makefile`; `infra/docker-compose.local.yml`; `.env.example`; `README.md` | Local stack builds, starts, migrates, seeds, and verifies using only local/default development secrets. |
+| 4 | Local migration and seed flow works | Needs local verification | `make local-migrate && make local-seed && make local-verify-demo` | Commands exist and README documents the flow. Keep this separate from full bootstrap so migration/seed issues can be isolated after containers are healthy. | `Makefile`; `backend/alembic/`; `scripts/seed_demo_data.py`; `scripts/verify_demo.py` | Alembic reaches head, demo seed completes, and verification confirms the seeded tenant and login are usable. |
+| 5 | Backend tests complete | Needs local verification | `make lint && make test` | CI documents backend lint, duplicate-module guard, targeted regressions, full pytest suite, schema validation, and runtime API contract checks. Do not mark Done until the repo-level backend gate passes locally for this cleanup. | `Makefile`; `.github/workflows/ci.yml`; `backend/pytest.ini`; `backend/tests/`; `scripts/validate_schemas.py` | Backend lint and full backend/schema test suite complete cleanly. |
+| 6 | Driver app tests complete | Needs local verification | `cd driver-app && npm run test:serial` | Driver package provides serial Jest and coverage commands; CI uses `npm run test:coverage`. Do not mark Done until the documented local driver test command passes. | `driver-app/package.json`; `driver-app/TESTING.md`; `.github/workflows/ci.yml`; `driver-app/` | Driver app Jest suite completes without failures. |
+| 7 | Local smoke test validates seeded incident workflow | Needs local verification | `make local-smoke` | Requires a running local API and worker from `make local-up` or `make local-bootstrap`; validates seeded demo data, login, incident access, export request, and export readiness. | `Makefile`; `scripts/verify_demo.py`; `backend/app/tasks/export_tasks.py` | Seeded demo login works, a seeded incident is accessible, export generation is requested, and export reaches ready status. |
+| 8 | Org-level authorization tests pass | Needs local verification | `cd backend && APP_ENV=test pytest tests/test_authorization_regressions.py tests/test_api_endpoints.py::TestExportEndpoints::test_get_export_forbidden_for_other_org tests/test_export_section23_acceptance.py::test_authorization_and_org_isolation -q` | Keep this targeted command explicit for pilot sign-off. Expand it if new org-boundary tests are added. | `backend/tests/test_authorization_regressions.py`; `backend/tests/test_api_endpoints.py`; `backend/tests/test_export_section23_acceptance.py`; `backend/app/security/authz.py` | Cross-org incident/export/content access is rejected and authorization regression tests pass. |
+| 9 | Demo login is documented | Done | `rg -n "demo-admin@adc.local|DemoAdmin!2345|DEMO_ADMIN_EMAIL|DEMO_ADMIN_PASSWORD" README.md .env.example scripts/seed_demo_data.py` | Verified by inspection on 2026-06-18: README documents the local demo email/password/org, `.env.example` provides matching frontend prefill values, and `scripts/seed_demo_data.py` uses the same default seeded credentials. | `README.md`; `.env.example`; `scripts/seed_demo_data.py` | Pilot operator can find the local demo URL, seeded email, seeded password, and organization name in repo docs. |
+| 10 | Known non-P0 features are explicitly listed as out of pilot scope | Done | `rg -n "P1|P2|out of pilot scope|non-P0" docs/operations/p0-pilot-readiness-checklist.md` | P1/P2 work remains listed below and is explicitly separated from P0 launch blockers. | `docs/operations/p0-pilot-readiness-checklist.md` | Later work is visible and explicitly separated from P0 blockers. |
+
+## Last verification commands
+
+Commands run for the latest checklist update on 2026-06-18:
+
+```bash
+cd frontend && npm run typecheck && npm run build
+timeout 10s npm run start
+rg -n "demo-admin@adc.local|DemoAdmin!2345|DEMO_ADMIN_EMAIL|DEMO_ADMIN_PASSWORD" README.md .env.example scripts/seed_demo_data.py
+rg -n "P1|P2|out of pilot scope|non-P0" docs/operations/p0-pilot-readiness-checklist.md
+```
+
+Known remaining P0 verification commands before P1:
+
+```bash
+# Remove or disable .github/workflows/nextjs.yml first, then verify the pilot frontend build path.
+test ! -f .github/workflows/nextjs.yml && cd frontend && npm run build
+
+# Verify the local-only Docker bootstrap and seeded demo smoke path.
+cp .env.example .env
+make local-bootstrap
+make local-smoke
+
+# If debugging bootstrap in smaller steps, verify migration/seed separately.
+make local-migrate && make local-seed && make local-verify-demo
+
+# Verify backend and schema gates.
+make lint && make test
+cd backend && APP_ENV=test pytest tests/test_authorization_regressions.py tests/test_api_endpoints.py::TestExportEndpoints::test_get_export_forbidden_for_other_org tests/test_export_section23_acceptance.py::test_authorization_and_org_isolation -q
+
+# Verify driver app tests.
+cd driver-app && npm run test:serial
+```
+
+## Remaining P0 blockers
+
+- `.github/workflows/nextjs.yml` still defines a GitHub Pages static deployment path and must be removed or disabled before the frontend dynamic deployment item can be marked `Done`.
+- Docker-based local bootstrap/smoke items remain `Needs local verification` until `make local-bootstrap` and `make local-smoke` pass.
+- Backend, driver app, and org-authorization test items remain `Needs local verification` until their documented commands pass locally for the P0 release candidate.
 
 ## Out of pilot scope: known P1/P2 work
 
@@ -32,5 +71,7 @@ These items are not P0 blockers for the controlled pilot demo unless they are ex
 ## Release check notes
 
 - Change a row to `In progress` only when an owner is actively working it.
+- Change a row to `Blocked` when a known repo or environment issue prevents truthful completion.
+- Change a row to `Needs local verification` when the repo appears wired for the item but the required command has not passed for this release candidate.
 - Change a row to `Done` only after the verification command has passed and the exit criteria are true.
 - If a verification command is intentionally replaced, update this file in the same PR so the next release check remains repeatable.


### PR DESCRIPTION
### Motivation
- Make the P0 pilot readiness checklist operational by replacing blanket `Not started` values with truthful statuses and explicit verification commands so the file can be used as a real go/no-go artifact before P1.

### Description
- Updated `docs/operations/p0-pilot-readiness-checklist.md` to change allowed status values to `Done`, `In progress`, `Blocked`, and `Needs local verification`. 
- Replaced stale `Not started` rows with repo-observed statuses and added an `Independent verification notes` column, a `Last verification commands` section, and a `Known remaining P0 verification commands` section. 
- Marked `Frontend dynamic deployment fixed` as `Blocked`, marked `Frontend typecheck/build/start` and demo documentation/out-of-scope listing as `Done`, and marked Docker/local migration/seed, backend, driver app, smoke, and org-authorization items as `Needs local verification`. 
- Documented exact commands to run to verify each remaining P0 item and listed explicit remaining P0 blockers (notably the GitHub Pages workflow and unverified Docker/backend/driver work).

### Testing
- Ran frontend typecheck and production build with `cd frontend && npm run typecheck && npm run build`, which completed successfully. 
- Started the frontend production server briefly with `timeout 10s npm run start`, which reported `Ready` before the `timeout` stopped the long-running process and was considered verification for the checklist entry. 
- Verified repo documentation and grep checks with `rg -n "demo-admin@adc.local|DemoAdmin!2345|DEMO_ADMIN_EMAIL|DEMO_ADMIN_PASSWORD" README.md .env.example scripts/seed_demo_data.py` and `rg -n "P1|P2|out of pilot scope|non-P0" docs/operations/p0-pilot-readiness-checklist.md`, and ran `git diff --check`; all returned clean results. 
- Did not run Docker bootstrap/smoke, backend full test suite, driver app tests, or targeted org-authorization pytest commands in this change, and those items remain `Needs local verification` until their documented commands are executed successfully locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3356636b5c8321b3e0b4a7eea64cfa)