### PR TITLE
fix(driver): stabilize instruction state hydration

### DIFF
--- a/driver-app/src/__tests__/rntl/screens/InstructionStepScreen.rntl.test.tsx
+++ b/driver-app/src/__tests__/rntl/screens/InstructionStepScreen.rntl.test.tsx
@@ -83,7 +83,9 @@ const STORAGE_KEY = 'driver_instruction_progress_v1';
 const mockedGetActive = () => jest.mocked(api.getDriverActiveInstructions);
 const mockedAck = () => jest.mocked(api.acknowledgeDriverInstructions);
 
-const buildResponse = (overrides: Partial<api.DriverActiveInstructionsResponse> = {}) => ({
+const buildResponse = (
+  overrides: Partial<api.DriverActiveInstructionsResponse> = {},
+) => ({
   instruction_set_id: 'set-1',
   scope: 'default' as const,
   require_ack: false,
@@ -104,7 +106,9 @@ const mountScreen = () =>
 describe('InstructionStepScreen', () => {
   beforeEach(async () => {
     AsyncStorage.__reset();
-    mockedAck().mockResolvedValue({ acknowledged: true } as api.DriverInstructionAckResponse);
+    mockedAck().mockResolvedValue({
+      acknowledged: true,
+    } as api.DriverInstructionAckResponse);
   });
 
   describe('loading + error', () => {
@@ -118,7 +122,9 @@ describe('InstructionStepScreen', () => {
       );
       mountScreen();
 
-      expect(screen.getByText(/Loading active instructions/i)).toBeOnTheScreen();
+      expect(
+        screen.getByText(/Loading active instructions/i),
+      ).toBeOnTheScreen();
 
       await act(async () => {
         resolveLoad!(buildResponse());
@@ -179,7 +185,9 @@ describe('InstructionStepScreen', () => {
       mountScreen();
 
       await screen.findByText('First');
-      expect(emitTimelineAndAnalyticsEvent).toHaveBeenCalledWith('driver_instruction_step_viewed');
+      expect(emitTimelineAndAnalyticsEvent).toHaveBeenCalledWith(
+        'driver_instruction_step_viewed',
+      );
       const stored = JSON.parse((await AsyncStorage.getItem(STORAGE_KEY))!);
       expect(stored).toEqual(
         expect.objectContaining({
@@ -194,7 +202,9 @@ describe('InstructionStepScreen', () => {
 
   describe('require_ack flow', () => {
     it('disables Next until Acknowledge runs, then unlocks Next and persists ack', async () => {
-      mockedGetActive().mockResolvedValueOnce(buildResponse({ require_ack: true }));
+      mockedGetActive().mockResolvedValueOnce(
+        buildResponse({ require_ack: true }),
+      );
       mountScreen();
 
       await screen.findByText('First');
@@ -225,7 +235,9 @@ describe('InstructionStepScreen', () => {
     });
 
     it('surfaces ack failures in the inline error slot', async () => {
-      mockedGetActive().mockResolvedValueOnce(buildResponse({ require_ack: true }));
+      mockedGetActive().mockResolvedValueOnce(
+        buildResponse({ require_ack: true }),
+      );
       mockedAck().mockRejectedValueOnce(new Error('Ack rejected by server.'));
       mountScreen();
 
@@ -234,7 +246,9 @@ describe('InstructionStepScreen', () => {
         fireEvent.press(screen.getByText('Acknowledge step'));
       });
 
-      expect(await screen.findByText('Ack rejected by server.')).toBeOnTheScreen();
+      expect(
+        await screen.findByText('Ack rejected by server.'),
+      ).toBeOnTheScreen();
       // Step still un-acknowledged → button label remains.
       expect(screen.getByText('Acknowledge step')).toBeOnTheScreen();
     });
@@ -254,7 +268,9 @@ describe('InstructionStepScreen', () => {
 
       expect(screen.getByText('Step 2 of 2')).toBeOnTheScreen();
       expect(screen.getByText('Second')).toBeOnTheScreen();
-      expect(emitTimelineAndAnalyticsEvent).toHaveBeenCalledWith('driver_instruction_step_viewed');
+      expect(emitTimelineAndAnalyticsEvent).toHaveBeenCalledWith(
+        'driver_instruction_step_viewed',
+      );
     });
 
     it('final step Continue completes the route and navigates to SceneFacts', async () => {
@@ -303,7 +319,9 @@ describe('InstructionStepScreen', () => {
           acknowledgedStepIds: ['step-a'],
         }),
       );
-      mockedGetActive().mockResolvedValueOnce(buildResponse({ require_ack: true }));
+      mockedGetActive().mockResolvedValueOnce(
+        buildResponse({ require_ack: true }),
+      );
       mountScreen();
 
       // We resume on step 2 (index 1) and step-b is not yet acknowledged.
@@ -336,6 +354,63 @@ describe('InstructionStepScreen', () => {
 
       await screen.findByText('First');
       expect(screen.getByText('Step 1 of 2')).toBeOnTheScreen();
+    });
+
+    it('starts at the first step when no stored progress exists', async () => {
+      mockedGetActive().mockResolvedValueOnce(buildResponse());
+      mountScreen();
+
+      await screen.findByText('First');
+      expect(screen.getByText('Step 1 of 2')).toBeOnTheScreen();
+    });
+
+    it('normalizes an out-of-range stored index to the last available step', async () => {
+      await AsyncStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          instructionSetId: 'set-1',
+          currentStepIndex: 99,
+          viewedStepIds: ['step-a'],
+          acknowledgedStepIds: [],
+        }),
+      );
+      mockedGetActive().mockResolvedValueOnce(buildResponse());
+      mountScreen();
+
+      await screen.findByText('Second');
+      expect(screen.getByText('Step 2 of 2')).toBeOnTheScreen();
+      const stored = JSON.parse((await AsyncStorage.getItem(STORAGE_KEY))!);
+      expect(stored.currentStepIndex).toBe(1);
+      expect(stored.viewedStepIds).toEqual(['step-a', 'step-b']);
+    });
+
+    it('does not let hydration overwrite a subsequent valid user action', async () => {
+      await AsyncStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          instructionSetId: 'set-1',
+          currentStepIndex: 0,
+          viewedStepIds: ['step-a'],
+          acknowledgedStepIds: [],
+        }),
+      );
+      mockedGetActive().mockResolvedValueOnce(buildResponse());
+      mountScreen();
+
+      await screen.findByText('First');
+      await act(async () => {
+        fireEvent.press(screen.getByText('Next'));
+      });
+
+      expect(screen.getByText('Step 2 of 2')).toBeOnTheScreen();
+      expect(mockedGetActive()).toHaveBeenCalledTimes(1);
+      const stored = JSON.parse((await AsyncStorage.getItem(STORAGE_KEY))!);
+      expect(stored).toEqual(
+        expect.objectContaining({
+          currentStepIndex: 1,
+          viewedStepIds: ['step-a', 'step-b'],
+        }),
+      );
     });
   });
 });

--- a/driver-app/src/screens/InstructionStepScreen.tsx
+++ b/driver-app/src/screens/InstructionStepScreen.tsx
@@ -38,6 +38,27 @@ function normalizeStepOrder(steps: DriverInstructionStepResponse[]) {
   return [...steps].sort((left, right) => left.step_order - right.step_order);
 }
 
+function clampStepIndex(stepIndex: unknown, stepCount: number) {
+  if (typeof stepIndex !== 'number' || !Number.isFinite(stepIndex)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(Math.trunc(stepIndex), stepCount - 1));
+}
+
+function toValidStepIdSet(stepIds: unknown, validStepIds: Set<string>) {
+  if (!Array.isArray(stepIds)) {
+    return new Set<string>();
+  }
+
+  return new Set(
+    stepIds.filter(
+      (stepId): stepId is string =>
+        typeof stepId === 'string' && validStepIds.has(stepId),
+    ),
+  );
+}
+
 export default function InstructionStepScreen({ navigation }: Props) {
   const { completeRoute, protocolContext } = useProtocolFlow();
   useProtocolRouteGuard('InstructionStep', navigation);
@@ -47,7 +68,9 @@ export default function InstructionStepScreen({ navigation }: Props) {
   const [activeSet, setActiveSet] = useState<ActiveInstructionSet | null>(null);
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
   const [viewedStepIds, setViewedStepIds] = useState<Set<string>>(new Set());
-  const [acknowledgedStepIds, setAcknowledgedStepIds] = useState<Set<string>>(new Set());
+  const [acknowledgedStepIds, setAcknowledgedStepIds] = useState<Set<string>>(
+    new Set(),
+  );
   const [isAcknowledging, setIsAcknowledging] = useState(false);
 
   const persistProgress = useCallback(
@@ -111,6 +134,13 @@ export default function InstructionStepScreen({ navigation }: Props) {
         steps: normalizedSteps,
       };
 
+      if (!normalizedSteps.length) {
+        completeRoute('InstructionStep');
+        navigation.replace('SceneFacts');
+        return;
+      }
+
+      const validStepIds = new Set(normalizedSteps.map((step) => step.step_id));
       const storedRaw = await AsyncStorage.getItem(
         INSTRUCTION_PROGRESS_STORAGE_KEY,
       );
@@ -122,22 +152,31 @@ export default function InstructionStepScreen({ navigation }: Props) {
         try {
           const stored = JSON.parse(storedRaw) as StoredInstructionProgress;
           if (stored.instructionSetId === response.instruction_set_id) {
-            nextStepIndex = Math.max(
-              0,
-              Math.min(stored.currentStepIndex ?? 0, normalizedSteps.length - 1),
+            nextStepIndex = clampStepIndex(
+              stored.currentStepIndex,
+              normalizedSteps.length,
             );
-            nextViewedStepIds = new Set(stored.viewedStepIds ?? []);
-            nextAcknowledgedStepIds = new Set(stored.acknowledgedStepIds ?? []);
+            nextViewedStepIds = toValidStepIdSet(
+              stored.viewedStepIds,
+              validStepIds,
+            );
+            nextAcknowledgedStepIds = toValidStepIdSet(
+              stored.acknowledgedStepIds,
+              validStepIds,
+            );
           }
         } catch {
           // Ignore malformed local progress state and reset to defaults.
         }
       }
 
-      if (!normalizedSteps.length) {
-        completeRoute('InstructionStep');
-        navigation.replace('SceneFacts');
-        return;
+      const initialStep = normalizedSteps[nextStepIndex];
+      const shouldMarkInitialStepViewed = !nextViewedStepIds.has(
+        initialStep.step_id,
+      );
+      if (shouldMarkInitialStepViewed) {
+        nextViewedStepIds = new Set(nextViewedStepIds);
+        nextViewedStepIds.add(initialStep.step_id);
       }
 
       setActiveSet(nextActiveSet);
@@ -145,21 +184,25 @@ export default function InstructionStepScreen({ navigation }: Props) {
       setViewedStepIds(nextViewedStepIds);
       setAcknowledgedStepIds(nextAcknowledgedStepIds);
 
-      const initialStep = normalizedSteps[nextStepIndex];
-      await markStepViewed(
-        initialStep.step_id,
-        response.instruction_set_id,
-        nextStepIndex,
-        nextAcknowledgedStepIds,
-      );
+      if (shouldMarkInitialStepViewed) {
+        emitTimelineAndAnalyticsEvent('driver_instruction_step_viewed');
+        await persistProgress(
+          response.instruction_set_id,
+          nextStepIndex,
+          nextViewedStepIds,
+          nextAcknowledgedStepIds,
+        );
+      }
     } catch (error) {
       setLoadError(
-        error instanceof Error ? error.message : 'Failed to load active instructions.',
+        error instanceof Error
+          ? error.message
+          : 'Failed to load active instructions.',
       );
     } finally {
       setIsLoading(false);
     }
-  }, [completeRoute, markStepViewed, navigation]);
+  }, [completeRoute, navigation, persistProgress]);
 
   useEffect(() => {
     void loadActiveInstructions();
@@ -176,7 +219,9 @@ export default function InstructionStepScreen({ navigation }: Props) {
   const isCurrentStepAcknowledged =
     currentStep != null && acknowledgedStepIds.has(currentStep.step_id);
   const shouldDisableNext =
-    Boolean(activeSet?.require_ack) && currentStep != null && !isCurrentStepAcknowledged;
+    Boolean(activeSet?.require_ack) &&
+    currentStep != null &&
+    !isCurrentStepAcknowledged;
 
   const handleAcknowledgeStep = useCallback(async () => {
     if (!activeSet || !currentStep || isCurrentStepAcknowledged) {
@@ -205,7 +250,9 @@ export default function InstructionStepScreen({ navigation }: Props) {
       );
     } catch (error) {
       setLoadError(
-        error instanceof Error ? error.message : 'Unable to acknowledge this step.',
+        error instanceof Error
+          ? error.message
+          : 'Unable to acknowledge this step.',
       );
     } finally {
       setIsAcknowledging(false);
@@ -281,7 +328,10 @@ export default function InstructionStepScreen({ navigation }: Props) {
     return (
       <View style={styles.stateContainer}>
         <Text variant="bodyLarge">No instructions available.</Text>
-        <Button mode="contained" onPress={() => navigation.navigate('SceneFacts')}>
+        <Button
+          mode="contained"
+          onPress={() => navigation.navigate('SceneFacts')}
+        >
           Continue
         </Button>
       </View>
@@ -321,7 +371,11 @@ export default function InstructionStepScreen({ navigation }: Props) {
         <Button mode="outlined" onPress={() => navigation.goBack()}>
           Back
         </Button>
-        <Button mode="contained" onPress={() => void handleContinue()} disabled={shouldDisableNext}>
+        <Button
+          mode="contained"
+          onPress={() => void handleContinue()}
+          disabled={shouldDisableNext}
+        >
           {currentStepIndex >= activeSet.steps.length - 1 ? 'Continue' : 'Next'}
         </Button>
       </View>


### PR DESCRIPTION
### Motivation
- A duplicate hydration/load race during instruction-set startup could re-trigger the load effect and overwrite restored AsyncStorage state, causing the coverage test to fail and producing UI that never reached the resumed step.

### Description
- Validate persisted progress before applying it by adding `clampStepIndex` and `toValidStepIdSet` and only restoring when `instructionSetId` matches the loaded instruction set.
- Apply restored `currentStepIndex`, `viewedStepIds`, and `acknowledgedStepIds` only after instructions are loaded, and persist the initial-step viewed update directly (without calling the stateful `markStepViewed` callback) to avoid changing effect callback identities and retriggering loads.
- Ensure missing/malformed storage is ignored safely, out-of-range indexes are clamped to the last available step, and viewed/ack IDs are filtered to known step IDs to avoid showing stale state.
- Updated RNTL tests to cover missing storage, malformed JSON, mismatched `instructionSetId`, out-of-range index normalization, and protection against hydration overwriting a later user action.

Files changed:
- `driver-app/src/screens/InstructionStepScreen.tsx`
- `driver-app/src/__tests__/rntl/screens/InstructionStepScreen.rntl.test.tsx`

### Testing
- Ran driver app typecheck with `cd driver-app && npm run typecheck` and it passed (`tsc --noEmit` completed successfully).
- Ran unit tests with `cd driver-app && npm run test:unit -- --runInBand` and they passed (`3 test suites`, all passing as shown in the test run).
- Ran RNTL tests with `cd driver-app && npm run test:rntl -- --runInBand` and the instruction-step suite passed (all RNTL suites passed in the coverage run).
- Ran coverage with `cd driver-app && npm run test:coverage -- --runInBand` and it passed; final coverage: statements `83.67%`, branches `69.01%`, functions `75.81%`, lines `84.46%`.
- Frontend checks: `cd frontend && npm run lint`, `npm run typecheck`, `npm run test`, and `npm run build` all passed (tests: `77 passed`; build completed successfully).
- Backend checks: `cd backend && python -m ruff check .` passed and `APP_ENV=test python -m pytest tests/ -q --durations=20` passed (`912 passed, 2 skipped`).
- Result: the previously failing AsyncStorage hydration coverage test is now passing and no remaining P0 blocker remains for this issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a598500ca608321bae57c52a23a56b3)